### PR TITLE
Prevent setting BAL as a reward token in `ChildChainGauge`.

### DIFF
--- a/pkg/liquidity-mining/contracts/gauges/ChildChainGauge.vy
+++ b/pkg/liquidity-mining/contracts/gauges/ChildChainGauge.vy
@@ -620,9 +620,11 @@ def claim_rewards(
 @external
 def add_reward(_reward_token: address, _distributor: address):
     """
-    @notice Set the active reward contract
+    @notice Set the active reward contract.
+    @dev The reward token cannot be BAL, since it is transferred automatically to the pseudo minter during checkpoints.
     """
     assert msg.sender == AUTHORIZER_ADAPTOR  # dev: only owner
+    assert _reward_token != BAL
 
     reward_count: uint256 = self.reward_count
     assert reward_count < MAX_REWARDS
@@ -723,8 +725,15 @@ def integrate_checkpoint() -> uint256:
 
 @view
 @external
+def bal_token() -> address:
+    return BAL
+
+
+@view
+@external
 def bal_pseudo_minter() -> address:
     return BAL_PSEUDO_MINTER
+
 
 @view
 @external

--- a/pkg/liquidity-mining/contracts/gauges/ChildChainGauge.vy
+++ b/pkg/liquidity-mining/contracts/gauges/ChildChainGauge.vy
@@ -624,7 +624,7 @@ def add_reward(_reward_token: address, _distributor: address):
     @dev The reward token cannot be BAL, since it is transferred automatically to the pseudo minter during checkpoints.
     """
     assert msg.sender == AUTHORIZER_ADAPTOR  # dev: only owner
-    assert _reward_token != BAL
+    assert _reward_token != BAL, "CANNOT_ADD_BAL_REWARD"
 
     reward_count: uint256 = self.reward_count
     assert reward_count < MAX_REWARDS

--- a/pkg/liquidity-mining/test/ChildChainGauge.test.ts
+++ b/pkg/liquidity-mining/test/ChildChainGauge.test.ts
@@ -400,5 +400,13 @@ describe('ChildChainGauge', () => {
         await expectEvent.notEmitted(await tx.wait(), 'Transfer');
       });
     });
+
+    it('reverts adding BAL as a reward', async () => {
+      await expect(
+        vault.authorizerAdaptorEntrypoint
+          .connect(admin)
+          .performAction(gauge.address, gauge.interface.encodeFunctionData('add_reward', [BAL.address, admin.address]))
+      ).to.be.revertedWith('CANNOT_ADD_BAL_REWARD');
+    });
   });
 });


### PR DESCRIPTION
# Description

BAL gets a special treatment in `ChildChainGauge`: it is transferred to the pseudo minter during checkpoints, so it cannot be distributed as a regular reward.

This PR enforces this condition by rejecting BAL when adding a new reward. It also adds a BAL getter.
Built on top of #2325 to make use of the tests introduced there. First review #2325, then this one.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

Closes #2329.