### PR TITLE
Remove `actionId` from Revoker

### DIFF
--- a/pkg/governance-scripts/contracts/TimelockAuthorizerMigrator.sol
+++ b/pkg/governance-scripts/contracts/TimelockAuthorizerMigrator.sol
@@ -88,7 +88,7 @@ contract TimelockAuthorizerMigrator {
         }
         for (uint256 i = 0; i < _revokersData.length; i++) {
             // Similarly to granters, we must manually verify that these permissions are set sensibly.
-            _newAuthorizer.addRevoker(_revokersData[i].role, _revokersData[i].grantee, _revokersData[i].target);
+            _newAuthorizer.addRevoker(_revokersData[i].grantee, _revokersData[i].target);
         }
 
         // We're going to schedule multiple actions, and we want to make sure we later execute them all. However, since

--- a/pkg/governance-scripts/test/TimelockAuthorizerMigrator.test.ts
+++ b/pkg/governance-scripts/test/TimelockAuthorizerMigrator.test.ts
@@ -137,7 +137,7 @@ describe('TimelockAuthorizerMigrator', () => {
 
     it('sets up revokers properly', async () => {
       for (const revokerData of revokersData) {
-        expect(await newAuthorizer.isRevoker(revokerData.role, revokerData.grantee, revokerData.target)).to.be.true;
+        expect(await newAuthorizer.isRevoker(revokerData.grantee, revokerData.target)).to.be.true;
       }
     });
 

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -390,10 +390,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
     /**
      * @notice Returns true if `account` is allowed to revoke permissions in target `where` for all actions.
      */
-    function isRevoker(
-        address account,
-        address where
-    ) public view returns (bool) {
+    function isRevoker(address account, address where) public view returns (bool) {
         return _isRevoker[account][where] || _isRevoker[account][EVERYWHERE] || isRoot(account);
     }
 
@@ -837,10 +834,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
      *
      * A malicious revoker cannot add new revokers, so root can simply revoke their status once.
      */
-    function addRevoker(
-        address account,
-        address where
-    ) external {
+    function addRevoker(address account, address where) external {
         require(isRoot(msg.sender), "SENDER_IS_NOT_ROOT");
 
         require(!isRevoker(account, where), "ACCOUNT_IS_ALREADY_REVOKER");
@@ -862,10 +856,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
      * is if we had contracts that were revoker, and this was depended upon for operation of the system. This however
      * doesn't seem like it will ever be required - revokers are typically subDAOs.
      */
-    function removeRevoker(
-        address account,
-        address where
-    ) external {
+    function removeRevoker(address account, address where) external {
         require(isRoot(msg.sender), "SENDER_IS_NOT_ROOT");
 
         require(isRevoker(account, where), "ACCOUNT_IS_NOT_REVOKER");

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -855,7 +855,7 @@ contract TimelockAuthorizer is IAuthorizer, IAuthentication, ReentrancyGuard {
     }
 
     /**
-     * @notice Removes revoker status from `account` in target `where`.
+     * @notice Removes revoker status from `account` in target `where` for all actions.
      * @dev Only the root can remove revokers.
      *
      * Note that there are no delays associated with removing revokers.  The only instance in which one might be useful

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -312,13 +312,6 @@ describe('TimelockAuthorizer', () => {
           expect(await authorizer.isRevoker(revoker, EVERYWHERE)).to.be.false;
         });
 
-        it('account is not a revoker for any other contract', async () => {
-          await authorizer.addRevoker(revoker, WHERE_1, { from: root });
-
-          expect(await authorizer.isRevoker(revoker, WHERE_2)).to.be.false;
-          expect(await authorizer.isRevoker(revoker, EVERYWHERE)).to.be.false;
-        });
-
         it('emits a RevokerAdded event', async () => {
           const receipt = await (await authorizer.addRevoker(revoker, WHERE_1, { from: root })).wait();
           expectEvent.inReceipt(receipt, 'RevokerAdded', {

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -449,7 +449,7 @@ describe('TimelockAuthorizer', () => {
           );
         });
       });
-  
+
       context('in any contract', () => {
         it('account is not a revoker for any contract', async () => {
           await authorizer.addRevoker(revoker, EVERYWHERE, { from: root });

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -404,7 +404,7 @@ describe('TimelockAuthorizer', () => {
 
     describe('removeRevoker', () => {
       context('in a specific contract', () => {
-        it('account is not a revoker for that action anywhere', async () => {
+        it('account is not a revoker anywhere', async () => {
           await authorizer.addRevoker(revoker, WHERE_1, { from: root });
           await authorizer.removeRevoker(revoker, WHERE_1, { from: root });
 

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -304,110 +304,98 @@ describe('TimelockAuthorizer', () => {
   describe('revokers', () => {
     describe('addRevoker', () => {
       context('in a specific contract', () => {
-        it('account is a revoker for that action only in that contract', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, WHERE_1, { from: root });
+        it('account is a revoker only in that contract', async () => {
+          await authorizer.addRevoker(revoker, WHERE_1, { from: root });
 
-          expect(await authorizer.isRevoker(ACTION_1, revoker, WHERE_1)).to.be.true;
-          expect(await authorizer.isRevoker(ACTION_1, revoker, WHERE_2)).to.be.false;
-          expect(await authorizer.isRevoker(ACTION_1, revoker, EVERYWHERE)).to.be.false;
+          expect(await authorizer.isRevoker(revoker, WHERE_1)).to.be.true;
+          expect(await authorizer.isRevoker(revoker, WHERE_2)).to.be.false;
+          expect(await authorizer.isRevoker(revoker, EVERYWHERE)).to.be.false;
         });
 
-        it('account is not a revoker for any other action anywhere', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, WHERE_1, { from: root });
+        it('account is not a revoker for any other contract', async () => {
+          await authorizer.addRevoker(revoker, WHERE_1, { from: root });
 
-          expect(await authorizer.isRevoker(ACTION_2, revoker, WHERE_1)).to.be.false;
-          expect(await authorizer.isRevoker(ACTION_2, revoker, WHERE_2)).to.be.false;
-          expect(await authorizer.isRevoker(ACTION_2, revoker, EVERYWHERE)).to.be.false;
+          expect(await authorizer.isRevoker(revoker, WHERE_2)).to.be.false;
+          expect(await authorizer.isRevoker(revoker, EVERYWHERE)).to.be.false;
         });
 
         it('emits a RevokerAdded event', async () => {
-          const receipt = await (await authorizer.addRevoker(ACTION_1, revoker, WHERE_1, { from: root })).wait();
+          const receipt = await (await authorizer.addRevoker(revoker, WHERE_1, { from: root })).wait();
           expectEvent.inReceipt(receipt, 'RevokerAdded', {
-            actionId: ACTION_1,
             account: revoker.address,
             where: WHERE_1,
           });
         });
 
         it('reverts if account is already a revoker', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, WHERE_1, { from: root });
-          await expect(authorizer.addRevoker(ACTION_1, revoker, WHERE_1, { from: root })).to.be.revertedWith(
+          await authorizer.addRevoker(revoker, WHERE_1, { from: root });
+          await expect(authorizer.addRevoker(revoker, WHERE_1, { from: root })).to.be.revertedWith(
             'ACCOUNT_IS_ALREADY_REVOKER'
           );
         });
 
         it('reverts if account is already a global revoker', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, EVERYWHERE, { from: root });
-          await expect(authorizer.addRevoker(ACTION_1, revoker, WHERE_1, { from: root })).to.be.revertedWith(
+          await authorizer.addRevoker(revoker, EVERYWHERE, { from: root });
+          await expect(authorizer.addRevoker(revoker, WHERE_1, { from: root })).to.be.revertedWith(
             'ACCOUNT_IS_ALREADY_REVOKER'
           );
         });
 
         it('reverts if the account is root', async () => {
-          await expect(authorizer.addRevoker(ACTION_1, root, WHERE_1, { from: root })).to.be.revertedWith(
+          await expect(authorizer.addRevoker(root, WHERE_1, { from: root })).to.be.revertedWith(
             'ACCOUNT_IS_ALREADY_REVOKER'
           );
         });
 
         it('reverts if the caller is not root', async () => {
-          await expect(authorizer.addRevoker(ACTION_1, revoker, WHERE_1, { from: other })).to.be.revertedWith(
+          await expect(authorizer.addRevoker(revoker, WHERE_1, { from: other })).to.be.revertedWith(
             'SENDER_IS_NOT_ROOT'
           );
         });
       });
 
       context('in any contract', () => {
-        it('account is a revoker for that action in any contract', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, EVERYWHERE, { from: root });
+        it('account is a revoker in any contract', async () => {
+          await authorizer.addRevoker(revoker, EVERYWHERE, { from: root });
 
-          expect(await authorizer.isRevoker(ACTION_1, revoker, WHERE_1)).to.be.true;
-          expect(await authorizer.isRevoker(ACTION_1, revoker, WHERE_2)).to.be.true;
-          expect(await authorizer.isRevoker(ACTION_1, revoker, EVERYWHERE)).to.be.true;
-        });
-
-        it('account is not a revoker for any other action anywhere', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, EVERYWHERE, { from: root });
-
-          expect(await authorizer.isRevoker(ACTION_2, revoker, WHERE_1)).to.be.false;
-          expect(await authorizer.isRevoker(ACTION_2, revoker, WHERE_2)).to.be.false;
-          expect(await authorizer.isRevoker(ACTION_2, revoker, EVERYWHERE)).to.be.false;
+          expect(await authorizer.isRevoker(revoker, WHERE_1)).to.be.true;
+          expect(await authorizer.isRevoker(revoker, WHERE_2)).to.be.true;
+          expect(await authorizer.isRevoker(revoker, EVERYWHERE)).to.be.true;
         });
 
         it('emits a RevokerAdded event', async () => {
-          const receipt = await (await authorizer.addRevoker(ACTION_1, revoker, EVERYWHERE, { from: root })).wait();
+          const receipt = await (await authorizer.addRevoker(revoker, EVERYWHERE, { from: root })).wait();
           expectEvent.inReceipt(receipt, 'RevokerAdded', {
-            actionId: ACTION_1,
             account: revoker.address,
             where: EVERYWHERE,
           });
         });
 
         it('does not revert if account is already revoker in a specific contract', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, WHERE_1, { from: root });
+          await authorizer.addRevoker(revoker, WHERE_1, { from: root });
 
-          const receipt = await (await authorizer.addRevoker(ACTION_1, revoker, EVERYWHERE, { from: root })).wait();
+          const receipt = await (await authorizer.addRevoker(revoker, EVERYWHERE, { from: root })).wait();
           expectEvent.inReceipt(receipt, 'RevokerAdded', {
-            actionId: ACTION_1,
             account: revoker.address,
             where: EVERYWHERE,
           });
         });
 
         it('reverts if account already is a global revoker', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, EVERYWHERE, { from: root });
-          await expect(authorizer.addRevoker(ACTION_1, revoker, EVERYWHERE, { from: root })).to.be.revertedWith(
+          await authorizer.addRevoker(revoker, EVERYWHERE, { from: root });
+          await expect(authorizer.addRevoker(revoker, EVERYWHERE, { from: root })).to.be.revertedWith(
             'ACCOUNT_IS_ALREADY_REVOKER'
           );
         });
 
         it('reverts if the account is root', async () => {
-          await expect(authorizer.addRevoker(ACTION_1, root, EVERYWHERE, { from: root })).to.be.revertedWith(
+          await expect(authorizer.addRevoker(root, EVERYWHERE, { from: root })).to.be.revertedWith(
             'ACCOUNT_IS_ALREADY_REVOKER'
           );
         });
 
         it('reverts if the caller is not root', async () => {
-          await expect(authorizer.addRevoker(ACTION_1, revoker, EVERYWHERE, { from: other })).to.be.revertedWith(
+          await expect(authorizer.addRevoker(revoker, EVERYWHERE, { from: other })).to.be.revertedWith(
             'SENDER_IS_NOT_ROOT'
           );
         });
@@ -417,128 +405,110 @@ describe('TimelockAuthorizer', () => {
     describe('removeRevoker', () => {
       context('in a specific contract', () => {
         it('account is not a revoker for that action anywhere', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, WHERE_1, { from: root });
-          await authorizer.removeRevoker(ACTION_1, revoker, WHERE_1, { from: root });
+          await authorizer.addRevoker(revoker, WHERE_1, { from: root });
+          await authorizer.removeRevoker(revoker, WHERE_1, { from: root });
 
-          expect(await authorizer.isRevoker(ACTION_1, revoker, WHERE_1)).to.be.false;
-          expect(await authorizer.isRevoker(ACTION_1, revoker, WHERE_2)).to.be.false;
-          expect(await authorizer.isRevoker(ACTION_1, revoker, EVERYWHERE)).to.be.false;
-        });
-
-        it('account is not a revoker for any other action', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, WHERE_1, { from: root });
-          await authorizer.removeRevoker(ACTION_1, revoker, WHERE_1, { from: root });
-
-          expect(await authorizer.isRevoker(ACTION_2, revoker, WHERE_1)).to.be.false;
-          expect(await authorizer.isRevoker(ACTION_2, revoker, WHERE_2)).to.be.false;
-          expect(await authorizer.isRevoker(ACTION_2, revoker, EVERYWHERE)).to.be.false;
+          expect(await authorizer.isRevoker(revoker, WHERE_1)).to.be.false;
+          expect(await authorizer.isRevoker(revoker, WHERE_2)).to.be.false;
+          expect(await authorizer.isRevoker(revoker, EVERYWHERE)).to.be.false;
         });
 
         it('emits a RevokerRemoved event', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, WHERE_1, { from: root });
+          await authorizer.addRevoker(revoker, WHERE_1, { from: root });
 
-          const receipt = await (await authorizer.removeRevoker(ACTION_1, revoker, WHERE_1, { from: root })).wait();
+          const receipt = await (await authorizer.removeRevoker(revoker, WHERE_1, { from: root })).wait();
           expectEvent.inReceipt(receipt, 'RevokerRemoved', {
-            actionId: ACTION_1,
             account: revoker.address,
             where: WHERE_1,
           });
         });
 
         it('reverts if the account is not a revoker', async () => {
-          await expect(authorizer.removeRevoker(ACTION_1, revoker, WHERE_1, { from: root })).to.be.revertedWith(
+          await expect(authorizer.removeRevoker(revoker, WHERE_1, { from: root })).to.be.revertedWith(
             'ACCOUNT_IS_NOT_REVOKER'
           );
         });
 
         it('reverts if the account is a global revoker', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, EVERYWHERE, { from: root });
-          await expect(authorizer.removeRevoker(ACTION_1, revoker, WHERE_1, { from: root })).to.be.revertedWith(
+          await authorizer.addRevoker(revoker, EVERYWHERE, { from: root });
+          await expect(authorizer.removeRevoker(revoker, WHERE_1, { from: root })).to.be.revertedWith(
             'REVOKER_IS_GLOBAL'
           );
         });
 
         it('reverts if the account is root', async () => {
-          await expect(authorizer.removeRevoker(ACTION_1, root, WHERE_1, { from: root })).to.be.revertedWith(
+          await expect(authorizer.removeRevoker(root, WHERE_1, { from: root })).to.be.revertedWith(
             'CANNOT_REMOVE_ROOT_REVOKER'
           );
         });
 
         it('reverts if the caller is not root', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, WHERE_1, { from: root });
-          await expect(authorizer.removeRevoker(ACTION_1, revoker, WHERE_1, { from: other })).to.be.revertedWith(
+          await authorizer.addRevoker(revoker, WHERE_1, { from: root });
+          await expect(authorizer.removeRevoker(revoker, WHERE_1, { from: other })).to.be.revertedWith(
             'SENDER_IS_NOT_ROOT'
           );
         });
       });
+  
       context('in any contract', () => {
-        it('account is not a revoker for that action on any contract', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, EVERYWHERE, { from: root });
-          await authorizer.removeRevoker(ACTION_1, revoker, EVERYWHERE, { from: root });
+        it('account is not a revoker for any contract', async () => {
+          await authorizer.addRevoker(revoker, EVERYWHERE, { from: root });
+          await authorizer.removeRevoker(revoker, EVERYWHERE, { from: root });
 
-          expect(await authorizer.isRevoker(ACTION_1, revoker, WHERE_1)).to.be.false;
-          expect(await authorizer.isRevoker(ACTION_1, revoker, EVERYWHERE)).to.be.false;
-        });
-
-        it('account is not a revoker for that any other action anywhere', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, EVERYWHERE, { from: root });
-          await authorizer.removeRevoker(ACTION_1, revoker, EVERYWHERE, { from: root });
-
-          expect(await authorizer.isRevoker(ACTION_2, revoker, WHERE_1)).to.be.false;
-          expect(await authorizer.isRevoker(ACTION_2, revoker, EVERYWHERE)).to.be.false;
+          expect(await authorizer.isRevoker(revoker, WHERE_1)).to.be.false;
+          expect(await authorizer.isRevoker(revoker, EVERYWHERE)).to.be.false;
         });
 
         it('emits a RevokerRemoved event', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, EVERYWHERE, { from: root });
+          await authorizer.addRevoker(revoker, EVERYWHERE, { from: root });
 
-          const receipt = await (await authorizer.removeRevoker(ACTION_1, revoker, EVERYWHERE, { from: root })).wait();
+          const receipt = await (await authorizer.removeRevoker(revoker, EVERYWHERE, { from: root })).wait();
           expectEvent.inReceipt(receipt, 'RevokerRemoved', {
-            actionId: ACTION_1,
             account: revoker.address,
             where: EVERYWHERE,
           });
         });
 
         it('reverts if the account is not a global revoker', async () => {
-          await expect(authorizer.removeRevoker(ACTION_1, revoker, EVERYWHERE, { from: root })).to.be.revertedWith(
+          await expect(authorizer.removeRevoker(revoker, EVERYWHERE, { from: root })).to.be.revertedWith(
             'ACCOUNT_IS_NOT_REVOKER'
           );
         });
 
         it('reverts if the account is a revoker in a specific contract', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, WHERE_1, { from: root });
-          await expect(authorizer.removeRevoker(ACTION_1, revoker, EVERYWHERE, { from: root })).to.be.revertedWith(
+          await authorizer.addRevoker(revoker, WHERE_1, { from: root });
+          await expect(authorizer.removeRevoker(revoker, EVERYWHERE, { from: root })).to.be.revertedWith(
             'ACCOUNT_IS_NOT_REVOKER'
           );
         });
 
         it('preserves revoker status if it was received over both a specific contract and globally', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, WHERE_1, { from: root });
-          await authorizer.addRevoker(ACTION_1, revoker, EVERYWHERE, { from: root });
+          await authorizer.addRevoker(revoker, WHERE_1, { from: root });
+          await authorizer.addRevoker(revoker, EVERYWHERE, { from: root });
 
-          expect(await authorizer.isRevoker(ACTION_1, revoker, WHERE_1)).to.be.true;
-          expect(await authorizer.isRevoker(ACTION_1, revoker, EVERYWHERE)).to.be.true;
+          expect(await authorizer.isRevoker(revoker, WHERE_1)).to.be.true;
+          expect(await authorizer.isRevoker(revoker, EVERYWHERE)).to.be.true;
 
-          await authorizer.removeRevoker(ACTION_1, revoker, EVERYWHERE, { from: root });
+          await authorizer.removeRevoker(revoker, EVERYWHERE, { from: root });
 
-          expect(await authorizer.isRevoker(ACTION_1, revoker, WHERE_1)).to.be.true;
-          expect(await authorizer.isRevoker(ACTION_1, revoker, EVERYWHERE)).to.be.false;
+          expect(await authorizer.isRevoker(revoker, WHERE_1)).to.be.true;
+          expect(await authorizer.isRevoker(revoker, EVERYWHERE)).to.be.false;
 
-          await authorizer.removeRevoker(ACTION_1, revoker, WHERE_1, { from: root });
+          await authorizer.removeRevoker(revoker, WHERE_1, { from: root });
 
-          expect(await authorizer.isRevoker(ACTION_1, revoker, WHERE_1)).to.be.false;
-          expect(await authorizer.isRevoker(ACTION_1, revoker, EVERYWHERE)).to.be.false;
+          expect(await authorizer.isRevoker(revoker, WHERE_1)).to.be.false;
+          expect(await authorizer.isRevoker(revoker, EVERYWHERE)).to.be.false;
         });
 
         it('reverts if the account is root', async () => {
-          await expect(authorizer.removeRevoker(ACTION_1, root, EVERYWHERE, { from: root })).to.be.revertedWith(
+          await expect(authorizer.removeRevoker(root, EVERYWHERE, { from: root })).to.be.revertedWith(
             'CANNOT_REMOVE_ROOT_REVOKER'
           );
         });
 
         it('reverts if the caller is not root', async () => {
-          await authorizer.addRevoker(ACTION_1, revoker, EVERYWHERE, { from: root });
-          await expect(authorizer.removeRevoker(ACTION_1, revoker, EVERYWHERE, { from: other })).to.be.revertedWith(
+          await authorizer.addRevoker(revoker, EVERYWHERE, { from: root });
+          await expect(authorizer.removeRevoker(revoker, EVERYWHERE, { from: other })).to.be.revertedWith(
             'SENDER_IS_NOT_ROOT'
           );
         });
@@ -2085,18 +2055,18 @@ describe('TimelockAuthorizer', () => {
 
       it('revokes powers to grant and revoke GENERAL_PERMISSION_SPECIFIER on EVERYWHERE from current root', async () => {
         expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE)).to.be.true;
-        expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE)).to.be.true;
+        expect(await authorizer.isRevoker(root, EVERYWHERE)).to.be.true;
         await authorizer.claimRoot({ from: granter });
         expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE)).to.be.false;
-        expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, root, EVERYWHERE)).to.be.false;
+        expect(await authorizer.isRevoker(root, EVERYWHERE)).to.be.false;
       });
 
       it('grants powers to grant and revoke GENERAL_PERMISSION_SPECIFIER on EVERYWHERE to the pending root', async () => {
         expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, granter, EVERYWHERE)).to.be.false;
-        expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, granter, EVERYWHERE)).to.be.false;
+        expect(await authorizer.isRevoker(granter, EVERYWHERE)).to.be.false;
         await authorizer.claimRoot({ from: granter });
         expect(await authorizer.isGranter(GENERAL_PERMISSION_SPECIFIER, granter, EVERYWHERE)).to.be.true;
-        expect(await authorizer.isRevoker(GENERAL_PERMISSION_SPECIFIER, granter, EVERYWHERE)).to.be.true;
+        expect(await authorizer.isRevoker(granter, EVERYWHERE)).to.be.true;
       });
 
       it('resets the pending root address to the zero address', async () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizerRoot.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerRoot.test.ts
@@ -94,24 +94,24 @@ describe('TimelockAuthorizerRoot', () => {
     });
 
     it('can manage other addresses to revoke permissions for a custom contract', async () => {
-      await authorizer.addRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1, { from: root });
+      await authorizer.addRevoker(grantee, WHERE_1, { from: root });
 
       expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
       expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
 
-      await authorizer.removeRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1, { from: root });
+      await authorizer.removeRevoker(grantee, WHERE_1, { from: root });
 
       expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
       expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;
     });
 
     it('can manage other addresses to revoke permissions everywhere', async () => {
-      await authorizer.addRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE, { from: root });
+      await authorizer.addRevoker(grantee, EVERYWHERE, { from: root });
 
       expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.true;
       expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.true;
 
-      await authorizer.removeRevoker(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE, { from: root });
+      await authorizer.removeRevoker(grantee, EVERYWHERE, { from: root });
 
       expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, WHERE_1)).to.be.false;
       expect(await authorizer.canRevoke(GENERAL_PERMISSION_SPECIFIER, grantee, EVERYWHERE)).to.be.false;

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -110,8 +110,8 @@ export default class TimelockAuthorizer {
     return this.instance.isGranter(actionId, this.toAddress(account), this.toAddress(where));
   }
 
-  async isRevoker(actionId: string, account: Account, where: Account): Promise<boolean> {
-    return this.instance.isRevoker(actionId, this.toAddress(account), this.toAddress(where));
+  async isRevoker(account: Account, where: Account): Promise<boolean> {
+    return this.instance.isRevoker(this.toAddress(account), this.toAddress(where));
   }
 
   async scheduleRootChange(root: Account, executors: Account[], params?: TxParams): Promise<number> {
@@ -209,17 +209,12 @@ export default class TimelockAuthorizer {
     return this.with(params).removeGranter(action, this.toAddress(account), this.toAddress(wheres));
   }
 
-  async addRevoker(action: string, account: Account, where: Account, params?: TxParams): Promise<ContractTransaction> {
-    return this.with(params).addRevoker(action, this.toAddress(account), this.toAddress(where));
+  async addRevoker(account: Account, where: Account, params?: TxParams): Promise<ContractTransaction> {
+    return this.with(params).addRevoker(this.toAddress(account), this.toAddress(where));
   }
 
-  async removeRevoker(
-    action: string,
-    account: Account,
-    wheres: Account,
-    params?: TxParams
-  ): Promise<ContractTransaction> {
-    return this.with(params).removeRevoker(action, this.toAddress(account), this.toAddress(wheres));
+  async removeRevoker(account: Account, wheres: Account, params?: TxParams): Promise<ContractTransaction> {
+    return this.with(params).removeRevoker(this.toAddress(account), this.toAddress(wheres));
   }
 
   async grantPermissions(


### PR DESCRIPTION
# Description

<!-- Describe the changes introduced in this pull request. -->
This PR removes the actionId parameter from the addRevoker, removeRevoker, and isRevoker functions because we don’t need that level of granularity. Revokers will now have the power to revoke from either a specific contract or from all contracts, but in both cases, for any actionId. Previously, specific revokers were limited to a combination of actionId and where (contract address). The rationale behind this change is that there are no use cases that require revoking powers for a specific combination of a contract and an actionId.
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [x] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

The PR is a continuation of work on `TimelockAuthorizer` milestone https://github.com/balancer/balancer-v2-monorepo/milestone/20.

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
