### PR TITLE
Add `L2BalancerPseudoMinter`

### DIFF
--- a/pkg/interfaces/CHANGELOG.md
+++ b/pkg/interfaces/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## Unreleased
 
+- Added `IChildChainGauge`.
+- Added `ILMGetters`.
+
 ### Breaking changes
 
 - Removed `IBaseGaugeFactory`.
+- Refactor: renamed `IBalancerMinter` to `IMainnetBalancerMinter`.
+  - `IMainnetBalancerMinter` now implements reduced version of previous `IBalancerMinter` and `ILMGetters`.
 
 ## 0.3.0 (20223-02-08)
 

--- a/pkg/interfaces/contracts/liquidity-mining/IChildChainGauge.sol
+++ b/pkg/interfaces/contracts/liquidity-mining/IChildChainGauge.sol
@@ -15,7 +15,37 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 import "../pool-utils/IVersion.sol";
+import "./ILiquidityGaugeFactory.sol";
+
+// For compatibility, we're keeping the same function names as in the original Curve code, including the mixed-case
+// naming convention.
+// solhint-disable func-name-mixedcase
+// solhint-disable func-param-name-mixedcase
 
 interface IChildChainGauge is IVersion {
+    /**
+     * @notice Proxy constructor.
+     * @param lpToken Pool allowed to stake in this gauge.
+     * @param version Gauge version string identifier.
+     */
     function initialize(address lpToken, string memory version) external;
+
+    /**
+     * @notice Returns BAL liquidity emissions calculated during checkpoints for the given user.
+     * @param user User address.
+     * @return uint256 BAL amount to issue for the address.
+     */
+    function integrate_fraction(address user) external view returns (uint256);
+
+    /**
+     * @notice Records a checkpoint for a given user.
+     * @param user User address.
+     * @return bool Always true.
+     */
+    function user_checkpoint(address user) external returns (bool);
+
+    /**
+     * @notice Returns gauge factory address.
+     */
+    function factory() external view returns (ILiquidityGaugeFactory);
 }

--- a/pkg/liquidity-mining/contracts/BalancerMinter.sol
+++ b/pkg/liquidity-mining/contracts/BalancerMinter.sol
@@ -47,7 +47,7 @@ abstract contract BalancerMinter is IBalancerMinter, ReentrancyGuard, EOASignatu
     }
 
     /// @inheritdoc IBalancerMinter
-    function getBalancerToken() external view override returns (IERC20) {
+    function getBalancerToken() public view override returns (IERC20) {
         return _token;
     }
 

--- a/pkg/liquidity-mining/contracts/L2BalancerPseudoMinter.sol
+++ b/pkg/liquidity-mining/contracts/L2BalancerPseudoMinter.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IChildChainGauge.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthentication.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeMath.sol";
+
+import "./BalancerMinter.sol";
+
+/**
+ * @dev Distributes bridged BAL tokens in child chains, using the same interface as the mainnet Balancer minter.
+ *
+ * This contract is analogous to the mainnet minter: it has the same interface and interacts with (L2) gauges in a
+ * similar manner, keeping track of how many tokens were already distributed to each gauge and user.
+ *
+ * The difference with the mainnet minter is that this contract does not have a way of minting BAL directly: the tokens
+ * are only minted in mainnet, and then bridged to L2s. Then, this contract accumulates the emissions received by
+ * child chain gauges and distributes them to users.
+ *
+ * Every time the tokens are 'minted' (i.e. distributed) from a gauge to a given user, the pseudo minter will query the
+ * child chain gauge for the total amount of tokes that need to be distributed to that user. By keeping track of the
+ * amount that it has already distributed for that gauge / user, the pseudo minter can then transfer the difference
+ * to the user and update the total transferred amount.
+ */
+contract L2BalancerPseudoMinter is BalancerMinter, SingletonAuthentication {
+    event GaugeFactoryAdded(ILiquidityGaugeFactory indexed factory);
+    event GaugeFactoryRemoved(ILiquidityGaugeFactory indexed factory);
+
+    using SafeMath for uint256;
+    using SafeERC20 for IERC20;
+
+    mapping(ILiquidityGaugeFactory => bool) private _validFactories;
+
+    constructor(IVault vault, IERC20 balancerToken)
+        BalancerMinter(balancerToken, "Balancer Pseudo Minter", "1")
+        SingletonAuthentication(vault)
+    {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    /**
+     * @notice Adds a given child chain gauge factory to the allowlist.
+     * @dev This is a permissioned function.
+     * Reverts if the given factory was added beforehand; emits `GaugeFactoryAdded` event upon success.
+     */
+    function addGaugeFactory(ILiquidityGaugeFactory factory) external authenticate {
+        require(!_validFactories[factory], "FACTORY_ALREADY_ADDED");
+        _validFactories[factory] = true;
+        emit GaugeFactoryAdded(factory);
+    }
+
+    /**
+     * @notice Removes a given child chain gauge factory from the allowlist.
+     * @dev This is a permissioned function.
+     * Reverts if the given factory had not been added beforehand; emits `GaugeFactoryRemoved` event upon success.
+     */
+    function removeGaugeFactory(ILiquidityGaugeFactory factory) external authenticate {
+        require(_validFactories[factory], "FACTORY_NOT_ADDED");
+        _validFactories[factory] = false;
+        emit GaugeFactoryRemoved(factory);
+    }
+
+    /**
+     * @notice Returns true if the given child chain gauge factory is in the allowlist; false otherwise.
+     */
+    function isValidGaugeFactory(ILiquidityGaugeFactory factory) public view returns (bool) {
+        return _validFactories[factory];
+    }
+
+    // Internal functions
+
+    function _mintFor(address gauge, address user) internal override returns (uint256 tokensToMint) {
+        tokensToMint = _updateGauge(gauge, user);
+        _pseudoMint(user, tokensToMint);
+    }
+
+    function _mintForMany(address[] calldata gauges, address user) internal override returns (uint256 tokensToMint) {
+        uint256 length = gauges.length;
+        for (uint256 i = 0; i < length; ++i) {
+            tokensToMint = tokensToMint.add(_updateGauge(gauges[i], user));
+        }
+        _pseudoMint(user, tokensToMint);
+    }
+
+    /**
+     * @dev Checkpoints given gauge and updates the internal accounting with the total tokens that should be transfered
+     * to the user since the start.
+     *
+     * @param gauge Gauge to checkpoint and query for total tokens to be transferred.
+     * @param user User to query in the given gauge.
+     * @return tokensToMint Amount of tokens to be transferred to the user, calculated as the difference between the
+     * total amount of tokens as indicated by the gauge and the tokens that have already been transferred to the user.
+     */
+    function _updateGauge(address gauge, address user) internal returns (uint256 tokensToMint) {
+        // First, we retrieve the factory address registered from the gauge.
+        // If the factory address is allowlisted in this contract, we verify that the gauge was actually created by
+        // the factory (otherwise it could be just a malicious gauge that claims to be created by an allowed factory).
+        IChildChainGauge ccGauge = IChildChainGauge(gauge);
+        ILiquidityGaugeFactory factory = ccGauge.factory();
+        require(isValidGaugeFactory(factory), "INVALID_GAUGE_FACTORY");
+        require(factory.isGaugeFromFactory(gauge), "INVALID_GAUGE");
+
+        ccGauge.user_checkpoint(user);
+        uint256 totalMint = ccGauge.integrate_fraction(user);
+        tokensToMint = totalMint.sub(minted(user, gauge));
+
+        if (tokensToMint > 0) {
+            _setMinted(user, gauge, totalMint);
+        }
+    }
+
+    /**
+     * @dev Transfers tokens to user if the given amount is not zero.
+     */
+    function _pseudoMint(address user, uint256 tokensToMint) internal {
+        if (tokensToMint > 0) {
+            getBalancerToken().safeTransfer(user, tokensToMint);
+        }
+    }
+}

--- a/pkg/liquidity-mining/contracts/gauges/ChildChainGauge.vy
+++ b/pkg/liquidity-mining/contracts/gauges/ChildChainGauge.vy
@@ -87,6 +87,7 @@ totalSupply: public(uint256)
 
 lp_token: public(address)
 version: public(String[128])
+factory: public(address)
 
 working_balances: public(HashMap[address, uint256])
 working_supply: public(uint256)
@@ -124,6 +125,7 @@ def __init__(
 ):
     self.lp_token = 0x000000000000000000000000000000000000dEaD
     self.version = _version
+    self.factory = 0x000000000000000000000000000000000000dEaD
 
     BAL = _bal_token
     VOTING_ESCROW = _voting_escrow
@@ -711,6 +713,7 @@ def initialize(_lp_token: address, _version: String[128]):
 
     self.lp_token = _lp_token
     self.version = _version
+    self.factory = msg.sender
 
     symbol: String[26] = ERC20Extended(_lp_token).symbol()
     name: String[64] = concat("Balancer ", symbol, " Gauge Deposit")

--- a/pkg/liquidity-mining/contracts/test/MockChildChainGauge.sol
+++ b/pkg/liquidity-mining/contracts/test/MockChildChainGauge.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IChildChainGauge.sol";
+import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeMath.sol";
+
+// solhint-disable func-name-mixedcase
+contract MockChildChainGauge is IChildChainGauge {
+    event UserCheckpoint(address user);
+
+    using SafeMath for uint256;
+
+    // solhint-disable-next-line var-name-mixedcase
+    address public lp_token;
+    ILiquidityGaugeFactory public override factory;
+    string public override version;
+
+    uint256 private _checkpointStep;
+    mapping(address => uint256) private _integrateFraction;
+
+    constructor(string memory _version) {
+        version = _version;
+    }
+
+    function initialize(address pool, string memory _version) external override {
+        lp_token = pool;
+        factory = ILiquidityGaugeFactory(msg.sender);
+        version = _version;
+    }
+
+    function setMockCheckpointStep(uint256 checkpointStep) external {
+        _checkpointStep = checkpointStep;
+    }
+
+    function setMockFactory(ILiquidityGaugeFactory _factory) external {
+        factory = _factory;
+    }
+
+    function integrate_fraction(address user) external view override returns (uint256) {
+        return _integrateFraction[user];
+    }
+
+    function user_checkpoint(address user) external override returns (bool) {
+        _integrateFraction[user] = _integrateFraction[user].add(_checkpointStep);
+        emit UserCheckpoint(user);
+        return true;
+    }
+}

--- a/pkg/liquidity-mining/test/L2BalancerPseudoMinter.test.ts
+++ b/pkg/liquidity-mining/test/L2BalancerPseudoMinter.test.ts
@@ -210,7 +210,7 @@ describe('L2BalancerPseudoMinter', () => {
     });
   });
 
-  describe('mintFor', () => {
+  describe('mintMany', () => {
     const mockCheckpointStep = fp(1);
     let gauges: Contract[];
     let gaugeAddresses: string[];
@@ -290,7 +290,7 @@ describe('L2BalancerPseudoMinter', () => {
     context('when the amount of tokens to transfer is 0', () => {
       let receipt: ContractReceipt;
 
-      sharedBeforeEach('ensure there will be tokens to transfer after next checkpoint', async () => {
+      sharedBeforeEach('ensure there will be no tokens to transfer after next checkpoint', async () => {
         // Accounting on the gauges will not increase after a checkpoint.
         await Promise.all(gauges.map((gauge) => gauge.setMockCheckpointStep(0)));
         receipt = await (await pseudoMinter.connect(user).mintMany(gaugeAddresses)).wait();

--- a/pkg/liquidity-mining/test/L2BalancerPseudoMinter.test.ts
+++ b/pkg/liquidity-mining/test/L2BalancerPseudoMinter.test.ts
@@ -1,0 +1,325 @@
+import { ethers } from 'hardhat';
+import { Contract, ContractReceipt } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
+import { expect } from 'chai';
+import { ANY_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+import { fp } from '@balancer-labs/v2-helpers/src/numbers';
+import { expectTransferEvent } from '@balancer-labs/v2-helpers/src/test/expectTransfer';
+import { range } from 'lodash';
+
+describe('L2BalancerPseudoMinter', () => {
+  let vault: Vault;
+  let BAL: Contract, pseudoMinter: Contract;
+  let admin: SignerWithAddress, user: SignerWithAddress, other: SignerWithAddress;
+  let gauge: Contract, gaugeFactory: Contract;
+
+  before('setup signers', async () => {
+    [, admin, user, other] = await ethers.getSigners();
+  });
+
+  async function deployGauge(factory: Contract): Promise<Contract> {
+    const tx = await factory.create(ANY_ADDRESS);
+    const event = await expectEvent.inReceipt(await tx.wait(), 'GaugeCreated');
+    return deployedAt('MockChildChainGauge', event.args.gauge);
+  }
+
+  sharedBeforeEach('setup minter and basic contracts', async () => {
+    vault = await Vault.create({ admin });
+    BAL = await deploy('TestBalancerToken', { args: [admin.address, 'Balancer', 'BAL'] });
+    pseudoMinter = await deploy('L2BalancerPseudoMinter', { args: [vault.address, BAL.address] });
+  });
+
+  sharedBeforeEach('setup test gauge and factory', async () => {
+    const version = 'test';
+    const gaugeImplementation = await deploy('MockChildChainGauge', { args: [version] });
+    gaugeFactory = await deploy('ChildChainGaugeFactory', { args: [gaugeImplementation.address, '', version] });
+    gauge = await deployGauge(gaugeFactory);
+  });
+
+  describe('addGaugeFactory', () => {
+    sharedBeforeEach('give permissions to admin', async () => {
+      await vault.grantPermissionsGlobally([await actionId(pseudoMinter, 'addGaugeFactory')], admin);
+      expect(await pseudoMinter.isValidGaugeFactory(gaugeFactory.address)).to.be.false;
+    });
+
+    context('when caller is not authorized', () => {
+      it('reverts', async () => {
+        await expect(pseudoMinter.connect(other).addGaugeFactory(gaugeFactory.address)).to.be.revertedWith(
+          'SENDER_NOT_ALLOWED'
+        );
+      });
+    });
+
+    context('when caller is authorized', () => {
+      let receipt: ContractReceipt;
+
+      sharedBeforeEach(async () => {
+        receipt = await (await pseudoMinter.connect(admin).addGaugeFactory(gaugeFactory.address)).wait();
+      });
+
+      it('adds the gauge factory', async () => {
+        expect(await pseudoMinter.isValidGaugeFactory(gaugeFactory.address)).to.be.true;
+      });
+
+      it('emits an event', async () => {
+        expectEvent.inReceipt(receipt, 'GaugeFactoryAdded', { factory: gaugeFactory.address });
+      });
+
+      it('reverts with already added factory', async () => {
+        await expect(pseudoMinter.connect(admin).addGaugeFactory(gaugeFactory.address)).to.be.revertedWith(
+          'FACTORY_ALREADY_ADDED'
+        );
+      });
+    });
+  });
+
+  describe('removeGaugeFactory', () => {
+    sharedBeforeEach('give permissions to admin and add factory', async () => {
+      await vault.grantPermissionsGlobally(
+        [await actionId(pseudoMinter, 'addGaugeFactory'), await actionId(pseudoMinter, 'removeGaugeFactory')],
+        admin
+      );
+      await pseudoMinter.connect(admin).addGaugeFactory(gaugeFactory.address);
+      expect(await pseudoMinter.isValidGaugeFactory(gaugeFactory.address)).to.be.true;
+    });
+
+    context('when caller is not authorized', () => {
+      it('reverts', async () => {
+        await expect(pseudoMinter.connect(other).removeGaugeFactory(gaugeFactory.address)).to.be.revertedWith(
+          'SENDER_NOT_ALLOWED'
+        );
+      });
+    });
+
+    context('when caller is authorized', () => {
+      let receipt: ContractReceipt;
+
+      sharedBeforeEach(async () => {
+        receipt = await (await pseudoMinter.connect(admin).removeGaugeFactory(gaugeFactory.address)).wait();
+      });
+
+      it('removes the gauge factory', async () => {
+        expect(await pseudoMinter.isValidGaugeFactory(gaugeFactory.address)).to.be.false;
+      });
+
+      it('emits an event', async () => {
+        expectEvent.inReceipt(receipt, 'GaugeFactoryRemoved', { factory: gaugeFactory.address });
+      });
+
+      it('reverts with factory not previously added', async () => {
+        await expect(pseudoMinter.connect(admin).removeGaugeFactory(ANY_ADDRESS)).to.be.revertedWith(
+          'FACTORY_NOT_ADDED'
+        );
+      });
+    });
+  });
+
+  describe('mint', () => {
+    const mockCheckpointStep = fp(1);
+
+    sharedBeforeEach('setup factory and fund pseudo minter', async () => {
+      await vault.grantPermissionsGlobally([await actionId(pseudoMinter, 'addGaugeFactory')], admin);
+      await pseudoMinter.connect(admin).addGaugeFactory(gaugeFactory.address);
+      await BAL.connect(admin).mint(pseudoMinter.address, fp(100));
+      expect(await pseudoMinter.minted(user.address, gauge.address)).to.be.eq(0);
+    });
+
+    it('reverts with valid gauge from invalid factory', async () => {
+      await gauge.setMockFactory(ANY_ADDRESS);
+      await expect(pseudoMinter.connect(user).mint(gauge.address)).to.be.revertedWith('INVALID_GAUGE_FACTORY');
+    });
+
+    it('reverts with malicious gauge prentending to come from a valid factory', async () => {
+      const maliciousGauge = await deploy('MockChildChainGauge', { args: ['test'] });
+      await maliciousGauge.setMockFactory(gaugeFactory.address);
+      await expect(pseudoMinter.connect(user).mint(maliciousGauge.address)).to.be.revertedWith('INVALID_GAUGE');
+    });
+
+    context('when the amount of tokens to transfer is greater than 0', () => {
+      let receipt: ContractReceipt;
+
+      sharedBeforeEach('ensure there will be tokens to transfer after next checkpoint', async () => {
+        // Accounting on the gauge will increase by this amount on every checkpoint.
+        await gauge.setMockCheckpointStep(mockCheckpointStep);
+        receipt = await (await pseudoMinter.connect(user).mint(gauge.address)).wait();
+      });
+
+      it('transfers the right amount of tokens to the user', async () => {
+        await expectTransferEvent(
+          receipt,
+          { from: pseudoMinter.address, to: user.address, value: mockCheckpointStep },
+          BAL
+        );
+      });
+
+      it('updates total minted amount for the user', async () => {
+        const totalBefore = await pseudoMinter.minted(user.address, gauge.address);
+        await pseudoMinter.connect(user).mint(gauge.address);
+        expect(await pseudoMinter.minted(user.address, gauge.address)).to.be.eq(totalBefore.add(mockCheckpointStep));
+      });
+
+      it('emits an event', async () => {
+        await expectEvent.inReceipt(receipt, 'Minted', {
+          recipient: user.address,
+          gauge: gauge.address,
+          minted: mockCheckpointStep,
+        });
+      });
+
+      it('calls gauge user checkpoint', async () => {
+        await expectEvent.inIndirectReceipt(receipt, gauge.interface, 'UserCheckpoint', {
+          user: user.address,
+        });
+      });
+    });
+
+    context('when the amount of tokens to transfer is 0', () => {
+      let receipt: ContractReceipt;
+
+      sharedBeforeEach('ensure there will be tokens to transfer after next checkpoint', async () => {
+        // Accounting on the gauge will not increase after a checkpoint.
+        await gauge.setMockCheckpointStep(0);
+        receipt = await (await pseudoMinter.connect(user).mint(gauge.address)).wait();
+      });
+
+      it('performs no transfers', async () => {
+        expectEvent.notEmitted(receipt, 'Transfer');
+      });
+
+      it('keeps the same minted amount for the user', async () => {
+        const totalBefore = await pseudoMinter.minted(user.address, gauge.address);
+        await pseudoMinter.connect(user).mint(gauge.address);
+        expect(await pseudoMinter.minted(user.address, gauge.address)).to.be.eq(totalBefore);
+      });
+
+      it('skips Minted event', async () => {
+        expectEvent.notEmitted(receipt, 'Minted');
+      });
+
+      it('calls gauge user checkpoint', async () => {
+        await expectEvent.inIndirectReceipt(receipt, gauge.interface, 'UserCheckpoint', {
+          user: user.address,
+        });
+      });
+    });
+  });
+
+  describe('mintFor', () => {
+    const mockCheckpointStep = fp(1);
+    let gauges: Contract[];
+    let gaugeAddresses: string[];
+
+    sharedBeforeEach('setup factory and fund pseudo minter', async () => {
+      await vault.grantPermissionsGlobally([await actionId(pseudoMinter, 'addGaugeFactory')], admin);
+      await pseudoMinter.connect(admin).addGaugeFactory(gaugeFactory.address);
+      await BAL.connect(admin).mint(pseudoMinter.address, fp(100));
+
+      gauges = await Promise.all(
+        range(3).map(() => {
+          return deployGauge(gaugeFactory);
+        })
+      );
+      gaugeAddresses = gauges.map((gauge) => gauge.address);
+    });
+
+    it('reverts with valid gauge from invalid factory', async () => {
+      await gauges[0].setMockFactory(ANY_ADDRESS);
+      await expect(pseudoMinter.connect(user).mintMany(gaugeAddresses)).to.be.revertedWith('INVALID_GAUGE_FACTORY');
+    });
+
+    it('reverts with malicious gauge prentending to come from a valid factory', async () => {
+      const maliciousGauge = await deploy('MockChildChainGauge', { args: ['test'] });
+      await maliciousGauge.setMockFactory(gaugeFactory.address);
+      const gaugesWithMalicious = [...gaugeAddresses, maliciousGauge.address];
+      await expect(pseudoMinter.connect(user).mintMany(gaugesWithMalicious)).to.be.revertedWith('INVALID_GAUGE');
+    });
+
+    context('when the amount of tokens to transfer is greater than 0', () => {
+      let receipt: ContractReceipt;
+
+      sharedBeforeEach('ensure there will be tokens to transfer after next checkpoint', async () => {
+        // Accounting on the gauge will increase by this amount on every checkpoint.
+        await Promise.all(gauges.map((gauge) => gauge.setMockCheckpointStep(mockCheckpointStep)));
+        receipt = await (await pseudoMinter.connect(user).mintMany(gaugeAddresses)).wait();
+      });
+
+      it('transfers the right amount of tokens to the user in a single transfer', async () => {
+        await expectTransferEvent(
+          receipt,
+          { from: pseudoMinter.address, to: user.address, value: mockCheckpointStep.mul(gauges.length) },
+          BAL
+        );
+      });
+
+      it('updates total minted amount for the user for each gauge', async () => {
+        const totalsBefore = await Promise.all(gauges.map((gauge) => pseudoMinter.minted(user.address, gauge.address)));
+        await pseudoMinter.connect(user).mintMany(gaugeAddresses);
+        const totalsAfter = await Promise.all(gauges.map((gauge) => pseudoMinter.minted(user.address, gauge.address)));
+        expect(totalsAfter).to.be.deep.eq(totalsBefore.map((totalBefore) => totalBefore.add(mockCheckpointStep)));
+      });
+
+      it('emits an event per gauge', async () => {
+        await Promise.all(
+          gauges.map((gauge) =>
+            expectEvent.inReceipt(receipt, 'Minted', {
+              recipient: user.address,
+              gauge: gauge.address,
+              minted: mockCheckpointStep,
+            })
+          )
+        );
+      });
+
+      it('calls gauge user checkpoint for every gauge', async () => {
+        await Promise.all(
+          gauges.map((gauge) =>
+            expectEvent.inIndirectReceipt(receipt, gauge.interface, 'UserCheckpoint', {
+              user: user.address,
+            })
+          )
+        );
+      });
+    });
+
+    context('when the amount of tokens to transfer is 0', () => {
+      let receipt: ContractReceipt;
+
+      sharedBeforeEach('ensure there will be tokens to transfer after next checkpoint', async () => {
+        // Accounting on the gauges will not increase after a checkpoint.
+        await Promise.all(gauges.map((gauge) => gauge.setMockCheckpointStep(0)));
+        receipt = await (await pseudoMinter.connect(user).mintMany(gaugeAddresses)).wait();
+      });
+
+      it('performs no transfers', async () => {
+        expectEvent.notEmitted(receipt, 'Transfer');
+      });
+
+      it('keeps the same minted amount for the user', async () => {
+        const totalsBefore = await Promise.all(gauges.map((gauge) => pseudoMinter.minted(user.address, gauge.address)));
+        await pseudoMinter.connect(user).mintMany(gaugeAddresses);
+        const totalsAfter = await Promise.all(gauges.map((gauge) => pseudoMinter.minted(user.address, gauge.address)));
+        expect(totalsAfter).to.be.deep.eq(totalsBefore);
+      });
+
+      it('skips Minted event', async () => {
+        expectEvent.notEmitted(receipt, 'Minted');
+      });
+
+      it('calls gauge user checkpoint for every gauge', async () => {
+        await Promise.all(
+          gauges.map((gauge) =>
+            expectEvent.inIndirectReceipt(receipt, gauge.interface, 'UserCheckpoint', {
+              user: user.address,
+            })
+          )
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Description

L2 pseudo minter implementation.
This contract is analogous to the `MainnetBalancerMinter`, but for L2s. It works together with child chain gauges to distribute BAL to users by transferring bridged tokens. It replaces the functionality present in Curve's `ChildChainGaugeFactory`.

Last but not least, it has a mechanism to validate that the gauges are correct (similar to the `GaugeAdder` in some sense) which is compatible with our permission system.
In short, at creation time the factory will mark the gauge as valid, and the gauge will store a reference to the factory. The pseudo minter can then retrieve the reference to the factory, and ask the factory whether the gauge was actually created the factory or not. A malicious gauge can pretend to be created from a valid factory, but a valid factory will reject the claim. Moreover, the external `mint` functions are protected against reentrancy in the base `BalancerMinter` layer, so it shouldn't be a problem to give the gauges the control of the execution.
Finally, valid factories need to be allowlisted in the pseudo minter by a permissioned account. So if the factory is valid, and the gauges come from a valid factory, gauges should be valid too.

I have some tests for this, but I wanted to split the work in smaller PRs to make the review easier.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

See #2289