### PR TITLE
Liquidity Bootstrapping Pool: fee fix

### DIFF
--- a/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPool.sol
+++ b/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPool.sol
@@ -119,7 +119,7 @@ contract LiquidityBootstrappingPool is LiquidityBootstrappingPoolSettings {
 
         if (request.kind == IVault.SwapKind.GIVEN_IN) {
             // Fees are subtracted before scaling, to reduce the complexity of the rounding direction analysis.
-            // This returns amount - fee amount, so we round up (favoring a higher fee amount).
+            // This returns amount - fee amount, so we round down (favoring a higher fee amount).
             request.amount = request.amount.mulDown(getSwapFeePercentage().complement());
 
             // All token amounts are upscaled.

--- a/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPool.sol
+++ b/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPool.sol
@@ -120,7 +120,7 @@ contract LiquidityBootstrappingPool is LiquidityBootstrappingPoolSettings {
         if (request.kind == IVault.SwapKind.GIVEN_IN) {
             // Fees are subtracted before scaling, to reduce the complexity of the rounding direction analysis.
             // This returns amount - fee amount, so we round up (favoring a higher fee amount).
-            request.amount = request.amount.mulDown(getSwapFeePercentage());
+            request.amount = request.amount.mulDown(getSwapFeePercentage().complement());
 
             // All token amounts are upscaled.
             request.amount = _upscale(request.amount, scalingFactorTokenIn);

--- a/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
+++ b/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
@@ -13,10 +13,7 @@ import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
 import { expectBalanceChange } from '@balancer-labs/v2-helpers/src/test/tokenBalance';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 
-export function itBehavesAsWeightedPool(
-  numberOfTokens: number,
-  poolType: WeightedPoolType = WeightedPoolType.WEIGHTED_POOL
-): void {
+export function itBehavesAsWeightedPool(numberOfTokens: number, poolType: WeightedPoolType): void {
   const POOL_SWAP_FEE_PERCENTAGE = fp(0.01);
   const WEIGHTS = [fp(30), fp(70), fp(5), fp(5)];
   const INITIAL_BALANCES = [fp(0.9), fp(1.8), fp(2.7), fp(3.6)];

--- a/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
+++ b/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
@@ -17,11 +17,12 @@ export function itBehavesAsWeightedPool(numberOfTokens: number, poolType: Weight
   const POOL_SWAP_FEE_PERCENTAGE = fp(0.01);
   const WEIGHTS = [fp(30), fp(70), fp(5), fp(5)];
   const INITIAL_BALANCES = [fp(0.9), fp(1.8), fp(2.7), fp(3.6)];
+  const MINIMAL_SWAP_INFO_ONSWAP =
+    'onSwap((uint8,address,address,uint256,bytes32,uint256,address,address,bytes),uint256,uint256)';
 
   let recipient: SignerWithAddress, other: SignerWithAddress, lp: SignerWithAddress;
   let vault: Vault;
   let pool: WeightedPool, allTokens: TokenList, tokens: TokenList;
-  const _poolType = poolType;
 
   const ZEROS = Array(numberOfTokens).fill(bn(0));
   const weights: BigNumberish[] = WEIGHTS.slice(0, numberOfTokens);
@@ -572,27 +573,25 @@ export function itBehavesAsWeightedPool(numberOfTokens: number, poolType: Weight
   describe('onSwap', () => {
     function itSwaps() {
       context('given in', () => {
-        if (_poolType != WeightedPoolType.LIQUIDITY_BOOTSTRAPPING_POOL) {
-          it('reverts if caller is not the vault', async () => {
-            await expect(
-              pool.instance.onSwap(
-                {
-                  kind: SwapKind.GivenIn,
-                  tokenIn: tokens.first.address,
-                  tokenOut: tokens.second.address,
-                  amount: 0,
-                  poolId: await pool.getPoolId(),
-                  lastChangeBlock: 0,
-                  from: lp.address,
-                  to: other.address,
-                  userData: '0x',
-                },
-                0,
-                0
-              )
-            ).to.be.revertedWith('CALLER_NOT_VAULT');
-          });
-        }
+        it('reverts if caller is not the vault', async () => {
+          await expect(
+            pool.instance[MINIMAL_SWAP_INFO_ONSWAP](
+              {
+                kind: SwapKind.GivenIn,
+                tokenIn: tokens.first.address,
+                tokenOut: tokens.second.address,
+                amount: 0,
+                poolId: await pool.getPoolId(),
+                lastChangeBlock: 0,
+                from: lp.address,
+                to: other.address,
+                userData: '0x',
+              },
+              0,
+              0
+            )
+          ).to.be.revertedWith('CALLER_NOT_VAULT');
+        });
 
         it('calculates amount out', async () => {
           const amount = fp(0.1);
@@ -642,27 +641,25 @@ export function itBehavesAsWeightedPool(numberOfTokens: number, poolType: Weight
       });
 
       context('given out', () => {
-        if (_poolType != WeightedPoolType.LIQUIDITY_BOOTSTRAPPING_POOL) {
-          it('reverts if caller is not the vault', async () => {
-            await expect(
-              pool.instance.onSwap(
-                {
-                  kind: SwapKind.GivenOut,
-                  tokenIn: tokens.first.address,
-                  tokenOut: tokens.second.address,
-                  amount: 0,
-                  poolId: await pool.getPoolId(),
-                  lastChangeBlock: 0,
-                  from: other.address,
-                  to: other.address,
-                  userData: '0x',
-                },
-                0,
-                0
-              )
-            ).to.be.revertedWith('CALLER_NOT_VAULT');
-          });
-        }
+        it('reverts if caller is not the vault', async () => {
+          await expect(
+            pool.instance[MINIMAL_SWAP_INFO_ONSWAP](
+              {
+                kind: SwapKind.GivenOut,
+                tokenIn: tokens.first.address,
+                tokenOut: tokens.second.address,
+                amount: 0,
+                poolId: await pool.getPoolId(),
+                lastChangeBlock: 0,
+                from: other.address,
+                to: other.address,
+                userData: '0x',
+              },
+              0,
+              0
+            )
+          ).to.be.revertedWith('CALLER_NOT_VAULT');
+        });
 
         it('calculates amount in', async () => {
           const amount = fp(0.1);

--- a/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
+++ b/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
@@ -651,7 +651,7 @@ export function itBehavesAsWeightedPool(numberOfTokens: number, poolType: Weight
                 amount: 0,
                 poolId: await pool.getPoolId(),
                 lastChangeBlock: 0,
-                from: other.address,
+                from: lp.address,
                 to: other.address,
                 userData: '0x',
               },

--- a/pkg/pool-weighted/test/BaseWeightedPool.test.ts
+++ b/pkg/pool-weighted/test/BaseWeightedPool.test.ts
@@ -5,6 +5,7 @@ import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import WeightedPool from '@balancer-labs/v2-helpers/src/models/pools/weighted/WeightedPool';
 
 import { itBehavesAsWeightedPool } from './BaseWeightedPool.behavior';
+import { WeightedPoolType } from '@balancer-labs/v2-helpers/src/models/pools/weighted/types';
 
 describe('BaseWeightedPool', function () {
   context('for a 1 token pool', () => {
@@ -17,11 +18,11 @@ describe('BaseWeightedPool', function () {
   });
 
   context('for a 2 token pool', () => {
-    itBehavesAsWeightedPool(2);
+    itBehavesAsWeightedPool(2, WeightedPoolType.WEIGHTED_POOL);
   });
 
   context('for a 3 token pool', () => {
-    itBehavesAsWeightedPool(3);
+    itBehavesAsWeightedPool(3, WeightedPoolType.WEIGHTED_POOL);
   });
 
   context('for a too-many token pool', () => {

--- a/pkg/pool-weighted/test/LiquidityBootstrappingPool.test.ts
+++ b/pkg/pool-weighted/test/LiquidityBootstrappingPool.test.ts
@@ -2,7 +2,7 @@ import { ethers } from 'hardhat';
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
-import { fp, fpMul } from '@balancer-labs/v2-helpers/src/numbers';
+import { fp } from '@balancer-labs/v2-helpers/src/numbers';
 import { MINUTE, currentTimestamp } from '@balancer-labs/v2-helpers/src/time';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 
@@ -26,15 +26,15 @@ describe('LiquidityBootstrappingPool', function () {
   // Add the weighted pool tests for the joins/exits, etc.
 
   context('for a 2 token pool', () => {
-    itBehavesAsWeightedPool(2);
+    itBehavesAsWeightedPool(2, WeightedPoolType.LIQUIDITY_BOOTSTRAPPING_POOL);
   });
 
   context('for a 3 token pool', () => {
-    itBehavesAsWeightedPool(3);
+    itBehavesAsWeightedPool(3, WeightedPoolType.LIQUIDITY_BOOTSTRAPPING_POOL);
   });
 
   context('for a 4 token pool', () => {
-    itBehavesAsWeightedPool(4);
+    itBehavesAsWeightedPool(4, WeightedPoolType.LIQUIDITY_BOOTSTRAPPING_POOL);
   });
 
   sharedBeforeEach('deploy tokens', async () => {
@@ -172,14 +172,7 @@ describe('LiquidityBootstrappingPool', function () {
       it('swaps are not blocked', async () => {
         await pool.init({ from: owner, initialBalances });
 
-        const amount = fp(0.1);
-        const swapFee = await pool.getSwapFeePercentage();
-        const amountWithFees = fpMul(amount, swapFee.add(fp(1)));
-        const expectedAmountOut = await pool.estimateGivenIn({ in: 1, out: 0, amount: amountWithFees });
-
-        const result = await pool.swapGivenIn({ in: 1, out: 0, amount: amountWithFees });
-
-        expect(result.amount).to.equalWithError(expectedAmountOut, 0.01);
+        await expect(pool.swapGivenIn({ in: 1, out: 0, amount: fp(0.1) })).to.not.be.reverted;
       });
 
       it('sets token weights', async () => {


### PR DESCRIPTION
# Description

Fee calculation was inverted for swaps given in. Tests that would have caught this were in BaseWeightedPool.behavior.ts. However, the pool type defaulted to WeightedPool: and we didn't override it. So it was never actually running those tests against the LBP.

Now it does: and I removed the defaulted parameter so that this doesn't happen again (e.g., with Managed or a future derived kind of Weighted Pool).

## Type of change

- [X] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

