### PR TITLE
Remove batching from grantPermissions, revokePermissions, and renouncePermissions

### DIFF
--- a/pkg/governance-scripts/contracts/TimelockAuthorizerMigrator.sol
+++ b/pkg/governance-scripts/contracts/TimelockAuthorizerMigrator.sol
@@ -77,13 +77,13 @@ contract TimelockAuthorizerMigrator {
         for (uint256 i = 0; i < _rolesData.length; i++) {
             RoleData memory roleData = _rolesData[i];
             // We require that any permissions being copied from the old Authorizer must exist on the old Authorizer.
-            // This simplifies verification of the permissions being added to the new TimelockAuthorizer.
+            // This simplifies verification of the permissions eing added to the new TimelockAuthorizer.
             require(_oldAuthorizer.canPerform(roleData.role, roleData.grantee, roleData.target), "UNEXPECTED_ROLE");
-            _newAuthorizer.grantPermissions(_arr(roleData.role), roleData.grantee, _arr(roleData.target));
+            _newAuthorizer.grantPermission((roleData.role), roleData.grantee, roleData.target);
         }
         for (uint256 i = 0; i < _grantersData.length; i++) {
             // There's no concept of a "granter" on the old Authorizer so we cannot verify these onchain.
-            // We must manually verify that these permissions are set sensibly.
+            // We must manually verify that these permissions are set sensily.
             _newAuthorizer.addGranter(_grantersData[i].role, _grantersData[i].grantee, _grantersData[i].target);
         }
         for (uint256 i = 0; i < _revokersData.length; i++) {

--- a/pkg/governance-scripts/contracts/TimelockAuthorizerMigrator.sol
+++ b/pkg/governance-scripts/contracts/TimelockAuthorizerMigrator.sol
@@ -77,13 +77,13 @@ contract TimelockAuthorizerMigrator {
         for (uint256 i = 0; i < _rolesData.length; i++) {
             RoleData memory roleData = _rolesData[i];
             // We require that any permissions being copied from the old Authorizer must exist on the old Authorizer.
-            // This simplifies verification of the permissions eing added to the new TimelockAuthorizer.
+            // This simplifies verification of the permissions being added to the new TimelockAuthorizer.
             require(_oldAuthorizer.canPerform(roleData.role, roleData.grantee, roleData.target), "UNEXPECTED_ROLE");
-            _newAuthorizer.grantPermission((roleData.role), roleData.grantee, roleData.target);
+            _newAuthorizer.grantPermission(roleData.role, roleData.grantee, roleData.target);
         }
         for (uint256 i = 0; i < _grantersData.length; i++) {
             // There's no concept of a "granter" on the old Authorizer so we cannot verify these onchain.
-            // We must manually verify that these permissions are set sensily.
+            // We must manually verify that these permissions are set sensibly.
             _newAuthorizer.addGranter(_grantersData[i].role, _grantersData[i].grantee, _grantersData[i].target);
         }
         for (uint256 i = 0; i < _revokersData.length; i++) {

--- a/pkg/liquidity-mining/test/AuthorizerAdaptorEntrypoint.test.ts
+++ b/pkg/liquidity-mining/test/AuthorizerAdaptorEntrypoint.test.ts
@@ -121,9 +121,8 @@ describe('AuthorizerAdaptorEntrypoint', () => {
 
     context('when caller is authorized globally', () => {
       sharedBeforeEach('authorize caller globally', async () => {
-        await authorizer
-          .connect(admin)
-          .grantPermissions([action, payableAction], grantee.address, [ANY_ADDRESS, ANY_ADDRESS]);
+        await authorizer.connect(admin).grantPermission(action, grantee.address, ANY_ADDRESS);
+        await authorizer.connect(admin).grantPermission(payableAction, grantee.address, ANY_ADDRESS);
       });
 
       itHandlesFunctionCallsCorrectly();
@@ -131,9 +130,8 @@ describe('AuthorizerAdaptorEntrypoint', () => {
 
     context('when caller is authorized locally on target', () => {
       sharedBeforeEach('authorize caller on target locally', async () => {
-        await authorizer
-          .connect(admin)
-          .grantPermissions([action, payableAction], grantee.address, [vault.address, paymentReceiver.address]);
+        await authorizer.connect(admin).grantPermission(action, grantee.address, vault.address);
+        await authorizer.connect(admin).grantPermission(payableAction, grantee.address, paymentReceiver.address);
       });
 
       itHandlesFunctionCallsCorrectly();
@@ -141,7 +139,7 @@ describe('AuthorizerAdaptorEntrypoint', () => {
 
     context('when caller is authorized locally on a different target', () => {
       sharedBeforeEach('authorize caller on different target locally', async () => {
-        await authorizer.connect(admin).grantPermissions([action], grantee.address, [other.address]);
+        await authorizer.connect(admin).grantPermission(action, grantee.address, other.address);
       });
 
       it('reverts', async () => {

--- a/pkg/liquidity-mining/test/BalancerTokenAdmin.test.ts
+++ b/pkg/liquidity-mining/test/BalancerTokenAdmin.test.ts
@@ -57,7 +57,7 @@ describe('BalancerTokenAdmin', () => {
     context('when the caller is authorised to call this function', () => {
       sharedBeforeEach('authorize caller', async () => {
         const action = await actionId(tokenAdmin, 'activate');
-        await vault.grantPermissionsGlobally([action], admin.address);
+        await vault.grantPermissionGlobally(action, admin.address);
       });
 
       context('when BalancerTokenAdmin has been activated already', () => {
@@ -141,7 +141,7 @@ describe('BalancerTokenAdmin', () => {
     context('when BalancerTokenAdmin has been activated', () => {
       sharedBeforeEach('activate', async () => {
         const action = await actionId(tokenAdmin, 'activate');
-        await vault.grantPermissionsGlobally([action], admin.address);
+        await vault.grantPermissionGlobally(action, admin.address);
 
         await token.connect(admin).grantRole(DEFAULT_ADMIN_ROLE, tokenAdmin.address);
         await tokenAdmin.connect(admin).activate();
@@ -188,7 +188,7 @@ describe('BalancerTokenAdmin', () => {
   describe('mint', () => {
     sharedBeforeEach('activate BalancerTokenAdmin', async () => {
       const action = await actionId(tokenAdmin, 'activate');
-      await vault.grantPermissionsGlobally([action], admin.address);
+      await vault.grantPermissionGlobally(action, admin.address);
 
       await token.connect(admin).grantRole(DEFAULT_ADMIN_ROLE, tokenAdmin.address);
       await tokenAdmin.connect(admin).activate();
@@ -203,7 +203,7 @@ describe('BalancerTokenAdmin', () => {
     context('when the caller is authorised to call this function', () => {
       sharedBeforeEach('activate', async () => {
         const action = await actionId(tokenAdmin, 'mint');
-        await vault.grantPermissionsGlobally([action], admin.address);
+        await vault.grantPermissionGlobally(action, admin.address);
       });
 
       context('when mint does not exceed available supply', () => {
@@ -251,7 +251,7 @@ describe('BalancerTokenAdmin', () => {
         await token.connect(admin).grantRole(SNAPSHOT_ROLE, tokenAdmin.address);
 
         const action = await actionId(tokenAdmin, 'snapshot');
-        await vault.grantPermissionsGlobally([action], admin.address);
+        await vault.grantPermissionGlobally(action, admin.address);
       });
 
       it('emits a Snapshot event', async () => {

--- a/pkg/liquidity-mining/test/ChildChainGaugeRewardHelper.test.ts
+++ b/pkg/liquidity-mining/test/ChildChainGaugeRewardHelper.test.ts
@@ -80,7 +80,7 @@ describe('ChildChainGaugeRewardHelper', () => {
 
   sharedBeforeEach('set up distributor on streamer', async () => {
     const setDistributorActionId = await actionId(adaptorEntrypoint, 'set_reward_distributor', streamerOne.interface);
-    await vault.grantPermissionsGlobally([setDistributorActionId], admin);
+    await vault.grantPermissionGlobally(setDistributorActionId, admin);
 
     const calldata = streamerOne.interface.encodeFunctionData('set_reward_distributor', [
       balToken.address,

--- a/pkg/liquidity-mining/test/ChildChainGaugeTokenAdder.test.ts
+++ b/pkg/liquidity-mining/test/ChildChainGaugeTokenAdder.test.ts
@@ -64,7 +64,8 @@ describe('ChildChainGaugeTokenAdder', () => {
     const addRewardRole = await actionId(adaptorEntrypoint, 'add_reward', streamer.interface);
     const setRewardsRole = await actionId(adaptorEntrypoint, 'set_rewards', gauge.interface);
 
-    await vault.grantPermissionsGlobally([addRewardRole, setRewardsRole], gaugeTokenAdder);
+    await vault.grantPermissionGlobally(addRewardRole, gaugeTokenAdder);
+    await vault.grantPermissionGlobally(setRewardsRole, gaugeTokenAdder);
   });
 
   describe('constructor', () => {
@@ -97,7 +98,7 @@ describe('ChildChainGaugeTokenAdder', () => {
     sharedBeforeEach('grant permission to add new tokens', async () => {
       const addTokenToGaugeRole = await actionId(gaugeTokenAdder, 'addTokenToGauge');
 
-      await vault.grantPermissionsGlobally([addTokenToGaugeRole], admin);
+      await vault.grantPermissionGlobally(addTokenToGaugeRole, admin);
     });
 
     context('when interacting with a gauge from the expected factory', () => {
@@ -165,7 +166,7 @@ describe('ChildChainGaugeTokenAdder', () => {
       context("when the gauge's streamer has been changed from the original", () => {
         sharedBeforeEach("change the gauge's streamer", async () => {
           const addTokenToGaugeRole = await actionId(adaptorEntrypoint, 'set_rewards', gauge.interface);
-          await vault.grantPermissionsGlobally([addTokenToGaugeRole], admin);
+          await vault.grantPermissionGlobally(addTokenToGaugeRole, admin);
 
           await adaptorEntrypoint
             .connect(admin)

--- a/pkg/liquidity-mining/test/ChildChainStreamer.test.ts
+++ b/pkg/liquidity-mining/test/ChildChainStreamer.test.ts
@@ -57,7 +57,7 @@ describe('ChildChainStreamer', () => {
     sharedBeforeEach('send tokens to streamer', async () => {
       await balToken.mint(streamer, 100);
       const removeRewardRole = await actionId(adaptorEntrypoint, 'remove_reward', streamer.interface);
-      await vault.grantPermissionsGlobally([removeRewardRole], admin);
+      await vault.grantPermissionGlobally(removeRewardRole, admin);
     });
 
     it('allows tokens to be recovered', async () => {
@@ -86,7 +86,7 @@ describe('ChildChainStreamer', () => {
 
     sharedBeforeEach('set up distributor on streamer', async () => {
       const setDistributorActionId = await actionId(adaptorEntrypoint, 'set_reward_distributor', streamer.interface);
-      await vault.grantPermissionsGlobally([setDistributorActionId], admin);
+      await vault.grantPermissionGlobally(setDistributorActionId, admin);
 
       const calldata = streamer.interface.encodeFunctionData('set_reward_distributor', [
         balToken.address,

--- a/pkg/liquidity-mining/test/GaugeAdder.test.ts
+++ b/pkg/liquidity-mining/test/GaugeAdder.test.ts
@@ -45,7 +45,7 @@ describe('GaugeAdder', () => {
 
   sharedBeforeEach('set up permissions', async () => {
     const action = await actionId(adaptorEntrypoint, 'add_gauge', gaugeController.interface);
-    await vault.grantPermissionsGlobally([action], gaugeAdder);
+    await vault.grantPermissionGlobally(action, gaugeAdder);
   });
 
   async function deployGauge(gaugeFactory: Contract, poolAddress: string): Promise<string> {
@@ -67,7 +67,7 @@ describe('GaugeAdder', () => {
     context('when caller is authorized', () => {
       sharedBeforeEach('authorize caller', async () => {
         const action = await actionId(gaugeAdder, 'addGaugeFactory');
-        await vault.grantPermissionsGlobally([action], admin);
+        await vault.grantPermissionGlobally(action, admin);
       });
 
       context('when gauge type does not exist on GaugeController', () => {
@@ -125,7 +125,7 @@ describe('GaugeAdder', () => {
     context('when factory has been added to GaugeAdder', () => {
       sharedBeforeEach('add gauge factory', async () => {
         const action = await actionId(gaugeAdder, 'addGaugeFactory');
-        await vault.grantPermissionsGlobally([action], admin);
+        await vault.grantPermissionGlobally(action, admin);
 
         await gaugeAdder.connect(admin).addGaugeFactory(gaugeFactory.address, GaugeType.Ethereum);
       });
@@ -160,7 +160,7 @@ describe('GaugeAdder', () => {
     context('when caller is authorized', () => {
       sharedBeforeEach('authorize caller', async () => {
         const action = await actionId(gaugeAdder, 'addEthereumGauge');
-        await vault.grantPermissionsGlobally([action], admin);
+        await vault.grantPermissionGlobally(action, admin);
       });
 
       context('when gauge has not been deployed from a valid factory', () => {
@@ -172,7 +172,7 @@ describe('GaugeAdder', () => {
       context('when gauge has been deployed from a valid factory', () => {
         sharedBeforeEach('add gauge factory', async () => {
           const action = await actionId(gaugeAdder, 'addGaugeFactory');
-          await vault.grantPermissionsGlobally([action], admin);
+          await vault.grantPermissionGlobally(action, admin);
 
           await gaugeAdder.connect(admin).addGaugeFactory(gaugeFactory.address, GaugeType.Ethereum);
         });

--- a/pkg/liquidity-mining/test/GaugeRelativeWeightCap.test.ts
+++ b/pkg/liquidity-mining/test/GaugeRelativeWeightCap.test.ts
@@ -66,7 +66,7 @@ describe('GaugeRelativeWeightCap', () => {
 
   sharedBeforeEach('set up permissions', async () => {
     const action = await actionId(adaptorEntrypoint, 'setRelativeWeightCap', liquidityGaugeImplementation.interface);
-    await vault.grantPermissionsGlobally([action], admin);
+    await vault.grantPermissionGlobally(action, admin);
   });
 
   enum GaugeKind {

--- a/pkg/liquidity-mining/test/L2BalancerPseudoMinter.test.ts
+++ b/pkg/liquidity-mining/test/L2BalancerPseudoMinter.test.ts
@@ -44,7 +44,7 @@ describe('L2BalancerPseudoMinter', () => {
 
   describe('addGaugeFactory', () => {
     sharedBeforeEach('give permissions to admin', async () => {
-      await vault.grantPermissionsGlobally([await actionId(pseudoMinter, 'addGaugeFactory')], admin);
+      await vault.grantPermissionGlobally(await actionId(pseudoMinter, 'addGaugeFactory'), admin);
       expect(await pseudoMinter.isValidGaugeFactory(gaugeFactory.address)).to.be.false;
     });
 
@@ -81,10 +81,8 @@ describe('L2BalancerPseudoMinter', () => {
 
   describe('removeGaugeFactory', () => {
     sharedBeforeEach('give permissions to admin and add factory', async () => {
-      await vault.grantPermissionsGlobally(
-        [await actionId(pseudoMinter, 'addGaugeFactory'), await actionId(pseudoMinter, 'removeGaugeFactory')],
-        admin
-      );
+      await vault.grantPermissionGlobally(await actionId(pseudoMinter, 'removeGaugeFactory'), admin);
+      await vault.grantPermissionGlobally(await actionId(pseudoMinter, 'addGaugeFactory'), admin);
       await pseudoMinter.connect(admin).addGaugeFactory(gaugeFactory.address);
       expect(await pseudoMinter.isValidGaugeFactory(gaugeFactory.address)).to.be.true;
     });
@@ -124,7 +122,7 @@ describe('L2BalancerPseudoMinter', () => {
     const mockCheckpointStep = fp(1);
 
     sharedBeforeEach('setup factory and fund pseudo minter', async () => {
-      await vault.grantPermissionsGlobally([await actionId(pseudoMinter, 'addGaugeFactory')], admin);
+      await vault.grantPermissionGlobally(await actionId(pseudoMinter, 'addGaugeFactory'), admin);
       await pseudoMinter.connect(admin).addGaugeFactory(gaugeFactory.address);
       await BAL.connect(admin).mint(pseudoMinter.address, fp(100));
       expect(await pseudoMinter.minted(user.address, gauge.address)).to.be.eq(0);
@@ -226,7 +224,7 @@ describe('L2BalancerPseudoMinter', () => {
     let gaugeAddresses: string[];
 
     sharedBeforeEach('setup factory and fund pseudo minter', async () => {
-      await vault.grantPermissionsGlobally([await actionId(pseudoMinter, 'addGaugeFactory')], admin);
+      await vault.grantPermissionGlobally(await actionId(pseudoMinter, 'addGaugeFactory'), admin);
       await pseudoMinter.connect(admin).addGaugeFactory(gaugeFactory.address);
       await BAL.connect(admin).mint(pseudoMinter.address, fp(100));
 

--- a/pkg/liquidity-mining/test/L2GaugeCheckpointer.test.ts
+++ b/pkg/liquidity-mining/test/L2GaugeCheckpointer.test.ts
@@ -69,7 +69,7 @@ describe('L2GaugeCheckpointer', () => {
       args: [gaugeController.address, adaptorEntrypoint.address],
     });
     const action = await actionId(gaugeAdder, 'addGaugeFactory');
-    await vault.grantPermissionsGlobally([action], admin);
+    await vault.grantPermissionGlobally(action, admin);
 
     await Promise.all(
       gaugeFactories.map((factory) => gaugeAdder.connect(admin).addGaugeFactory(factory.contract.address, factory.type))

--- a/pkg/liquidity-mining/test/RewardsOnlyGauge.test.ts
+++ b/pkg/liquidity-mining/test/RewardsOnlyGauge.test.ts
@@ -169,7 +169,7 @@ describe('RewardsOnlyGauge', () => {
 
     sharedBeforeEach('set up distributor on streamer', async () => {
       const setDistributorActionId = await actionId(adaptorEntrypoint, 'set_reward_distributor', streamer.interface);
-      await vault.grantPermissionsGlobally([setDistributorActionId], admin);
+      await vault.grantPermissionGlobally(setDistributorActionId, admin);
 
       const calldata = streamer.interface.encodeFunctionData('set_reward_distributor', [
         balToken.address,

--- a/pkg/liquidity-mining/test/SmartWalletChecker.test.ts
+++ b/pkg/liquidity-mining/test/SmartWalletChecker.test.ts
@@ -28,7 +28,8 @@ describe('SmartWalletChecker', () => {
   sharedBeforeEach('set up permissions', async () => {
     const allowAction = await actionId(smartWalletChecker, 'allowlistAddress');
     const denyAction = await actionId(smartWalletChecker, 'denylistAddress');
-    await vault.grantPermissionsGlobally([allowAction, denyAction], admin);
+    await vault.grantPermissionGlobally(allowAction, admin);
+    await vault.grantPermissionGlobally(denyAction, admin);
   });
 
   describe('constructor', () => {
@@ -58,7 +59,7 @@ describe('SmartWalletChecker', () => {
     context('when caller is authorized', () => {
       sharedBeforeEach('authorize caller', async () => {
         const action = await actionId(smartWalletChecker, 'allowlistAddress');
-        await vault.grantPermissionsGlobally([action], caller);
+        await vault.grantPermissionGlobally(action, caller);
       });
 
       context('when address is already allowlisted', () => {
@@ -103,7 +104,7 @@ describe('SmartWalletChecker', () => {
     context('when caller is authorized', () => {
       sharedBeforeEach('authorize caller', async () => {
         const action = await actionId(smartWalletChecker, 'denylistAddress');
-        await vault.grantPermissionsGlobally([action], caller);
+        await vault.grantPermissionGlobally(action, caller);
       });
 
       context('when address is already denylisted', () => {

--- a/pkg/pool-stable/test/ComposableStablePoolProtocolFees.test.ts
+++ b/pkg/pool-stable/test/ComposableStablePoolProtocolFees.test.ts
@@ -60,14 +60,17 @@ describe('ComposableStablePoolProtocolFees', () => {
   sharedBeforeEach('grant permissions to admin', async () => {
     await vault.authorizer
       .connect(admin)
-      .grantPermissions([actionId(feesProvider, 'setFeeTypePercentage')], admin.address, [feesProvider.address]);
+      .grantPermission(actionId(feesProvider, 'setFeeTypePercentage'), admin.address, feesProvider.address);
 
     await vault.authorizer
       .connect(admin)
-      .grantPermissions(
-        [actionId(feesCollector, 'setSwapFeePercentage'), actionId(feesCollector, 'setFlashLoanFeePercentage')],
+      .grantPermission(actionId(feesCollector, 'setSwapFeePercentage'), feesProvider.address, feesCollector.address);
+    await vault.authorizer
+      .connect(admin)
+      .grantPermission(
+        actionId(feesCollector, 'setFlashLoanFeePercentage'),
         feesProvider.address,
-        [feesCollector.address, feesCollector.address]
+        feesCollector.address
       );
   });
 

--- a/pkg/pool-stable/test/ComposableStablePoolRates.test.ts
+++ b/pkg/pool-stable/test/ComposableStablePoolRates.test.ts
@@ -658,7 +658,7 @@ describe('ComposableStablePoolRates', () => {
           context('when the sender is allowed', () => {
             sharedBeforeEach('grant role to caller', async () => {
               const action = await actionId(pool, 'setTokenRateCacheDuration');
-              await vault.grantPermissionsGlobally([action], other);
+              await vault.grantPermissionGlobally(action, other);
             });
 
             context('before the cache expires', () => {

--- a/pkg/pool-stable/test/StablePoolAmplification.test.ts
+++ b/pkg/pool-stable/test/StablePoolAmplification.test.ts
@@ -301,7 +301,8 @@ describe('StablePoolAmplification', () => {
         sharedBeforeEach('grant permissions', async () => {
           const startAmpChangePermission = await actionId(pool, 'startAmplificationParameterUpdate');
           const stopAmpChangePermission = await actionId(pool, 'stopAmplificationParameterUpdate');
-          await vault.grantPermissionsGlobally([startAmpChangePermission, stopAmpChangePermission], other);
+          await vault.grantPermissionGlobally(stopAmpChangePermission, other);
+          await vault.grantPermissionGlobally(startAmpChangePermission, other);
         });
 
         itStartsAnAmpUpdateCorrectly();
@@ -401,7 +402,8 @@ describe('StablePoolAmplification', () => {
         sharedBeforeEach('grant permissions', async () => {
           const startAmpChangePermission = await actionId(pool, 'startAmplificationParameterUpdate');
           const stopAmpChangePermission = await actionId(pool, 'stopAmplificationParameterUpdate');
-          await vault.grantPermissionsGlobally([startAmpChangePermission, stopAmpChangePermission], other);
+          await vault.grantPermissionGlobally(startAmpChangePermission, other);
+          await vault.grantPermissionGlobally(stopAmpChangePermission, other);
         });
 
         itStopsAnAmpUpdateCorrectly();

--- a/pkg/pool-utils/test/BasePool.test.ts
+++ b/pkg/pool-utils/test/BasePool.test.ts
@@ -548,12 +548,8 @@ describe('BasePool', function () {
         sharedBeforeEach('grant permission', async () => {
           const enableRecoveryAction = await actionId(pool, 'enableRecoveryMode');
           const disableRecoveryAction = await actionId(pool, 'disableRecoveryMode');
-          await authorizer
-            .connect(admin)
-            .grantPermission(enableRecoveryAction, sender.address, ANY_ADDRESS);
-          await authorizer
-            .connect(admin)
-            .grantPermission(disableRecoveryAction, sender.address, ANY_ADDRESS);
+          await authorizer.connect(admin).grantPermission(enableRecoveryAction, sender.address, ANY_ADDRESS);
+          await authorizer.connect(admin).grantPermission(disableRecoveryAction, sender.address, ANY_ADDRESS);
         });
 
         itCanEnableRecoveryMode();

--- a/pkg/pool-utils/test/BasePool.test.ts
+++ b/pkg/pool-utils/test/BasePool.test.ts
@@ -93,7 +93,7 @@ describe('BasePool', function () {
 
     it('tracks authorizer changes in the vault', async () => {
       const action = await actionId(vault, 'setAuthorizer');
-      await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+      await authorizer.connect(admin).grantPermission(action, admin.address, ANY_ADDRESS);
 
       await vault.connect(admin).setAuthorizer(other.address);
 
@@ -180,7 +180,7 @@ describe('BasePool', function () {
           context('when paused', () => {
             sharedBeforeEach('pause pool', async () => {
               const action = await actionId(pool, 'pause');
-              await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+              await authorizer.connect(admin).grantPermission(action, admin.address, ANY_ADDRESS);
               await pool.connect(admin).pause();
             });
 
@@ -235,7 +235,7 @@ describe('BasePool', function () {
         context('when the sender has the set fee permission in the authorizer', () => {
           sharedBeforeEach('grant permission', async () => {
             const action = await actionId(pool, 'setSwapFeePercentage');
-            await authorizer.connect(admin).grantPermissions([action], sender.address, [ANY_ADDRESS]);
+            await authorizer.connect(admin).grantPermission(action, sender.address, ANY_ADDRESS);
           });
 
           itSetsSwapFeePercentage();
@@ -274,7 +274,7 @@ describe('BasePool', function () {
           context('when the sender has the set fee permission in the authorizer', () => {
             sharedBeforeEach(async () => {
               const action = await actionId(pool, 'setSwapFeePercentage');
-              await authorizer.connect(admin).grantPermissions([action], sender.address, [ANY_ADDRESS]);
+              await authorizer.connect(admin).grantPermission(action, sender.address, ANY_ADDRESS);
             });
 
             itRevertsWithUnallowedSender();
@@ -398,9 +398,8 @@ describe('BasePool', function () {
         sharedBeforeEach('grant permission', async () => {
           const pauseAction = await actionId(pool, 'pause');
           const unpauseAction = await actionId(pool, 'unpause');
-          await authorizer
-            .connect(admin)
-            .grantPermissions([pauseAction, unpauseAction], sender.address, [ANY_ADDRESS, ANY_ADDRESS]);
+          await authorizer.connect(admin).grantPermission(pauseAction, sender.address, ANY_ADDRESS);
+          await authorizer.connect(admin).grantPermission(unpauseAction, sender.address, ANY_ADDRESS);
         });
 
         itCanPause();
@@ -440,9 +439,8 @@ describe('BasePool', function () {
           sharedBeforeEach(async () => {
             const pauseAction = await actionId(pool, 'pause');
             const unpauseAction = await actionId(pool, 'unpause');
-            await authorizer
-              .connect(admin)
-              .grantPermissions([pauseAction, unpauseAction], sender.address, [ANY_ADDRESS, ANY_ADDRESS]);
+            await authorizer.connect(admin).grantPermission(pauseAction, sender.address, ANY_ADDRESS);
+            await authorizer.connect(admin).grantPermission(unpauseAction, sender.address, ANY_ADDRESS);
           });
 
           itCanPause();
@@ -552,10 +550,10 @@ describe('BasePool', function () {
           const disableRecoveryAction = await actionId(pool, 'disableRecoveryMode');
           await authorizer
             .connect(admin)
-            .grantPermissions([enableRecoveryAction, disableRecoveryAction], sender.address, [
-              ANY_ADDRESS,
-              ANY_ADDRESS,
-            ]);
+            .grantPermission(enableRecoveryAction, sender.address, ANY_ADDRESS);
+          await authorizer
+            .connect(admin)
+            .grantPermission(disableRecoveryAction, sender.address, ANY_ADDRESS);
         });
 
         itCanEnableRecoveryMode();
@@ -595,12 +593,8 @@ describe('BasePool', function () {
           sharedBeforeEach('grant permission', async () => {
             const enableRecoveryAction = await actionId(pool, 'enableRecoveryMode');
             const disableRecoveryAction = await actionId(pool, 'disableRecoveryMode');
-            await authorizer
-              .connect(admin)
-              .grantPermissions([enableRecoveryAction, disableRecoveryAction], sender.address, [
-                ANY_ADDRESS,
-                ANY_ADDRESS,
-              ]);
+            await authorizer.connect(admin).grantPermission(enableRecoveryAction, sender.address, ANY_ADDRESS);
+            await authorizer.connect(admin).grantPermission(disableRecoveryAction, sender.address, ANY_ADDRESS);
           });
 
           itCanEnableRecoveryMode();
@@ -645,7 +639,7 @@ describe('BasePool', function () {
 
         await authorizer
           .connect(admin)
-          .grantPermissions([await actionId(feesCollector, 'setSwapFeePercentage')], admin.address, [ANY_ADDRESS]);
+          .grantPermission(await actionId(feesCollector, 'setSwapFeePercentage'), admin.address, ANY_ADDRESS);
 
         await feesCollector.connect(admin).setSwapFeePercentage(PROTOCOL_SWAP_FEE_PERCENTAGE);
 
@@ -726,9 +720,8 @@ describe('BasePool', function () {
         sharedBeforeEach('enable recovery mode', async () => {
           const enableRecoveryAction = await actionId(pool, 'enableRecoveryMode');
           const disableRecoveryAction = await actionId(pool, 'disableRecoveryMode');
-          await authorizer
-            .connect(admin)
-            .grantPermissions([enableRecoveryAction, disableRecoveryAction], admin.address, [ANY_ADDRESS, ANY_ADDRESS]);
+          await authorizer.connect(admin).grantPermission(enableRecoveryAction, admin.address, ANY_ADDRESS);
+          await authorizer.connect(admin).grantPermission(disableRecoveryAction, admin.address, ANY_ADDRESS);
 
           await pool.connect(admin).enableRecoveryMode();
         });
@@ -789,9 +782,7 @@ describe('BasePool', function () {
 
         context('when paused', () => {
           sharedBeforeEach('pause pool', async () => {
-            await authorizer
-              .connect(admin)
-              .grantPermissions([await actionId(pool, 'pause')], admin.address, [ANY_ADDRESS]);
+            await authorizer.connect(admin).grantPermission(await actionId(pool, 'pause'), admin.address, ANY_ADDRESS);
 
             await pool.connect(admin).pause();
           });

--- a/pkg/pool-utils/test/NewBasePool.test.ts
+++ b/pkg/pool-utils/test/NewBasePool.test.ts
@@ -154,7 +154,7 @@ describe('NewBasePool', function () {
 
     it('tracks authorizer changes in the vault', async () => {
       const action = await actionId(vault, 'setAuthorizer');
-      await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+      await authorizer.connect(admin).grantPermission(action, admin.address, ANY_ADDRESS);
 
       await vault.connect(admin).setAuthorizer(other.address);
 
@@ -379,12 +379,11 @@ describe('NewBasePool', function () {
         sharedBeforeEach('grant permission', async () => {
           const pauseAction = await actionId(pool, 'pause');
           const unpauseAction = await actionId(pool, 'unpause');
+          await authorizer.connect(admin).grantPermission(unpauseAction, sender.address, ANY_ADDRESS);
+          await authorizer.connect(admin).grantPermission(pauseAction, sender.address, ANY_ADDRESS);
           await authorizer
             .connect(admin)
-            .grantPermissions([pauseAction, unpauseAction], sender.address, [ANY_ADDRESS, ANY_ADDRESS]);
-          await authorizer
-            .connect(admin)
-            .grantPermissions([await actionId(minimalPool, 'pause')], sender.address, [ANY_ADDRESS]);
+            .grantPermission(await actionId(minimalPool, 'pause'), sender.address, ANY_ADDRESS);
         });
 
         itCanPause();
@@ -431,9 +430,8 @@ describe('NewBasePool', function () {
           sharedBeforeEach('grant permission', async () => {
             const pauseAction = await actionId(pool, 'pause');
             const unpauseAction = await actionId(pool, 'unpause');
-            await authorizer
-              .connect(admin)
-              .grantPermissions([pauseAction, unpauseAction], sender.address, [ANY_ADDRESS, ANY_ADDRESS]);
+            await authorizer.connect(admin).grantPermission(pauseAction, sender.address, ANY_ADDRESS);
+            await authorizer.connect(admin).grantPermission(unpauseAction, sender.address, ANY_ADDRESS);
           });
 
           itCanPause();
@@ -497,12 +495,8 @@ describe('NewBasePool', function () {
         sharedBeforeEach('grant permission', async () => {
           const enableRecoveryAction = await actionId(pool, 'enableRecoveryMode');
           const disableRecoveryAction = await actionId(pool, 'disableRecoveryMode');
-          await authorizer
-            .connect(admin)
-            .grantPermissions([enableRecoveryAction, disableRecoveryAction], sender.address, [
-              ANY_ADDRESS,
-              ANY_ADDRESS,
-            ]);
+          await authorizer.connect(admin).grantPermission(disableRecoveryAction, sender.address, ANY_ADDRESS);
+          await authorizer.connect(admin).grantPermission(enableRecoveryAction, sender.address, ANY_ADDRESS);
         });
 
         itCanEnableRecoveryMode();
@@ -542,12 +536,8 @@ describe('NewBasePool', function () {
           sharedBeforeEach('grant permission', async () => {
             const enableRecoveryAction = await actionId(pool, 'enableRecoveryMode');
             const disableRecoveryAction = await actionId(pool, 'disableRecoveryMode');
-            await authorizer
-              .connect(admin)
-              .grantPermissions([enableRecoveryAction, disableRecoveryAction], sender.address, [
-                ANY_ADDRESS,
-                ANY_ADDRESS,
-              ]);
+            await authorizer.connect(admin).grantPermission(enableRecoveryAction, sender.address, ANY_ADDRESS);
+            await authorizer.connect(admin).grantPermission(disableRecoveryAction, sender.address, ANY_ADDRESS);
           });
 
           itCanEnableRecoveryMode();
@@ -642,7 +632,7 @@ describe('NewBasePool', function () {
 
       await authorizer
         .connect(admin)
-        .grantPermissions([await actionId(feesCollector, 'setSwapFeePercentage')], admin.address, [ANY_ADDRESS]);
+        .grantPermission(await actionId(feesCollector, 'setSwapFeePercentage'), admin.address, ANY_ADDRESS);
 
       await feesCollector.connect(admin).setSwapFeePercentage(PROTOCOL_SWAP_FEE_PERCENTAGE);
 
@@ -677,9 +667,9 @@ describe('NewBasePool', function () {
       sharedBeforeEach('enable recovery mode', async () => {
         const enableRecoveryAction = await actionId(pool, 'enableRecoveryMode');
         const disableRecoveryAction = await actionId(pool, 'disableRecoveryMode');
-        await authorizer
-          .connect(admin)
-          .grantPermissions([enableRecoveryAction, disableRecoveryAction], admin.address, [ANY_ADDRESS, ANY_ADDRESS]);
+        await authorizer.connect(admin).grantPermission(enableRecoveryAction, admin.address, ANY_ADDRESS);
+
+        await authorizer.connect(admin).grantPermission(disableRecoveryAction, admin.address, ANY_ADDRESS);
 
         await pool.connect(admin).enableRecoveryMode();
       });
@@ -737,9 +727,7 @@ describe('NewBasePool', function () {
 
       context('when paused', () => {
         sharedBeforeEach('pause pool', async () => {
-          await authorizer
-            .connect(admin)
-            .grantPermissions([await actionId(pool, 'pause')], admin.address, [ANY_ADDRESS]);
+          await authorizer.connect(admin).grantPermission(await actionId(pool, 'pause'), admin.address, ANY_ADDRESS);
 
           await pool.connect(admin).pause();
         });
@@ -949,9 +937,7 @@ describe('NewBasePool', function () {
 
     context('when paused', () => {
       sharedBeforeEach(async () => {
-        await authorizer
-          .connect(admin)
-          .grantPermissions([await actionId(pool, 'pause')], sender.address, [ANY_ADDRESS]);
+        await authorizer.connect(admin).grantPermission(await actionId(pool, 'pause'), sender.address, ANY_ADDRESS);
         await pool.connect(sender).pause();
       });
 

--- a/pkg/pool-utils/test/ProtocolFeeCache.test.ts
+++ b/pkg/pool-utils/test/ProtocolFeeCache.test.ts
@@ -10,6 +10,8 @@ import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import { ProtocolFee } from '@balancer-labs/v2-helpers/src/models/vault/types';
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
 
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+
 type ProviderFeeIDs = {
   swap: BigNumberish;
   yield: BigNumberish;
@@ -34,16 +36,25 @@ describe('ProtocolFeeCache', () => {
 
     await vault.authorizer
       .connect(admin)
-      .grantPermissions([actionId(vault.protocolFeesProvider, 'setFeeTypePercentage')], admin.address, [
-        vault.protocolFeesProvider.address,
-      ]);
+      .grantPermission(
+        actionId(vault.protocolFeesProvider, 'setFeeTypePercentage'),
+        admin.address,
+        vault.protocolFeesProvider.address
+      );
 
     await vault.authorizer
       .connect(admin)
-      .grantPermissions(
-        [actionId(feesCollector, 'setSwapFeePercentage'), actionId(feesCollector, 'setFlashLoanFeePercentage')],
+      .grantPermission(
+        actionId(feesCollector, 'setFlashLoanFeePercentage'),
         vault.protocolFeesProvider.address,
-        [feesCollector.address, feesCollector.address]
+        feesCollector.address
+      );
+    await vault.authorizer
+      .connect(admin)
+      .grantPermission(
+        actionId(feesCollector, 'setSwapFeePercentage'),
+        vault.protocolFeesProvider.address,
+        feesCollector.address
       );
   });
 

--- a/pkg/pool-utils/test/VaultReentrancyLib.test.ts
+++ b/pkg/pool-utils/test/VaultReentrancyLib.test.ts
@@ -153,7 +153,7 @@ describe('VaultReentrancyLib', function () {
       describe('recovery mode', () => {
         sharedBeforeEach('enable recovery mode', async () => {
           const enableRecoveryAction = await actionId(pool, 'enableRecoveryMode');
-          await authorizer.connect(admin).grantPermissions([enableRecoveryAction], poolOwner.address, [ANY_ADDRESS]);
+          await authorizer.connect(admin).grantPermission(enableRecoveryAction, poolOwner.address, ANY_ADDRESS);
 
           await pool.connect(poolOwner).enableRecoveryMode();
 

--- a/pkg/pool-utils/test/factories/BasePoolFactory.test.ts
+++ b/pkg/pool-utils/test/factories/BasePoolFactory.test.ts
@@ -43,7 +43,7 @@ describe('BasePoolFactory', function () {
     });
 
     const action = await actionId(factory, 'disable');
-    await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+    await authorizer.connect(admin).grantPermission(action, admin.address, ANY_ADDRESS);
   });
 
   it('stores the vault address', async () => {

--- a/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolSettings.test.ts
@@ -839,7 +839,7 @@ describe('ManagedPoolSettings', function () {
       context('when the sender is allowed', () => {
         sharedBeforeEach('grant permissions', async () => {
           const updateSwapFeeGraduallyPermission = await actionId(pool.instance, 'updateSwapFeeGradually');
-          await pool.vault.grantPermissionsGlobally([updateSwapFeeGraduallyPermission], other);
+          await pool.vault.grantPermissionGlobally(updateSwapFeeGraduallyPermission, other);
         });
 
         itStartsAGradualFeeChange();
@@ -1075,7 +1075,7 @@ describe('ManagedPoolSettings', function () {
         context('when the sender is allowed', () => {
           sharedBeforeEach('grant permissions', async () => {
             const setCircuitBreakersPermission = await actionId(pool.instance, 'setCircuitBreakers');
-            await pool.vault.grantPermissionsGlobally([setCircuitBreakersPermission], other);
+            await pool.vault.grantPermissionGlobally(setCircuitBreakersPermission, other);
           });
 
           itSetsTheCircuitBreaker();
@@ -1540,7 +1540,7 @@ describe('ManagedPoolSettings', function () {
       protocolFeesProvider = vault.protocolFeesProvider;
 
       const action = await actionId(protocolFeesProvider, 'setFeeTypePercentage');
-      await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+      await authorizer.connect(admin).grantPermission(action, admin.address, ANY_ADDRESS);
       await protocolFeesProvider.connect(admin).setFeeTypePercentage(ProtocolFee.AUM, AUM_PROTOCOL_FEE_PERCENTAGE);
     });
 

--- a/pkg/pool-weighted/test/PostJoinExitProtocolFees.test.ts
+++ b/pkg/pool-weighted/test/PostJoinExitProtocolFees.test.ts
@@ -48,15 +48,18 @@ describe('PostJoinExitProtocolFees', () => {
   sharedBeforeEach('grant permissions to admin', async () => {
     await vault.authorizer
       .connect(admin)
-      .grantPermissions([actionId(feesProvider, 'setFeeTypePercentage')], admin.address, [feesProvider.address]);
+      .grantPermission(actionId(feesProvider, 'setFeeTypePercentage'), admin.address, feesProvider.address);
 
     await vault.authorizer
       .connect(admin)
-      .grantPermissions(
-        [actionId(feesCollector, 'setSwapFeePercentage'), actionId(feesCollector, 'setFlashLoanFeePercentage')],
+      .grantPermission(
+        actionId(feesCollector, 'setFlashLoanFeePercentage'),
         feesProvider.address,
-        [feesCollector.address, feesCollector.address]
+        feesCollector.address
       );
+    await vault.authorizer
+      .connect(admin)
+      .grantPermission(actionId(feesCollector, 'setSwapFeePercentage'), feesProvider.address, feesCollector.address);
   });
 
   for (let numTokens = 2; numTokens <= MAX_TOKENS; numTokens++) {

--- a/pkg/pool-weighted/test/YieldProtocolFees.test.ts
+++ b/pkg/pool-weighted/test/YieldProtocolFees.test.ts
@@ -30,7 +30,7 @@ describe('WeightedPoolProtocolFees (Yield)', () => {
     if (!vault.admin) throw new Error('Vault has no admin');
     const protocolFeesProvider = vault.protocolFeesProvider;
     const action = await actionId(protocolFeesProvider, 'setFeeTypePercentage');
-    await vault.grantPermissionsGlobally([action], vault.admin);
+    await vault.grantPermissionGlobally(action, vault.admin);
     await protocolFeesProvider
       .connect(vault.admin)
       .setFeeTypePercentage(ProtocolFee.YIELD, PROTOCOL_YIELD_FEE_PERCENTAGE);

--- a/pkg/solidity-utils/test/SingletonAuthentication.test.ts
+++ b/pkg/solidity-utils/test/SingletonAuthentication.test.ts
@@ -21,7 +21,7 @@ describe('SingletonAuthentication', () => {
     ({ instance: vault, authorizer } = await Vault.create({ admin }));
 
     const action = await actionId(vault, 'setAuthorizer');
-    await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+    await authorizer.connect(admin).grantPermission(action, admin.address, ANY_ADDRESS);
 
     singleton = await deploy('SingletonAuthenticationMock', { args: [vault.address] });
   });

--- a/pkg/standalone-utils/test/AaveWrapping.test.ts
+++ b/pkg/standalone-utils/test/AaveWrapping.test.ts
@@ -60,7 +60,7 @@ describe('AaveWrapping', function () {
     const relayerActionIds = await Promise.all(
       ['setRelayerApproval', 'manageUserBalance'].map((action) => actionId(vault.instance, action))
     );
-    await vault.grantPermissionsGlobally(relayerActionIds, relayer);
+    await Promise.all(relayerActionIds.map((action) => vault.grantPermissionGlobally(action, relayer)));
 
     // Approve relayer by sender
     await vault.setRelayerApproval(user, relayer, true);

--- a/pkg/standalone-utils/test/BALTokenHolder.test.ts
+++ b/pkg/standalone-utils/test/BALTokenHolder.test.ts
@@ -51,9 +51,7 @@ describe('BALTokenHolder', function () {
     context('when the caller is authorized', () => {
       sharedBeforeEach(async () => {
         const withdrawActionId = await actionId(holder, 'withdrawFunds');
-        await vault.authorizer
-          .connect(admin)
-          .grantPermissions([withdrawActionId], authorized.address, [holder.address]);
+        await vault.authorizer.connect(admin).grantPermission(withdrawActionId, authorized.address, holder.address);
       });
 
       it('sends funds to the recipient', async () => {
@@ -75,7 +73,7 @@ describe('BALTokenHolder', function () {
     context('when the caller is authorized', () => {
       sharedBeforeEach(async () => {
         const sweepActionId = await actionId(holder, 'sweepTokens');
-        await vault.authorizer.connect(admin).grantPermissions([sweepActionId], authorized.address, [holder.address]);
+        await vault.authorizer.connect(admin).grantPermission(sweepActionId, authorized.address, holder.address);
       });
 
       context('when the token is not BAL', () => {

--- a/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
+++ b/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
@@ -226,7 +226,7 @@ describe('BaseRelayerLibrary', function () {
         sharedBeforeEach('authorise relayer', async () => {
           const setApprovalRole = await actionId(vault, 'setRelayerApproval');
           const authorizer = await deployedAt('v2-vault/TimelockAuthorizer', await vault.getAuthorizer());
-          await authorizer.connect(admin).grantPermissions([setApprovalRole], relayer.address, [ANY_ADDRESS]);
+          await authorizer.connect(admin).grantPermission(setApprovalRole, relayer.address, ANY_ADDRESS);
         });
 
         describe('when modifying its own approval', () => {

--- a/pkg/standalone-utils/test/GaugeActions.test.ts
+++ b/pkg/standalone-utils/test/GaugeActions.test.ts
@@ -89,7 +89,7 @@ describe('GaugeActions', function () {
     const relayerActionIds = await Promise.all(
       ['setRelayerApproval', 'manageUserBalance'].map((action) => actionId(vault.instance, action))
     );
-    await vault.grantPermissionsGlobally(relayerActionIds, relayer);
+    await Promise.all(relayerActionIds.map((action) => vault.grantPermissionGlobally(action, relayer)));
 
     // Approve relayer by BPT holder
     await vault.setRelayerApproval(userSender, relayer, true);
@@ -217,7 +217,7 @@ describe('GaugeActions', function () {
     describe('gaugeClaimRewards', () => {
       sharedBeforeEach('setup and deposit reward tokens in gauge', async () => {
         const action = await actionId(adaptorEntrypoint, 'add_reward', gauge.interface);
-        await vault.grantPermissionsGlobally([action], admin);
+        await vault.grantPermissionGlobally(action, admin);
 
         const rewardAmount = fp(500);
         await rewardToken.connect(admin).mint(admin.address, rewardAmount);

--- a/pkg/standalone-utils/test/GearboxWrapping.test.ts
+++ b/pkg/standalone-utils/test/GearboxWrapping.test.ts
@@ -64,7 +64,11 @@ describe('GearboxWrapping', function () {
         actionId(vault.instance, action)
       )
     );
-    await vault.grantPermissionsGlobally(relayerActionIds, relayer);
+    await Promise.all(
+      relayerActionIds.map((action) => {
+        vault.grantPermissionGlobally(action, relayer);
+      })
+    );
 
     // Approve relayer by sender
     await vault.setRelayerApproval(senderUser, relayer, true);

--- a/pkg/standalone-utils/test/LidoWrapping.test.ts
+++ b/pkg/standalone-utils/test/LidoWrapping.test.ts
@@ -12,7 +12,7 @@ import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { expectTransferEvent } from '@balancer-labs/v2-helpers/src/test/expectTransfer';
 import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
-import { MAX_INT256, MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { ANY_ADDRESS, MAX_INT256, MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { BigNumberish, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { Account } from '@balancer-labs/v2-helpers/src/models/types/types';
@@ -64,7 +64,11 @@ describe('LidoWrapping', function () {
         actionId(vault.instance, action)
       )
     );
-    await vault.grantPermissionsGlobally(relayerActionIds, relayer);
+    await Promise.all(
+      relayerActionIds.map((action) => {
+        return vault.grantPermissionGlobally(action, relayer.address);
+      })
+    );
 
     // Approve relayer by sender
     await vault.setRelayerApproval(senderUser, relayer, true);

--- a/pkg/standalone-utils/test/LidoWrapping.test.ts
+++ b/pkg/standalone-utils/test/LidoWrapping.test.ts
@@ -12,7 +12,7 @@ import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { expectTransferEvent } from '@balancer-labs/v2-helpers/src/test/expectTransfer';
 import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
-import { ANY_ADDRESS, MAX_INT256, MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { MAX_INT256, MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { BigNumberish, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { Account } from '@balancer-labs/v2-helpers/src/models/types/types';

--- a/pkg/standalone-utils/test/PoolRecoveryHelper.test.ts
+++ b/pkg/standalone-utils/test/PoolRecoveryHelper.test.ts
@@ -52,7 +52,7 @@ describe('PoolRecoveryHelper', function () {
         helper = await deploy('PoolRecoveryHelper', { args: [vault.address, []] });
         newFactory = randomAddress();
 
-        await vault.grantPermissionsGlobally([await actionId(helper, 'addPoolFactory')], operator);
+        await vault.grantPermissionGlobally(await actionId(helper, 'addPoolFactory'), operator);
       });
 
       it('reverts if the caller does not have permission', async () => {
@@ -78,10 +78,10 @@ describe('PoolRecoveryHelper', function () {
         helper = await deploy('PoolRecoveryHelper', { args: [vault.address, []] });
         factory = randomAddress();
 
-        await vault.grantPermissionsGlobally([await actionId(helper, 'addPoolFactory')], admin);
+        await vault.grantPermissionGlobally(await actionId(helper, 'addPoolFactory'), admin);
         await helper.connect(admin).addPoolFactory(factory);
 
-        await vault.grantPermissionsGlobally([await actionId(helper, 'removePoolFactory')], operator);
+        await vault.grantPermissionGlobally(await actionId(helper, 'removePoolFactory'), operator);
       });
 
       it('reverts if the caller does not have permission', async () => {
@@ -120,7 +120,7 @@ describe('PoolRecoveryHelper', function () {
 
       helper = await deploy('PoolRecoveryHelper', { args: [vault.address, factories.map((f) => f.address)] });
 
-      await vault.grantPermissionsGlobally([await actionId(pool, 'enableRecoveryMode')], helper);
+      await vault.grantPermissionGlobally(await actionId(pool, 'enableRecoveryMode'), helper);
     });
 
     it('reverts if the pool is not from a known factory', async () => {

--- a/pkg/standalone-utils/test/ProtocolFeePercentagesProvider.test.ts
+++ b/pkg/standalone-utils/test/ProtocolFeePercentagesProvider.test.ts
@@ -204,18 +204,25 @@ describe('ProtocolFeePercentagesProvider', function () {
               sharedBeforeEach('grant permission to caller', async () => {
                 await authorizer
                   .connect(admin)
-                  .grantPermissions([actionId(provider, 'setFeeTypePercentage')], authorized.address, [
-                    provider.address,
-                  ]);
+                  .grantPermission(actionId(provider, 'setFeeTypePercentage'), authorized.address, provider.address);
               });
 
               context('when the provider is authorized', () => {
                 sharedBeforeEach('grant permission to provider', async () => {
-                  await authorizer.connect(admin).grantPermissions(
-                    ['setSwapFeePercentage', 'setFlashLoanFeePercentage'].map((fn) => actionId(feesCollector, fn)),
-                    provider.address,
-                    [feesCollector.address, feesCollector.address]
-                  );
+                  await authorizer
+                    .connect(admin)
+                    .grantPermission(
+                      actionId(feesCollector, 'setSwapFeePercentage'),
+                      provider.address,
+                      feesCollector.address
+                    );
+                  await authorizer
+                    .connect(admin)
+                    .grantPermission(
+                      actionId(feesCollector, 'setFlashLoanFeePercentage'),
+                      provider.address,
+                      feesCollector.address
+                    );
                 });
 
                 function itSetsTheValueCorrectly(feeType: number, value: BigNumber) {
@@ -283,9 +290,7 @@ describe('ProtocolFeePercentagesProvider', function () {
               sharedBeforeEach('grant permission to caller', async () => {
                 await authorizer
                   .connect(admin)
-                  .grantPermissions([actionId(provider, 'setFeeTypePercentage')], authorized.address, [
-                    provider.address,
-                  ]);
+                  .grantPermission(actionId(provider, 'setFeeTypePercentage'), authorized.address, provider.address);
               });
 
               function itSetsTheValueCorrectly(feeType: number, value: BigNumber) {
@@ -345,11 +350,12 @@ describe('ProtocolFeePercentagesProvider', function () {
 
     describe('native fee type out of band change', () => {
       sharedBeforeEach('grant permission', async () => {
-        await authorizer.connect(admin).grantPermissions(
-          ['setSwapFeePercentage', 'setFlashLoanFeePercentage'].map((fn) => actionId(feesCollector, fn)),
-          other.address,
-          [feesCollector.address, feesCollector.address]
-        );
+        await authorizer
+          .connect(admin)
+          .grantPermission(actionId(feesCollector, 'setSwapFeePercentage'), other.address, feesCollector.address);
+        await authorizer
+          .connect(admin)
+          .grantPermission(actionId(feesCollector, 'setFlashLoanFeePercentage'), other.address, feesCollector.address);
       });
 
       describe('swap fee', () => {
@@ -375,7 +381,7 @@ describe('ProtocolFeePercentagesProvider', function () {
         sharedBeforeEach('grant permission', async () => {
           await authorizer
             .connect(admin)
-            .grantPermissions([actionId(provider, 'registerFeeType')], authorized.address, [provider.address]);
+            .grantPermission(actionId(provider, 'registerFeeType'), authorized.address, provider.address);
         });
 
         context('when the fee type is already in use', () => {
@@ -475,7 +481,7 @@ describe('ProtocolFeePercentagesProvider', function () {
 
             await authorizer
               .connect(admin)
-              .grantPermissions([actionId(provider, 'setFeeTypePercentage')], authorized.address, [provider.address]);
+              .grantPermission(actionId(provider, 'setFeeTypePercentage'), authorized.address, provider.address);
 
             await provider.connect(authorized).setFeeTypePercentage(NEW_FEE_TYPE, fp(0.042));
             expect(await provider.getFeeTypePercentage(NEW_FEE_TYPE)).to.equal(fp(0.042));

--- a/pkg/standalone-utils/test/ProtocolFeeSplitter.test.ts
+++ b/pkg/standalone-utils/test/ProtocolFeeSplitter.test.ts
@@ -73,24 +73,25 @@ describe('ProtocolFeeSplitter', function () {
 
     const setRevenueShareRole = await actionId(protocolFeeSplitter, 'setRevenueSharePercentage');
     const clearRevenueShareRole = await actionId(protocolFeeSplitter, 'clearRevenueSharePercentage');
-    await vault.grantPermissionsGlobally([setRevenueShareRole, clearRevenueShareRole], admin);
+    await vault.grantPermissionGlobally(setRevenueShareRole, admin);
+    await vault.grantPermissionGlobally(clearRevenueShareRole, admin);
 
     const setDefaultRevenueSharePercentageRole = await actionId(
       protocolFeeSplitter,
       'setDefaultRevenueSharePercentage'
     );
-    await vault.grantPermissionsGlobally([setDefaultRevenueSharePercentageRole], admin);
+    await vault.grantPermissionGlobally(setDefaultRevenueSharePercentageRole, admin);
 
     // Allow withdrawer to pull from collector
     const withdrawCollectedFeesRole = await actionId(await vault.getFeesCollector(), 'withdrawCollectedFees');
-    await vault.grantPermissionsGlobally([withdrawCollectedFeesRole], protocolFeesWithdrawer);
+    await vault.grantPermissionGlobally(withdrawCollectedFeesRole, protocolFeesWithdrawer);
 
     // Allow fee splitter to pull from withdrawer
     const withdrawCollectedFeesWithdrawerRole = await actionId(protocolFeesWithdrawer, 'withdrawCollectedFees');
-    await vault.grantPermissionsGlobally([withdrawCollectedFeesWithdrawerRole], protocolFeeSplitter);
+    await vault.grantPermissionGlobally(withdrawCollectedFeesWithdrawerRole, protocolFeeSplitter);
 
     const setTreasuryRole = await actionId(protocolFeeSplitter, 'setDaoFundsRecipient');
-    await vault.grantPermissionsGlobally([setTreasuryRole], admin);
+    await vault.grantPermissionGlobally(setTreasuryRole, admin);
   });
 
   describe('constructor', () => {
@@ -234,7 +235,7 @@ describe('ProtocolFeeSplitter', function () {
       sharedBeforeEach('set permissions', async () => {
         caller = other;
         const setBeneficiaryRole = await actionId(protocolFeeSplitter, 'setPoolBeneficiary');
-        await vault.grantPermissionsGlobally([setBeneficiaryRole], other);
+        await vault.grantPermissionGlobally(setBeneficiaryRole, other);
       });
 
       itSetsThePoolsBeneficiary();

--- a/pkg/standalone-utils/test/ProtocolFeesWithdrawer.test.ts
+++ b/pkg/standalone-utils/test/ProtocolFeesWithdrawer.test.ts
@@ -40,7 +40,8 @@ describe('ProtocolFeesWithdrawer', function () {
   sharedBeforeEach('grant permissions to allow/denylist tokens', async () => {
     const denylistTokenRole = await actionId(protocolFeesWithdrawer, 'denylistToken');
     const allowlistTokenRole = await actionId(protocolFeesWithdrawer, 'allowlistToken');
-    await vault.grantPermissionsGlobally([denylistTokenRole, allowlistTokenRole], admin);
+    await vault.grantPermissionGlobally(denylistTokenRole, admin);
+    await vault.grantPermissionGlobally(allowlistTokenRole, admin);
   });
 
   describe('constructor', () => {
@@ -119,10 +120,10 @@ describe('ProtocolFeesWithdrawer', function () {
   describe('withdrawCollectedFees', () => {
     sharedBeforeEach('grant permissions to withdraw tokens', async () => {
       const unsafeWithdrawCollectedFeesRole = await actionId(protocolFeesCollector, 'withdrawCollectedFees');
-      await vault.grantPermissionsGlobally([unsafeWithdrawCollectedFeesRole], protocolFeesWithdrawer);
+      await vault.grantPermissionGlobally(unsafeWithdrawCollectedFeesRole, protocolFeesWithdrawer);
 
       const safeWithdrawCollectedFeesRole = await actionId(protocolFeesWithdrawer, 'withdrawCollectedFees');
-      await vault.grantPermissionsGlobally([safeWithdrawCollectedFeesRole], claimer);
+      await vault.grantPermissionGlobally(safeWithdrawCollectedFeesRole, claimer);
     });
 
     sharedBeforeEach('deposit some tokens into the ProtocolFeeCollector', async () => {

--- a/pkg/standalone-utils/test/ProtocolIdRegistry.test.ts
+++ b/pkg/standalone-utils/test/ProtocolIdRegistry.test.ts
@@ -26,11 +26,12 @@ describe('ProtocolIdRegistry', () => {
   });
 
   sharedBeforeEach('grant permissions', async () => {
-    await authorizer.connect(admin).grantPermissions(
-      ['registerProtocolId', 'renameProtocolId'].map((fn) => actionId(registry, fn)),
-      authorizedUser.address,
-      [registry.address, registry.address]
-    );
+    await authorizer
+      .connect(admin)
+      .grantPermission(actionId(registry, 'registerProtocolId'), authorizedUser.address, registry.address);
+    await authorizer
+      .connect(admin)
+      .grantPermission(actionId(registry, 'renameProtocolId'), authorizedUser.address, registry.address);
   });
 
   describe('Constructor', () => {

--- a/pkg/standalone-utils/test/ReaperWrapping.test.ts
+++ b/pkg/standalone-utils/test/ReaperWrapping.test.ts
@@ -56,10 +56,11 @@ describe('ReaperWrapping', function () {
         actionId(vault.instance, action)
       )
     );
+
     const authorizer = vault.authorizer;
     await Promise.all(
       relayerActionIds.map((action) => {
-        authorizer.grantPermission(action, relayer, ANY_ADDRESS);
+        authorizer.connect(admin).grantPermission(action, relayer.address, ANY_ADDRESS);
       })
     );
 

--- a/pkg/standalone-utils/test/ReaperWrapping.test.ts
+++ b/pkg/standalone-utils/test/ReaperWrapping.test.ts
@@ -57,8 +57,11 @@ describe('ReaperWrapping', function () {
       )
     );
     const authorizer = vault.authorizer;
-    const wheres = relayerActionIds.map(() => ANY_ADDRESS);
-    await authorizer.connect(admin).grantPermissions(relayerActionIds, relayer.address, wheres);
+    await Promise.all(
+      relayerActionIds.map((action) => {
+        authorizer.grantPermission(action, relayer, ANY_ADDRESS);
+      })
+    );
 
     // Approve relayer by sender
     await vault.instance.connect(user).setRelayerApproval(user.address, relayer.address, true);

--- a/pkg/standalone-utils/test/SiloWrapping.test.ts
+++ b/pkg/standalone-utils/test/SiloWrapping.test.ts
@@ -76,8 +76,11 @@ describe('SiloWrapping', function () {
       )
     );
     const authorizer = vault.authorizer;
-    const wheres = relayerActionIds.map(() => ANY_ADDRESS);
-    await authorizer.connect(admin).grantPermissions(relayerActionIds, relayer.address, wheres);
+    await Promise.all(
+      relayerActionIds.map((action) => {
+        return authorizer.connect(admin).grantPermission(action, relayer.address, ANY_ADDRESS);
+      })
+    );
 
     // Approve relayer by sender
     await vault.instance.connect(senderUser).setRelayerApproval(senderUser.address, relayer.address, true);

--- a/pkg/standalone-utils/test/TetuWrapping.test.ts
+++ b/pkg/standalone-utils/test/TetuWrapping.test.ts
@@ -66,7 +66,11 @@ describe('TetuWrapping', function () {
         actionId(vault.instance, action)
       )
     );
-    await vault.grantPermissionsGlobally(relayerActionIds, relayer);
+    await Promise.all(
+      relayerActionIds.map((action) => {
+        vault.grantPermissionGlobally(action, relayer);
+      })
+    );
 
     // Approve relayer by sender
     await vault.setRelayerApproval(senderUser, relayer, true);

--- a/pkg/standalone-utils/test/UnbuttonWrapping.test.ts
+++ b/pkg/standalone-utils/test/UnbuttonWrapping.test.ts
@@ -72,8 +72,11 @@ describe('UnbuttonWrapping', function () {
       )
     );
     const authorizer = vault.authorizer;
-    const wheres = relayerActionIds.map(() => ANY_ADDRESS);
-    await authorizer.connect(admin).grantPermissions(relayerActionIds, relayer.address, wheres);
+    await Promise.all(
+      relayerActionIds.map((action) => {
+        return authorizer.connect(admin).grantPermission(action, relayer.address, ANY_ADDRESS);
+      })
+    );
 
     // Approve relayer by sender
     await vault.instance.connect(senderUser).setRelayerApproval(senderUser.address, relayer.address, true);

--- a/pkg/standalone-utils/test/VaultActions.test.ts
+++ b/pkg/standalone-utils/test/VaultActions.test.ts
@@ -61,7 +61,8 @@ describe('VaultActions', function () {
         actionId(vault.instance, action)
       )
     );
-    await vault.grantPermissionsGlobally(relayerActionIds, relayer);
+
+    await Promise.all(relayerActionIds.map((action) => vault.grantPermissionGlobally(action, relayer)));
 
     // Approve relayer by sender
     await vault.setRelayerApproval(user, relayer, true);

--- a/pkg/standalone-utils/test/YearnWrapping.test.ts
+++ b/pkg/standalone-utils/test/YearnWrapping.test.ts
@@ -62,7 +62,11 @@ describe('YearnWrapping', function () {
         actionId(vault.instance, action)
       )
     );
-    await vault.grantPermissionsGlobally(relayerActionIds, relayer);
+    await Promise.all(
+      relayerActionIds.map((action) => {
+        vault.grantPermissionGlobally(action, relayer);
+      })
+    );
 
     // Approve relayer by sender
     await vault.setRelayerApproval(senderUser, relayer, true);

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -1086,7 +1086,7 @@ contract TimelockAuthorizer is IAuthorizer, ReentrancyGuard {
      * @dev Note that the caller can always renounce permissions, even if revoking them would typically be
      * subject to a delay.
      */
-    function renouncePermissions(bytes32 actionId, address where) external {
+    function renouncePermission(bytes32 actionId, address where) external {
         _revokePermission(actionId, msg.sender, where);
     }
 

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -929,27 +929,28 @@ contract TimelockAuthorizer is IAuthorizer, ReentrancyGuard {
     }
 
     /**
-     * @notice Grants multiple permissions to a single `account`.
+     * @notice Grants a permission to a single `account` at 'where' address.
      * @dev This function can only be used for actions that have no grant delay. For those that do, use
      * `scheduleGrantPermission` instead.
      */
-    function grantPermissions(
-        bytes32[] memory actionIds,
+    function grantPermission(
+        bytes32 actionId,
         address account,
-        address[] memory where
+        address where
     ) external {
-        InputHelpers.ensureInputLengthMatch(actionIds.length, where.length);
-        for (uint256 i = 0; i < actionIds.length; i++) {
-            if (_grantDelays[actionIds[i]] == 0) {
-                require(isGranter(actionIds[i], msg.sender, where[i]), "SENDER_IS_NOT_GRANTER");
-            } else {
-                // Some actions may have delays associated with granting them - these permissions cannot be granted
-                // directly, even if the caller is a granter, and must instead be scheduled for future execution via
-                // `scheduleGrantPermission`.
-                require(msg.sender == address(_executionHelper), "GRANT_MUST_BE_SCHEDULED");
-            }
+        if (_grantDelays[actionId] == 0) {
+            require(isGranter(actionId, msg.sender, where), "SENDER_IS_NOT_GRANTER");
+        } else {
+            // Some actions may have delays associated with granting them - these permissions cannot be granted
+            // directly, even if the caller is a granter, and must instead be scheduled for future execution via
+            // `scheduleGrantPermission`.
+            require(msg.sender == address(_executionHelper), "GRANT_MUST_BE_SCHEDULED");
+        }
 
-            _grantPermission(actionIds[i], account, where[i]);
+        bytes32 permission = getPermissionId(actionId, account, where);
+        if (!_isPermissionGranted[permission]) {
+            _isPermissionGranted[permission] = true;
+            emit PermissionGranted(actionId, account, where);
         }
     }
 
@@ -967,7 +968,7 @@ contract TimelockAuthorizer is IAuthorizer, ReentrancyGuard {
         uint256 delay = _grantDelays[actionId];
         require(delay > 0, "ACTION_HAS_NO_GRANT_DELAY");
 
-        bytes memory data = abi.encodeWithSelector(this.grantPermissions.selector, _ar(actionId), account, _ar(where));
+        bytes memory data = abi.encodeWithSelector(this.grantPermission.selector, actionId, account, where);
 
         uint256 scheduledExecutionId = _scheduleWithDelay(address(this), data, delay, executors);
         emit GrantPermissionScheduled(actionId, account, where, scheduledExecutionId);
@@ -1033,27 +1034,24 @@ contract TimelockAuthorizer is IAuthorizer, ReentrancyGuard {
     }
 
     /**
-     * @notice Revokes multiple permissions from a single `account`.
+     * @notice Revokes a permission from a single `account` at `where` address.
      * @dev This function can only be used for actions that have no revoke delay. For those that do, use
      * `scheduleRevokePermission` instead.
      */
-    function revokePermissions(
-        bytes32[] memory actionIds,
+    function revokePermission(
+        bytes32 actionId,
         address account,
-        address[] memory where
+        address where
     ) external {
-        InputHelpers.ensureInputLengthMatch(actionIds.length, where.length);
-        for (uint256 i = 0; i < actionIds.length; i++) {
-            if (_revokeDelays[actionIds[i]] == 0) {
-                require(isRevoker(msg.sender, where[i]), "SENDER_IS_NOT_REVOKER");
-            } else {
-                // Some actions may have delays associated with revoking them - these permissions cannot be revoked
-                // directly, even if the caller is a revoker, and must instead be scheduled for future execution via
-                // `scheduleRevokePermission`.
-                require(msg.sender == address(_executionHelper), "REVOKE_MUST_BE_SCHEDULED");
-            }
-            _revokePermission(actionIds[i], account, where[i]);
+        if (_revokeDelays[actionId] == 0) {
+            require(isRevoker(msg.sender, where), "SENDER_IS_NOT_REVOKER");
+        } else {
+            // Some actions may have delays associated with revoking them - these permissions cannot be revoked
+            // directly, even if the caller is a revoker, and must instead be scheduled for future execution via
+            // `scheduleRevokePermission`.
+            require(msg.sender == address(_executionHelper), "REVOKE_MUST_BE_SCHEDULED");
         }
+        _revokePermission(actionId, account, where);
     }
 
     /**
@@ -1070,7 +1068,7 @@ contract TimelockAuthorizer is IAuthorizer, ReentrancyGuard {
         uint256 delay = _revokeDelays[actionId];
         require(delay > 0, "ACTION_HAS_NO_REVOKE_DELAY");
 
-        bytes memory data = abi.encodeWithSelector(this.revokePermissions.selector, _ar(actionId), account, _ar(where));
+        bytes memory data = abi.encodeWithSelector(this.revokePermission.selector, actionId, account, where);
 
         uint256 scheduledExecutionId = _scheduleWithDelay(address(this), data, delay, executors);
         emit RevokePermissionScheduled(actionId, account, where, scheduledExecutionId);
@@ -1084,27 +1082,12 @@ contract TimelockAuthorizer is IAuthorizer, ReentrancyGuard {
     }
 
     /**
-     * @notice Revokes multiple permissions from the caller.
+     * @notice Revokes a permission from the caller for `actionId` at `where` address
      * @dev Note that the caller can always renounce permissions, even if revoking them would typically be
      * subject to a delay.
      */
-    function renouncePermissions(bytes32[] memory actionIds, address[] memory where) external {
-        InputHelpers.ensureInputLengthMatch(actionIds.length, where.length);
-        for (uint256 i = 0; i < actionIds.length; i++) {
-            _revokePermission(actionIds[i], msg.sender, where[i]);
-        }
-    }
-
-    function _grantPermission(
-        bytes32 actionId,
-        address account,
-        address where
-    ) private {
-        bytes32 permission = getPermissionId(actionId, account, where);
-        if (!_isPermissionGranted[permission]) {
-            _isPermissionGranted[permission] = true;
-            emit PermissionGranted(actionId, account, where);
-        }
+    function renouncePermissions(bytes32 actionId, address where) external {
+        _revokePermission(actionId, msg.sender, where);
     }
 
     function _revokePermission(
@@ -1169,15 +1152,5 @@ contract TimelockAuthorizer is IAuthorizer, ReentrancyGuard {
         // The bytes4 type is left-aligned and padded with zeros: we make use of that property to build the selector
         if (data.length < 4) return bytes4(0);
         return bytes4(data[0]) | (bytes4(data[1]) >> 8) | (bytes4(data[2]) >> 16) | (bytes4(data[3]) >> 24);
-    }
-
-    function _ar(bytes32 item) private pure returns (bytes32[] memory result) {
-        result = new bytes32[](1);
-        result[0] = item;
-    }
-
-    function _ar(address item) private pure returns (address[] memory result) {
-        result = new address[](1);
-        result[0] = item;
     }
 }

--- a/pkg/vault/test/AssetManagement.test.ts
+++ b/pkg/vault/test/AssetManagement.test.ts
@@ -318,7 +318,7 @@ describe('Asset Management', function () {
             context('when paused', () => {
               sharedBeforeEach('pause', async () => {
                 const action = await actionId(vault, 'setPaused');
-                await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+                await authorizer.connect(admin).grantPermission(action, admin.address, ANY_ADDRESS);
                 await vault.connect(admin).setPaused(true);
               });
 
@@ -443,7 +443,7 @@ describe('Asset Management', function () {
               context('when paused', () => {
                 sharedBeforeEach('pause', async () => {
                   const action = await actionId(vault, 'setPaused');
-                  await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+                  await authorizer.connect(admin).grantPermission(action, admin.address, ANY_ADDRESS);
                   await vault.connect(admin).setPaused(true);
                 });
 
@@ -603,7 +603,7 @@ describe('Asset Management', function () {
               context('when paused', () => {
                 sharedBeforeEach('pause', async () => {
                   const action = await actionId(vault, 'setPaused');
-                  await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+                  await authorizer.connect(admin).grantPermission(action, admin.address, ANY_ADDRESS);
                   await vault.connect(admin).setPaused(true);
                 });
 

--- a/pkg/vault/test/ExitPool.test.ts
+++ b/pkg/vault/test/ExitPool.test.ts
@@ -40,7 +40,7 @@ describe('Exit Pool', () => {
     feesCollector = await deployedAt('ProtocolFeesCollector', await vault.getProtocolFeesCollector());
 
     const action = await actionId(feesCollector, 'setSwapFeePercentage');
-    await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+    await authorizer.connect(admin).grantPermission(action, admin.address, ANY_ADDRESS);
     await feesCollector.connect(admin).setSwapFeePercentage(SWAP_FEE_PERCENTAGE);
 
     allTokens = await TokenList.create(['DAI', 'MKR', 'SNX', 'BAT'], { sorted: true });
@@ -259,7 +259,7 @@ describe('Exit Pool', () => {
             context('when the relayer is whitelisted by the authorizer', () => {
               sharedBeforeEach('grant permission to relayer', async () => {
                 const action = await actionId(vault, 'exitPool');
-                await authorizer.connect(admin).grantPermissions([action], relayer.address, [ANY_ADDRESS]);
+                await authorizer.connect(admin).grantPermission(action, relayer.address, ANY_ADDRESS);
               });
 
               context('when the relayer is allowed by the user', () => {
@@ -296,7 +296,7 @@ describe('Exit Pool', () => {
             context('when the relayer is not whitelisted by the authorizer', () => {
               sharedBeforeEach('revoke permission from relayer', async () => {
                 const action = await actionId(vault, 'exitPool');
-                await authorizer.connect(admin).revokePermissions([action], relayer.address, [ANY_ADDRESS]);
+                await authorizer.connect(admin).revokePermission(action, relayer.address, ANY_ADDRESS);
               });
 
               context('when the relayer is allowed by the user', () => {
@@ -401,7 +401,7 @@ describe('Exit Pool', () => {
         context('when paused', () => {
           sharedBeforeEach('pause', async () => {
             const action = await actionId(vault, 'setPaused');
-            await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+            await authorizer.connect(admin).grantPermission(action, admin.address, ANY_ADDRESS);
             await vault.connect(admin).setPaused(true);
           });
 

--- a/pkg/vault/test/Fees.test.ts
+++ b/pkg/vault/test/Fees.test.ts
@@ -125,7 +125,7 @@ describe('Fees', () => {
 
       it('authorized accounts can withdraw protocol fees to any recipient', async () => {
         const action = await actionId(feesCollector, 'withdrawCollectedFees');
-        await vault.grantPermissionsGlobally([action], feeCollector);
+        await vault.grantPermissionGlobally(action, feeCollector);
 
         await expectBalanceChange(
           () =>
@@ -142,7 +142,7 @@ describe('Fees', () => {
 
       it('protocol fees cannot be over-withdrawn', async () => {
         const action = await actionId(feesCollector, 'withdrawCollectedFees');
-        await vault.grantPermissionsGlobally([action], feeCollector);
+        await vault.grantPermissionGlobally(action, feeCollector);
 
         await expect(
           vault.withdrawCollectedFees(tokens.DAI.address, bn(0.05e18).add(1), other, { from: feeCollector })

--- a/pkg/vault/test/FlashLoan.test.ts
+++ b/pkg/vault/test/FlashLoan.test.ts
@@ -28,7 +28,7 @@ describe('Flash Loans', () => {
     recipient = await deploy('MockFlashLoanRecipient', { from: other, args: [vault.address] });
 
     const action = await actionId(feesCollector, 'setFlashLoanFeePercentage');
-    await authorizer.connect(admin).grantPermissions([action], feeSetter.address, [ANY_ADDRESS]);
+    await authorizer.connect(admin).grantPermission(action, feeSetter.address, ANY_ADDRESS);
 
     tokens = await TokenList.create(['DAI', 'MKR'], { from: minter, sorted: true });
     await tokens.mint({ from: minter, to: vault, amount: bn(100e18) });

--- a/pkg/vault/test/InternalBalance.test.ts
+++ b/pkg/vault/test/InternalBalance.test.ts
@@ -315,7 +315,7 @@ describe('Internal Balance', () => {
       context('when the relayer is whitelisted by the authorizer', () => {
         sharedBeforeEach('grant permission to relayer', async () => {
           const action = await actionId(vault, 'manageUserBalance');
-          await authorizer.connect(admin).grantPermissions([action], relayer.address, [ANY_ADDRESS]);
+          await authorizer.connect(admin).grantPermission(action, relayer.address, ANY_ADDRESS);
         });
 
         context('when the relayer is allowed to deposit by the user', () => {
@@ -656,7 +656,7 @@ describe('Internal Balance', () => {
       context('when the relayer is whitelisted by the authorizer', () => {
         sharedBeforeEach('grant permission to relayer', async () => {
           const action = await actionId(vault, 'manageUserBalance');
-          await authorizer.connect(admin).grantPermissions([action], relayer.address, [ANY_ADDRESS]);
+          await authorizer.connect(admin).grantPermission(action, relayer.address, ANY_ADDRESS);
         });
 
         context('when the relayer is allowed by the user', () => {
@@ -969,7 +969,7 @@ describe('Internal Balance', () => {
       context('when the relayer is whitelisted by the authorizer', () => {
         sharedBeforeEach('grant permission to relayer', async () => {
           const action = await actionId(vault, 'manageUserBalance');
-          await authorizer.connect(admin).grantPermissions([action], relayer.address, [ANY_ADDRESS]);
+          await authorizer.connect(admin).grantPermission(action, relayer.address, ANY_ADDRESS);
         });
 
         context('when the relayer is allowed by the user', () => {
@@ -1177,7 +1177,7 @@ describe('Internal Balance', () => {
       context('when the relayer is whitelisted by the authorizer', () => {
         sharedBeforeEach('grant permission to relayer', async () => {
           const action = await actionId(vault, 'manageUserBalance');
-          await authorizer.connect(admin).grantPermissions([action], relayer.address, [ANY_ADDRESS]);
+          await authorizer.connect(admin).grantPermission(action, relayer.address, ANY_ADDRESS);
         });
 
         context('when the relayer is allowed to transfer by the user', () => {
@@ -1275,7 +1275,7 @@ describe('Internal Balance', () => {
 
     sharedBeforeEach('allow relayer', async () => {
       const action = await actionId(vault, 'manageUserBalance');
-      await authorizer.connect(admin).grantPermissions([action], relayer.address, [ANY_ADDRESS]);
+      await authorizer.connect(admin).grantPermission(action, relayer.address, ANY_ADDRESS);
       await vault.connect(sender).setRelayerApproval(sender.address, relayer.address, true);
       await vault.connect(recipient).setRelayerApproval(recipient.address, relayer.address, true);
     });
@@ -1363,7 +1363,7 @@ describe('Internal Balance', () => {
 
       sharedBeforeEach('pause', async () => {
         const action = await actionId(vault, 'setPaused');
-        await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+        await authorizer.connect(admin).grantPermission(action, admin.address, ANY_ADDRESS);
         await vault.connect(admin).setPaused(true);
       });
 

--- a/pkg/vault/test/JoinPool.test.ts
+++ b/pkg/vault/test/JoinPool.test.ts
@@ -36,7 +36,7 @@ describe('Join Pool', () => {
     feesCollector = await deployedAt('ProtocolFeesCollector', await vault.getProtocolFeesCollector());
 
     const action = await actionId(feesCollector, 'setSwapFeePercentage');
-    await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+    await authorizer.connect(admin).grantPermission(action, admin.address, ANY_ADDRESS);
     await feesCollector.connect(admin).setSwapFeePercentage(fp(0.1));
 
     allTokens = await TokenList.create(['DAI', 'MKR', 'SNX', 'BAT'], { sorted: true });
@@ -233,7 +233,7 @@ describe('Join Pool', () => {
                 context('when the relayer is whitelisted by the authorizer', () => {
                   sharedBeforeEach('grant permission to relayer', async () => {
                     const action = await actionId(vault, 'joinPool');
-                    await authorizer.connect(admin).grantPermissions([action], relayer.address, [ANY_ADDRESS]);
+                    await authorizer.connect(admin).grantPermission(action, relayer.address, ANY_ADDRESS);
                   });
 
                   context('when the relayer is allowed by the user', () => {
@@ -270,7 +270,7 @@ describe('Join Pool', () => {
                 context('when the relayer is not whitelisted by the authorizer', () => {
                   sharedBeforeEach('revoke permission from relayer', async () => {
                     const action = await actionId(vault, 'joinPool');
-                    await authorizer.connect(admin).revokePermissions([action], relayer.address, [ANY_ADDRESS]);
+                    await authorizer.connect(admin).revokePermission(action, relayer.address, ANY_ADDRESS);
                   });
 
                   context('when the relayer is allowed by the user', () => {
@@ -311,7 +311,7 @@ describe('Join Pool', () => {
           context('when paused', () => {
             sharedBeforeEach('pause', async () => {
               const action = await actionId(vault, 'setPaused');
-              await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+              await authorizer.connect(admin).grantPermission(action, admin.address, ANY_ADDRESS);
               await vault.connect(admin).setPaused(true);
             });
 

--- a/pkg/vault/test/SwapValidation.test.ts
+++ b/pkg/vault/test/SwapValidation.test.ts
@@ -142,7 +142,7 @@ describe('Swap Validation', () => {
       context('when paused', () => {
         sharedBeforeEach('pause', async () => {
           const action = await actionId(vault, 'setPaused');
-          await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+          await authorizer.connect(admin).grantPermission(action, admin.address, ANY_ADDRESS);
           await vault.connect(admin).setPaused(true);
         });
 

--- a/pkg/vault/test/Swaps.test.ts
+++ b/pkg/vault/test/Swaps.test.ts
@@ -597,7 +597,7 @@ describe('Swaps', () => {
                               const single = await actionId(vault, 'swap');
                               const batch = await actionId(vault, 'batchSwap');
                               await authorizer.connect(admin).revokePermission(single, other.address, ANY_ADDRESS);
-                              await authorizer.connect(admin).revokePermissions(batch, other.address, ANY_ADDRESS);
+                              await authorizer.connect(admin).revokePermission(batch, other.address, ANY_ADDRESS);
                             });
 
                             context('when the relayer is allowed by the user', () => {
@@ -1079,8 +1079,8 @@ describe('Swaps', () => {
                             sharedBeforeEach('revoke permission from relayer', async () => {
                               const single = await actionId(vault, 'swap');
                               const batch = await actionId(vault, 'batchSwap');
-                              await authorizer.connect(admin).revokePermissions(single, other.address, ANY_ADDRESS);
-                              await authorizer.connect(admin).revokePermissions(batch, other.address, ANY_ADDRESS);
+                              await authorizer.connect(admin).revokePermission(single, other.address, ANY_ADDRESS);
+                              await authorizer.connect(admin).revokePermission(batch, other.address, ANY_ADDRESS);
                             });
 
                             context('when the relayer is allowed by the user', () => {

--- a/pkg/vault/test/Swaps.test.ts
+++ b/pkg/vault/test/Swaps.test.ts
@@ -298,7 +298,7 @@ describe('Swaps', () => {
       context('when the sender is an approved relayer', () => {
         sharedBeforeEach(async () => {
           const action = await actionId(vault, 'batchSwap');
-          await authorizer.connect(admin).grantPermissions([action], other.address, [ANY_ADDRESS]);
+          await authorizer.connect(admin).grantPermission(action, other.address, ANY_ADDRESS);
 
           await vault.connect(trader).setRelayerApproval(trader.address, other.address, true);
         });
@@ -558,9 +558,8 @@ describe('Swaps', () => {
                             sharedBeforeEach('grant permission to relayer', async () => {
                               const single = await actionId(vault, 'swap');
                               const batch = await actionId(vault, 'batchSwap');
-                              await authorizer
-                                .connect(admin)
-                                .grantPermissions([single, batch], other.address, [ANY_ADDRESS, ANY_ADDRESS]);
+                              await authorizer.connect(admin).grantPermission(single, other.address, ANY_ADDRESS);
+                              await authorizer.connect(admin).grantPermission(batch, other.address, ANY_ADDRESS);
                             });
 
                             context('when the relayer is allowed by the user', () => {
@@ -597,9 +596,8 @@ describe('Swaps', () => {
                             sharedBeforeEach('revoke permission from relayer', async () => {
                               const single = await actionId(vault, 'swap');
                               const batch = await actionId(vault, 'batchSwap');
-                              await authorizer
-                                .connect(admin)
-                                .revokePermissions([single, batch], other.address, [ANY_ADDRESS, ANY_ADDRESS]);
+                              await authorizer.connect(admin).revokePermission(single, other.address, ANY_ADDRESS);
+                              await authorizer.connect(admin).revokePermissions(batch, other.address, ANY_ADDRESS);
                             });
 
                             context('when the relayer is allowed by the user', () => {
@@ -1056,9 +1054,8 @@ describe('Swaps', () => {
                             sharedBeforeEach('grant permission to relayer', async () => {
                               const single = await actionId(vault, 'swap');
                               const batch = await actionId(vault, 'batchSwap');
-                              await authorizer
-                                .connect(admin)
-                                .grantPermissions([single, batch], other.address, [ANY_ADDRESS, ANY_ADDRESS]);
+                              await authorizer.connect(admin).grantPermission(single, other.address, ANY_ADDRESS);
+                              await authorizer.connect(admin).grantPermission(batch, other.address, ANY_ADDRESS);
                             });
 
                             context('when the relayer is allowed by the user', () => {
@@ -1082,9 +1079,8 @@ describe('Swaps', () => {
                             sharedBeforeEach('revoke permission from relayer', async () => {
                               const single = await actionId(vault, 'swap');
                               const batch = await actionId(vault, 'batchSwap');
-                              await authorizer
-                                .connect(admin)
-                                .revokePermissions([single, batch], other.address, [ANY_ADDRESS, ANY_ADDRESS]);
+                              await authorizer.connect(admin).revokePermissions(single, other.address, ANY_ADDRESS);
+                              await authorizer.connect(admin).revokePermissions(batch, other.address, ANY_ADDRESS);
                             });
 
                             context('when the relayer is allowed by the user', () => {

--- a/pkg/vault/test/VaultAuthorization.test.ts
+++ b/pkg/vault/test/VaultAuthorization.test.ts
@@ -10,6 +10,7 @@ import { ANY_ADDRESS, MAX_GAS_LIMIT, MAX_UINT256, ZERO_ADDRESS } from '@balancer
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { RelayerAuthorization } from '@balancer-labs/balancer-js';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
 
 describe('VaultAuthorization', function () {
   let authorizer: Contract, vault: Contract;
@@ -55,7 +56,7 @@ describe('VaultAuthorization', function () {
 
       sharedBeforeEach('grant permission', async () => {
         action = await actionId(vault, 'setAuthorizer');
-        await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+        await authorizer.connect(admin).grantPermission(action, admin.address, ANY_ADDRESS);
       });
 
       it('can change the authorizer to another address', async () => {
@@ -76,7 +77,7 @@ describe('VaultAuthorization', function () {
       });
 
       it('can not change the authorizer if the permission was revoked', async () => {
-        await authorizer.connect(admin).revokePermissions([action], admin.address, [ANY_ADDRESS]);
+        await authorizer.connect(admin).revokePermission(action, admin.address, ANY_ADDRESS);
 
         expect(await authorizer.canPerform(action, admin.address, WHERE)).to.be.false;
 
@@ -114,7 +115,7 @@ describe('VaultAuthorization', function () {
       context('when the sender is allowed by the authorizer', () => {
         sharedBeforeEach('grant permission to sender', async () => {
           const action = await actionId(vault, 'setRelayerApproval');
-          await authorizer.connect(admin).grantPermissions([action], sender.address, [ANY_ADDRESS]);
+          await authorizer.connect(admin).grantPermission(action, sender.address, [ANY_ADDRESS]);
         });
 
         context('when the sender is approved by the user', () => {
@@ -148,7 +149,7 @@ describe('VaultAuthorization', function () {
       context('when the sender is not allowed by the authorizer', () => {
         sharedBeforeEach('revoke permission for sender', async () => {
           const action = await actionId(vault, 'setRelayerApproval');
-          await authorizer.connect(admin).revokePermissions([action], sender.address, [ANY_ADDRESS]);
+          await authorizer.connect(admin).revokePermission(action, sender.address, ANY_ADDRESS);
         });
 
         context('when the sender is approved by the user', () => {
@@ -257,7 +258,7 @@ describe('VaultAuthorization', function () {
 
       sharedBeforeEach('grant permission', async () => {
         action = await actionId(vault, 'setPaused');
-        await authorizer.connect(admin).grantPermissions([action], admin.address, [ANY_ADDRESS]);
+        await authorizer.connect(admin).grantPermission(action, admin.address, [ANY_ADDRESS]);
       });
 
       it('can pause', async () => {
@@ -276,7 +277,7 @@ describe('VaultAuthorization', function () {
       });
 
       it('cannot pause if the permission is revoked', async () => {
-        await authorizer.connect(admin).revokePermissions([action], admin.address, [ANY_ADDRESS]);
+        await authorizer.connect(admin).revokePermission(action, admin.address, ANY_ADDRESS);
         expect(await authorizer.canPerform(action, admin.address, WHERE)).to.be.false;
         await expect(vault.connect(admin).setPaused(true)).to.be.revertedWith('SENDER_NOT_ALLOWED');
       });

--- a/pkg/vault/test/VaultAuthorization.test.ts
+++ b/pkg/vault/test/VaultAuthorization.test.ts
@@ -115,7 +115,7 @@ describe('VaultAuthorization', function () {
       context('when the sender is allowed by the authorizer', () => {
         sharedBeforeEach('grant permission to sender', async () => {
           const action = await actionId(vault, 'setRelayerApproval');
-          await authorizer.connect(admin).grantPermission(action, sender.address, [ANY_ADDRESS]);
+          await authorizer.connect(admin).grantPermission(action, sender.address, ANY_ADDRESS);
         });
 
         context('when the sender is approved by the user', () => {
@@ -258,7 +258,7 @@ describe('VaultAuthorization', function () {
 
       sharedBeforeEach('grant permission', async () => {
         action = await actionId(vault, 'setPaused');
-        await authorizer.connect(admin).grantPermission(action, admin.address, [ANY_ADDRESS]);
+        await authorizer.connect(admin).grantPermission(action, admin.address, ANY_ADDRESS);
       });
 
       it('can pause', async () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizer.test.ts
@@ -31,11 +31,9 @@ describe('TimelockAuthorizer', () => {
 
   const ACTION_1 = '0x0000000000000000000000000000000000000000000000000000000000000001';
   const ACTION_2 = '0x0000000000000000000000000000000000000000000000000000000000000002';
-  const ACTIONS = [ACTION_1, ACTION_2];
 
   const WHERE_1 = ethers.Wallet.createRandom().address;
   const WHERE_2 = ethers.Wallet.createRandom().address;
-  const WHERE = [WHERE_1, WHERE_2];
 
   const EVERYWHERE = TimelockAuthorizer.EVERYWHERE;
   const NOT_WHERE = ethers.Wallet.createRandom().address;
@@ -747,40 +745,35 @@ describe('TimelockAuthorizer', () => {
     });
   });
 
-  describe('grantPermissions', () => {
+  describe('grantPermission', () => {
     context('when the sender is the root', () => {
       context('when the target does not have the permission granted', () => {
         context('when there is no delay set to grant permissions', () => {
-          it('grants permission to perform the requested actions for the requested contracts', async () => {
-            await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root });
+          it('grants permission to perform the requested action for the requested contract', async () => {
+            await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root });
 
             expect(await authorizer.canPerform(ACTION_1, granter, WHERE_1)).to.be.true;
-            expect(await authorizer.canPerform(ACTION_2, granter, WHERE_2)).to.be.true;
           });
 
-          it('does not grant permission to perform the requested actions everywhere', async () => {
-            await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root });
+          it('does not grant permission to perform the requested action everywhere', async () => {
+            await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root });
 
             expect(await authorizer.canPerform(ACTION_1, granter, EVERYWHERE)).to.be.false;
-            expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.false;
           });
 
           it('does not grant permission to perform the requested actions for other contracts', async () => {
-            await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root });
+            await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root });
 
             expect(await authorizer.canPerform(ACTION_1, granter, NOT_WHERE)).to.be.false;
-            expect(await authorizer.canPerform(ACTION_2, granter, NOT_WHERE)).to.be.false;
           });
 
           it('emits an event', async () => {
-            const receipt = await (await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root })).wait();
+            const receipt = await (await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root })).wait();
 
-            ACTIONS.forEach((action, i) => {
-              expectEvent.inReceipt(receipt, 'PermissionGranted', {
-                actionId: action,
-                account: granter.address,
-                where: WHERE[i],
-              });
+            expectEvent.inReceipt(receipt, 'PermissionGranted', {
+              actionId: ACTION_1,
+              account: granter.address,
+              where: WHERE_1,
             });
           });
         });
@@ -795,7 +788,7 @@ describe('TimelockAuthorizer', () => {
           });
 
           it('reverts', async () => {
-            await expect(authorizer.grantPermissions(ACTION_1, granter, WHERE_1, { from: root })).to.be.revertedWith(
+            await expect(authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root })).to.be.revertedWith(
               'GRANT_MUST_BE_SCHEDULED'
             );
           });
@@ -816,75 +809,68 @@ describe('TimelockAuthorizer', () => {
       });
 
       context('when the target has the permission granted', () => {
-        context('when the permission was granted for a set of contracts', () => {
-          sharedBeforeEach('grant permissions', async () => {
-            await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root });
+        context('when the permission was granted for a contract', () => {
+          sharedBeforeEach('grant a permission', async () => {
+            await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root });
           });
 
-          it('ignores the request and can still perform those actions', async () => {
-            await expect(authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root })).not.to.reverted;
+          it('ignores the request and can still perform the action', async () => {
+            await expect(authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root })).not.to.reverted;
 
             expect(await authorizer.canPerform(ACTION_1, granter, WHERE_1)).to.be.true;
-            expect(await authorizer.canPerform(ACTION_2, granter, WHERE_2)).to.be.true;
           });
 
-          it('does not grant permission to perform the requested actions everywhere', async () => {
-            await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root });
+          it('does not grant the permission to perform the requested action everywhere', async () => {
+            await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root });
 
             expect(await authorizer.canPerform(ACTION_1, granter, EVERYWHERE)).to.be.false;
-            expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.false;
           });
 
-          it('does not grant permission to perform the requested actions for other contracts', async () => {
-            await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root });
+          it('does not grant the permission to perform the requested action for other contracts', async () => {
+            await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root });
 
             expect(await authorizer.canPerform(ACTION_1, granter, NOT_WHERE)).to.be.false;
-            expect(await authorizer.canPerform(ACTION_2, granter, NOT_WHERE)).to.be.false;
+            expect(await authorizer.canPerform(ACTION_1, granter, WHERE_2)).to.be.false;
           });
 
           it('does not emit an event', async () => {
-            const tx = await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root });
+            const tx = await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root });
             expectEvent.notEmitted(await tx.wait(), 'PermissionGranted');
           });
         });
 
         context('when the permission was granted globally', () => {
-          sharedBeforeEach('grant permissions', async () => {
-            await authorizer.grantPermissionsGlobally(ACTIONS, granter, { from: root });
+          sharedBeforeEach('grant the permission', async () => {
+            await authorizer.grantPermissionGlobally(ACTION_1, granter, { from: root });
           });
 
-          it('grants permission to perform the requested actions for the requested contracts', async () => {
-            await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root });
+          it('grants the permission to perform the requested action for the requested contract', async () => {
+            await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root });
 
             expect(await authorizer.canPerform(ACTION_1, granter, WHERE_1)).to.be.true;
-            expect(await authorizer.canPerform(ACTION_2, granter, WHERE_1)).to.be.true;
             expect(await authorizer.canPerform(ACTION_1, granter, WHERE_2)).to.be.true;
-            expect(await authorizer.canPerform(ACTION_2, granter, WHERE_2)).to.be.true;
           });
 
           it('still can perform the requested actions everywhere', async () => {
-            await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root });
+            await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root });
 
             expect(await authorizer.canPerform(ACTION_1, granter, EVERYWHERE)).to.be.true;
-            expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.true;
+            expect(await authorizer.canPerform(ACTION_1, granter, WHERE_2)).to.be.true;
           });
 
           it('still can perform the requested actions for other contracts', async () => {
-            await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root });
+            await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root });
 
             expect(await authorizer.canPerform(ACTION_1, granter, NOT_WHERE)).to.be.true;
-            expect(await authorizer.canPerform(ACTION_2, granter, NOT_WHERE)).to.be.true;
+            expect(await authorizer.canPerform(ACTION_1, granter, WHERE_2)).to.be.true;
           });
 
           it('emits an event', async () => {
-            const receipt = await (await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root })).wait();
-
-            ACTIONS.forEach((action, i) => {
-              expectEvent.inReceipt(receipt, 'PermissionGranted', {
-                actionId: action,
-                account: granter.address,
-                where: WHERE[i],
-              });
+            const receipt = await (await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root })).wait();
+            expectEvent.inReceipt(receipt, 'PermissionGranted', {
+              actionId: ACTION_1,
+              account: granter.address,
+              where: WHERE_1,
             });
           });
         });
@@ -893,99 +879,92 @@ describe('TimelockAuthorizer', () => {
 
     context('when the sender is not the root', () => {
       it('reverts', async () => {
-        await expect(authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: granter })).to.be.revertedWith(
+        await expect(authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: granter })).to.be.revertedWith(
           'SENDER_IS_NOT_GRANTER'
         );
       });
     });
   });
 
-  describe('grantPermissionsGlobally', () => {
+  describe('grantPermissionGlobally', () => {
     context('when the sender is the root', () => {
       context('when the target does not have the permission granted', () => {
-        it('grants permission to perform the requested actions everywhere', async () => {
-          await authorizer.grantPermissionsGlobally(ACTIONS, granter, { from: root });
+        it('grants the permission to perform the requested action everywhere', async () => {
+          await authorizer.grantPermissionGlobally(ACTION_1, granter, { from: root });
 
           expect(await authorizer.canPerform(ACTION_1, granter, EVERYWHERE)).to.be.true;
-          expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.true;
+          expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.false;
         });
 
-        it('grants permission to perform the requested actions in any specific contract', async () => {
-          await authorizer.grantPermissionsGlobally(ACTIONS, granter, { from: root });
+        it('grants permission to perform the requested action in any specific contract', async () => {
+          await authorizer.grantPermissionGlobally(ACTION_1, granter, { from: root });
 
           expect(await authorizer.canPerform(ACTION_1, granter, NOT_WHERE)).to.be.true;
-          expect(await authorizer.canPerform(ACTION_2, granter, NOT_WHERE)).to.be.true;
+          expect(await authorizer.canPerform(ACTION_1, granter, WHERE_2)).to.be.true;
         });
 
         it('emits an event', async () => {
-          const receipt = await (await authorizer.grantPermissionsGlobally(ACTIONS, granter, { from: root })).wait();
+          const receipt = await (await authorizer.grantPermissionGlobally(ACTION_1, granter, { from: root })).wait();
 
-          for (const action of ACTIONS) {
-            expectEvent.inReceipt(receipt, 'PermissionGranted', {
-              actionId: action,
-              account: granter.address,
-              where: TimelockAuthorizer.EVERYWHERE,
-            });
-          }
+          expectEvent.inReceipt(receipt, 'PermissionGranted', {
+            actionId: ACTION_1,
+            account: granter.address,
+            where: TimelockAuthorizer.EVERYWHERE,
+          });
         });
       });
 
       context('when the target has the permission granted', () => {
-        context('when the permission was granted for a set of contracts', () => {
+        context('when the permission was granted for a contract', () => {
           sharedBeforeEach('grant permissions', async () => {
-            await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root });
+            await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root });
           });
 
-          it('grants permission to perform the requested actions everywhere', async () => {
-            await authorizer.grantPermissionsGlobally(ACTIONS, granter, { from: root });
+          it('grants permission to perform the requested action everywhere', async () => {
+            await authorizer.grantPermissionGlobally(ACTION_1, granter, { from: root });
 
             expect(await authorizer.canPerform(ACTION_1, granter, EVERYWHERE)).to.be.true;
-            expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.true;
           });
 
-          it('still can perform the requested actions for the previously granted contracts', async () => {
-            await authorizer.grantPermissionsGlobally(ACTIONS, granter, { from: root });
+          it('still can perform the requested action for the previously granted contracts', async () => {
+            await authorizer.grantPermissionGlobally(ACTION_2, granter, { from: root });
 
             expect(await authorizer.canPerform(ACTION_1, granter, WHERE_1)).to.be.true;
             expect(await authorizer.canPerform(ACTION_2, granter, WHERE_1)).to.be.true;
-            expect(await authorizer.canPerform(ACTION_1, granter, WHERE_2)).to.be.true;
             expect(await authorizer.canPerform(ACTION_2, granter, WHERE_2)).to.be.true;
           });
 
           it('emits an event', async () => {
-            const receipt = await (await authorizer.grantPermissionsGlobally(ACTIONS, granter, { from: root })).wait();
+            const receipt = await (await authorizer.grantPermissionGlobally(ACTION_1, granter, { from: root })).wait();
 
-            for (const action of ACTIONS) {
-              expectEvent.inReceipt(receipt, 'PermissionGranted', {
-                actionId: action,
-                account: granter.address,
-                where: TimelockAuthorizer.EVERYWHERE,
-              });
-            }
+            expectEvent.inReceipt(receipt, 'PermissionGranted', {
+              actionId: ACTION_1,
+              account: granter.address,
+              where: TimelockAuthorizer.EVERYWHERE,
+            });
           });
         });
 
         context('when the permission was granted globally', () => {
           sharedBeforeEach('grant permissions', async () => {
-            await authorizer.grantPermissionsGlobally(ACTIONS, granter, { from: root });
+            await authorizer.grantPermissionGlobally(ACTION_1, granter, { from: root });
           });
 
-          it('ignores the request and can still perform the requested actions everywhere', async () => {
-            await expect(authorizer.grantPermissionsGlobally(ACTIONS, granter, { from: root })).not.to.be.reverted;
+          it('ignores the request and can still perform the requested action everywhere', async () => {
+            await expect(authorizer.grantPermissionGlobally(ACTION_1, granter, { from: root })).not.to.be.reverted;
 
             expect(await authorizer.canPerform(ACTION_1, granter, EVERYWHERE)).to.be.true;
-            expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.true;
           });
 
-          it('ignores the request and can still perform the requested actions in any specific contract', async () => {
-            await expect(authorizer.grantPermissionsGlobally(ACTIONS, granter, { from: root })).not.to.be.reverted;
+          it('ignores the request and can still perform the requested action in any specific contract', async () => {
+            await expect(authorizer.grantPermissionGlobally(ACTION_1, granter, { from: root })).not.to.be.reverted;
 
             expect(await authorizer.canPerform(ACTION_1, granter, NOT_WHERE)).to.be.true;
-            expect(await authorizer.canPerform(ACTION_2, granter, NOT_WHERE)).to.be.true;
+            expect(await authorizer.canPerform(ACTION_1, granter, WHERE_1)).to.be.true;
           });
 
           it('does not emit an event', async () => {
-            const tx = await authorizer.grantPermissionsGlobally(ACTIONS, granter, { from: root });
+            const tx = await authorizer.grantPermissionGlobally(ACTION_1, granter, { from: root });
             expectEvent.notEmitted(await tx.wait(), 'PermissionGrantedGlobally');
           });
         });
@@ -994,45 +973,45 @@ describe('TimelockAuthorizer', () => {
 
     context('when the sender is not the root', () => {
       it('reverts', async () => {
-        await expect(authorizer.grantPermissionsGlobally(ACTIONS, granter, { from: granter })).to.be.revertedWith(
+        await expect(authorizer.grantPermissionGlobally(ACTION_1, granter, { from: granter })).to.be.revertedWith(
           'SENDER_IS_NOT_GRANTER'
         );
       });
     });
   });
 
-  describe('revokePermissions', () => {
+  describe('revokePermission', () => {
     context('when the sender is the root', () => {
       context('when the target does not have the permission granted', () => {
-        it('ignores the request and cannot perform the requested actions everywhere', async () => {
-          await expect(authorizer.revokePermissions(ACTIONS, granter, WHERE, { from: root })).not.to.be.reverted;
+        it('ignores the request and cannot perform the requested action everywhere', async () => {
+          await expect(authorizer.revokePermission(ACTION_1, granter, WHERE_1, { from: root })).not.to.be.reverted;
 
           expect(await authorizer.canPerform(ACTION_1, granter, EVERYWHERE)).to.be.false;
           expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.false;
         });
 
-        it('ignores the request and cannot perform the requested actions in any specific contract', async () => {
-          await expect(authorizer.revokePermissions(ACTIONS, granter, WHERE, { from: root })).not.to.be.reverted;
+        it('ignores the request and cannot perform the requested action in any specific contract', async () => {
+          await expect(authorizer.revokePermission(ACTION_1, granter, WHERE_1, { from: root })).not.to.be.reverted;
 
           expect(await authorizer.canPerform(ACTION_1, granter, NOT_WHERE)).to.be.false;
-          expect(await authorizer.canPerform(ACTION_2, granter, NOT_WHERE)).to.be.false;
+          expect(await authorizer.canPerform(ACTION_1, granter, WHERE_2)).to.be.false;
         });
 
         it('does not emit an event', async () => {
-          const tx = await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root });
+          const tx = await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root });
           expectEvent.notEmitted(await tx.wait(), 'PermissionRevoked');
         });
       });
 
       context('when the target has the permission granted', () => {
-        context('when the permission was granted for a set of contracts', () => {
-          sharedBeforeEach('grant permissions', async () => {
-            await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root });
+        context('when the permission was granted for a contract', () => {
+          sharedBeforeEach('grants the permission', async () => {
+            await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root });
           });
 
           context('when there is no delay set to revoke permissions', () => {
-            it('revokes the requested permission for the requested contracts', async () => {
-              await authorizer.revokePermissions(ACTIONS, granter, WHERE, { from: root });
+            it('revokes the requested permission for the requested contract', async () => {
+              await authorizer.revokePermission(ACTION_1, granter, WHERE_1, { from: root });
 
               expect(await authorizer.canPerform(ACTION_1, granter, WHERE_1)).to.be.false;
               expect(await authorizer.canPerform(ACTION_2, granter, WHERE_1)).to.be.false;
@@ -1040,8 +1019,8 @@ describe('TimelockAuthorizer', () => {
               expect(await authorizer.canPerform(ACTION_2, granter, WHERE_2)).to.be.false;
             });
 
-            it('still cannot perform the requested actions everywhere', async () => {
-              await authorizer.revokePermissions(ACTIONS, granter, WHERE, { from: root });
+            it('still cannot perform the requested action everywhere', async () => {
+              await authorizer.revokePermission(ACTION_1, granter, WHERE_1, { from: root });
 
               expect(await authorizer.canPerform(ACTION_1, granter, EVERYWHERE)).to.be.false;
               expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.false;
@@ -1049,15 +1028,13 @@ describe('TimelockAuthorizer', () => {
 
             it('emits an event', async () => {
               const receipt = await (
-                await authorizer.revokePermissions(ACTIONS, granter, WHERE, { from: root })
+                await authorizer.revokePermission(ACTION_1, granter, WHERE_1, { from: root })
               ).wait();
 
-              ACTIONS.forEach((action, i) => {
-                expectEvent.inReceipt(receipt, 'PermissionRevoked', {
-                  actionId: action,
-                  account: granter.address,
-                  where: WHERE[i],
-                });
+              expectEvent.inReceipt(receipt, 'PermissionRevoked', {
+                actionId: ACTION_1,
+                account: granter.address,
+                where: WHERE_1,
               });
             });
           });
@@ -1069,12 +1046,12 @@ describe('TimelockAuthorizer', () => {
               const setAuthorizerAction = await actionId(vault, 'setAuthorizer');
               await authorizer.scheduleAndExecuteDelayChange(setAuthorizerAction, delay * 2, { from: root });
               await authorizer.scheduleAndExecuteRevokeDelayChange(ACTION_1, delay, { from: root });
-              await authorizer.grantPermissions(ACTION_1, granter, authenticatedContract, { from: root });
-              await authorizer.grantPermissions(ACTION_2, granter, authenticatedContract, { from: root });
+              await authorizer.grantPermission(ACTION_1, granter, authenticatedContract, { from: root });
+              await authorizer.grantPermission(ACTION_2, granter, authenticatedContract, { from: root });
             });
 
             it('reverts', async () => {
-              await expect(authorizer.revokePermissions(ACTION_1, granter, WHERE_1, { from: root })).to.be.revertedWith(
+              await expect(authorizer.revokePermission(ACTION_1, granter, WHERE_1, { from: root })).to.be.revertedWith(
                 'REVOKE_MUST_BE_SCHEDULED'
               );
             });
@@ -1089,34 +1066,30 @@ describe('TimelockAuthorizer', () => {
               await authorizer.execute(id, { from: root });
 
               expect(await authorizer.canPerform(ACTION_1, granter, WHERE_1)).to.be.false;
-              expect(await authorizer.canPerform(ACTION_2, granter, WHERE_2)).to.be.true;
             });
           });
         });
 
         context('when the permission was granted globally', () => {
-          sharedBeforeEach('grant permissions', async () => {
-            await authorizer.grantPermissionsGlobally(ACTIONS, granter, { from: root });
+          sharedBeforeEach('grants the permissions', async () => {
+            await authorizer.grantPermissionGlobally(ACTION_1, granter, { from: root });
           });
 
-          it('still can perform the requested actions for the requested contracts', async () => {
-            await authorizer.revokePermissions(ACTIONS, granter, WHERE, { from: root });
+          it('still can perform the requested action for the requested contract', async () => {
+            await authorizer.revokePermission(ACTION_1, granter, WHERE_1, { from: root });
 
             expect(await authorizer.canPerform(ACTION_1, granter, WHERE_1)).to.be.true;
-            expect(await authorizer.canPerform(ACTION_2, granter, WHERE_1)).to.be.true;
             expect(await authorizer.canPerform(ACTION_1, granter, WHERE_2)).to.be.true;
-            expect(await authorizer.canPerform(ACTION_2, granter, WHERE_2)).to.be.true;
           });
 
-          it('still can perform the requested actions everywhere', async () => {
-            await authorizer.revokePermissions(ACTIONS, granter, WHERE, { from: root });
+          it('still can perform the requested action everywhere', async () => {
+            await authorizer.revokePermission(ACTION_1, granter, WHERE_1, { from: root });
 
             expect(await authorizer.canPerform(ACTION_1, granter, EVERYWHERE)).to.be.true;
-            expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.true;
           });
 
           it('does not emit an event', async () => {
-            const tx = await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root });
+            const tx = await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root });
             expectEvent.notEmitted(await tx.wait(), 'PermissionRevoked');
           });
         });
@@ -1125,93 +1098,87 @@ describe('TimelockAuthorizer', () => {
 
     context('when the sender is not the root', () => {
       it('reverts', async () => {
-        await expect(authorizer.revokePermissions(ACTIONS, granter, WHERE, { from: granter })).to.be.revertedWith(
+        await expect(authorizer.revokePermission(ACTION_1, granter, WHERE_1, { from: granter })).to.be.revertedWith(
           'SENDER_IS_NOT_REVOKER'
         );
       });
     });
   });
 
-  describe('revokePermissionsGlobally', () => {
+  describe('revokePermissionGlobally', () => {
     context('when the sender is the root', () => {
       context('when the sender does not have the permission granted', () => {
-        it('ignores the request and cannot perform the requested actions everywhere', async () => {
-          await expect(authorizer.revokePermissionsGlobally(ACTIONS, granter, { from: root })).not.to.be.reverted;
+        it('ignores the request and cannot perform the requested action everywhere', async () => {
+          await expect(authorizer.revokePermissionGlobally(ACTION_1, granter, { from: root })).not.to.be.reverted;
 
           expect(await authorizer.canPerform(ACTION_1, granter, EVERYWHERE)).to.be.false;
           expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.false;
         });
 
-        it('ignores the request and cannot perform the requested actions in any specific contract', async () => {
-          await expect(authorizer.revokePermissionsGlobally(ACTIONS, granter, { from: root })).not.to.be.reverted;
+        it('ignores the request and cannot perform the requested action in any specific contract', async () => {
+          await expect(authorizer.revokePermissionGlobally(ACTION_1, granter, { from: root })).not.to.be.reverted;
 
           expect(await authorizer.canPerform(ACTION_1, granter, NOT_WHERE)).to.be.false;
-          expect(await authorizer.canPerform(ACTION_2, granter, NOT_WHERE)).to.be.false;
         });
 
         it('does not emit an event', async () => {
-          const tx = await authorizer.revokePermissionsGlobally(ACTIONS, granter, { from: root });
+          const tx = await authorizer.revokePermissionGlobally(ACTION_1, granter, { from: root });
           expectEvent.notEmitted(await tx.wait(), 'PermissionRevokedGlobally');
         });
       });
 
-      context('when the grantee has the permission granted', () => {
-        context('when the permission was granted for a set of contracts', () => {
-          sharedBeforeEach('grant permissions', async () => {
-            await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root });
+      context('when the account has the permission granted', () => {
+        context('when the permission was granted for a contract', () => {
+          sharedBeforeEach('grants the permission', async () => {
+            await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root });
           });
 
-          it('still cannot perform the requested actions everywhere', async () => {
-            await authorizer.revokePermissionsGlobally(ACTIONS, granter, { from: root });
+          it('still cannot perform the requested action everywhere', async () => {
+            await authorizer.revokePermissionGlobally(ACTION_1, granter, { from: root });
 
             expect(await authorizer.canPerform(ACTION_1, granter, EVERYWHERE)).to.be.false;
             expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.false;
           });
 
-          it('still can perform the requested actions for the previously granted permissions', async () => {
-            await authorizer.revokePermissionsGlobally(ACTIONS, granter, { from: root });
+          it('still can perform the requested action for the previously granted permissions', async () => {
+            await authorizer.revokePermissionGlobally(ACTION_1, granter, { from: root });
 
             expect(await authorizer.canPerform(ACTION_1, granter, WHERE_1)).to.be.true;
-            expect(await authorizer.canPerform(ACTION_2, granter, WHERE_2)).to.be.true;
           });
 
           it('does not emit an event', async () => {
-            const tx = await authorizer.revokePermissionsGlobally(ACTIONS, granter, { from: root });
+            const tx = await authorizer.revokePermissionGlobally(ACTION_1, granter, { from: root });
             expectEvent.notEmitted(await tx.wait(), 'PermissionRevokedGlobally');
           });
         });
 
         context('when the permission was granted globally', () => {
-          sharedBeforeEach('grant permissions', async () => {
-            await authorizer.grantPermissionsGlobally(ACTIONS, granter, { from: root });
+          sharedBeforeEach('grants the permission', async () => {
+            await authorizer.grantPermissionGlobally(ACTION_1, granter, { from: root });
           });
 
-          it('revokes the requested global permission and cannot perform the requested actions everywhere', async () => {
-            await authorizer.revokePermissionsGlobally(ACTIONS, granter, { from: root });
+          it('revokes the requested global permission and cannot perform the requested action everywhere', async () => {
+            await authorizer.revokePermissionGlobally(ACTION_1, granter, { from: root });
 
             expect(await authorizer.canPerform(ACTION_1, granter, WHERE_1)).to.be.false;
-            expect(await authorizer.canPerform(ACTION_2, granter, WHERE_1)).to.be.false;
             expect(await authorizer.canPerform(ACTION_1, granter, WHERE_2)).to.be.false;
-            expect(await authorizer.canPerform(ACTION_2, granter, WHERE_2)).to.be.false;
           });
 
-          it('cannot perform the requested actions in any specific contract', async () => {
-            await authorizer.revokePermissionsGlobally(ACTIONS, granter, { from: root });
+          it('cannot perform the requested action in any specific contract', async () => {
+            await authorizer.revokePermissionGlobally(ACTION_1, granter, { from: root });
 
             expect(await authorizer.canPerform(ACTION_1, granter, NOT_WHERE)).to.be.false;
-            expect(await authorizer.canPerform(ACTION_2, granter, NOT_WHERE)).to.be.false;
+            expect(await authorizer.canPerform(ACTION_1, granter, WHERE_2)).to.be.false;
           });
 
           it('emits an event', async () => {
-            const receipt = await (await authorizer.revokePermissionsGlobally(ACTIONS, granter, { from: root })).wait();
+            const receipt = await (await authorizer.revokePermissionGlobally(ACTION_1, granter, { from: root })).wait();
 
-            for (const action of ACTIONS) {
-              expectEvent.inReceipt(receipt, 'PermissionRevoked', {
-                actionId: action,
-                account: granter.address,
-                where: TimelockAuthorizer.EVERYWHERE,
-              });
-            }
+            expectEvent.inReceipt(receipt, 'PermissionRevoked', {
+              actionId: ACTION_1,
+              account: granter.address,
+              where: TimelockAuthorizer.EVERYWHERE,
+            });
           });
         });
       });
@@ -1219,38 +1186,37 @@ describe('TimelockAuthorizer', () => {
 
     context('when the sender is not the root', () => {
       it('reverts', async () => {
-        await expect(authorizer.revokePermissionsGlobally(ACTIONS, granter, { from: granter })).to.be.revertedWith(
+        await expect(authorizer.revokePermissionGlobally(ACTION_1, granter, { from: granter })).to.be.revertedWith(
           'SENDER_IS_NOT_REVOKER'
         );
       });
     });
   });
 
-  describe('renouncePermissions', () => {
+  describe('renouncePermission', () => {
     context('when the sender does not have the permission granted', () => {
-      it('ignores the request and still cannot perform the requested actions everywhere', async () => {
-        await expect(authorizer.renouncePermissions(ACTIONS, WHERE, { from: granter })).not.to.be.reverted;
+      it('ignores the request and still cannot perform the requested action everywhere', async () => {
+        await expect(authorizer.renouncePermission(ACTION_1, WHERE_1, { from: granter })).not.to.be.reverted;
 
         expect(await authorizer.canPerform(ACTION_1, granter, EVERYWHERE)).to.be.false;
-        expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.false;
       });
 
-      it('ignores the request and still cannot perform the requested actions in any specific contract', async () => {
-        await expect(authorizer.renouncePermissions(ACTIONS, WHERE, { from: granter })).not.to.be.reverted;
+      it('ignores the request and still cannot perform the requested action in any specific contract', async () => {
+        await expect(authorizer.renouncePermission(ACTION_1, WHERE_1, { from: granter })).not.to.be.reverted;
 
         expect(await authorizer.canPerform(ACTION_1, granter, NOT_WHERE)).to.be.false;
-        expect(await authorizer.canPerform(ACTION_2, granter, NOT_WHERE)).to.be.false;
+        expect(await authorizer.canPerform(ACTION_1, granter, WHERE_2)).to.be.false;
       });
     });
 
     context('when the sender has the permission granted', () => {
       context('when the sender has the permission granted for a specific contract', () => {
-        sharedBeforeEach('grant permissions', async () => {
-          await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root });
+        sharedBeforeEach('grants the permission', async () => {
+          await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root });
         });
 
-        it('revokes the requested permission for the requested contracts', async () => {
-          await authorizer.renouncePermissions(ACTIONS, WHERE, { from: granter });
+        it('revokes the requested permission for the requested contract', async () => {
+          await authorizer.renouncePermission(ACTION_1, WHERE_1, { from: granter });
 
           expect(await authorizer.canPerform(ACTION_1, granter, WHERE_1)).to.be.false;
           expect(await authorizer.canPerform(ACTION_2, granter, WHERE_1)).to.be.false;
@@ -1258,70 +1224,65 @@ describe('TimelockAuthorizer', () => {
           expect(await authorizer.canPerform(ACTION_2, granter, WHERE_2)).to.be.false;
         });
 
-        it('still cannot perform the requested actions everywhere', async () => {
-          await authorizer.renouncePermissions(ACTIONS, WHERE, { from: granter });
+        it('still cannot perform the requested action everywhere', async () => {
+          await authorizer.renouncePermission(ACTION_1, WHERE_1, { from: granter });
 
           expect(await authorizer.canPerform(ACTION_1, granter, EVERYWHERE)).to.be.false;
-          expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.false;
         });
       });
 
       context('when the sender has the permission granted globally', () => {
-        sharedBeforeEach('grant permissions', async () => {
-          await authorizer.grantPermissionsGlobally(ACTIONS, granter, { from: root });
+        sharedBeforeEach('grants the permission', async () => {
+          await authorizer.grantPermissionGlobally(ACTION_1, granter, { from: root });
         });
 
-        it('still can perform the requested actions for the requested contracts', async () => {
-          await authorizer.renouncePermissions(ACTIONS, WHERE, { from: granter });
+        it('still can perform the requested actions for the requested contract', async () => {
+          await authorizer.renouncePermission(ACTION_1, WHERE_1, { from: granter });
 
           expect(await authorizer.canPerform(ACTION_1, granter, WHERE_1)).to.be.true;
-          expect(await authorizer.canPerform(ACTION_2, granter, WHERE_1)).to.be.true;
           expect(await authorizer.canPerform(ACTION_1, granter, WHERE_2)).to.be.true;
-          expect(await authorizer.canPerform(ACTION_2, granter, WHERE_2)).to.be.true;
         });
 
-        it('still can perform the requested actions everywhere', async () => {
-          await authorizer.renouncePermissions(ACTIONS, WHERE, { from: granter });
+        it('still can perform the requested action everywhere', async () => {
+          await authorizer.renouncePermission(ACTION_1, WHERE_1, { from: granter });
 
           expect(await authorizer.canPerform(ACTION_1, granter, EVERYWHERE)).to.be.true;
-          expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.true;
+          expect(await authorizer.canPerform(ACTION_1, granter, WHERE_2)).to.be.true;
         });
       });
     });
   });
 
-  describe('renouncePermissionsGlobally', () => {
+  describe('renouncePermissionGlobally', () => {
     context('when the sender does not have the permission granted', () => {
-      it('ignores the request and still cannot perform the requested actions everywhere', async () => {
-        await expect(authorizer.renouncePermissionsGlobally(ACTIONS, { from: granter })).not.to.be.reverted;
+      it('ignores the request and still cannot perform the requested action everywhere', async () => {
+        await expect(authorizer.renouncePermissionGlobally(ACTION_1, { from: granter })).not.to.be.reverted;
 
         expect(await authorizer.canPerform(ACTION_1, granter, EVERYWHERE)).to.be.false;
-        expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.false;
       });
 
-      it('ignores the request and still cannot perform the requested actions in any specific contract', async () => {
-        await expect(authorizer.renouncePermissionsGlobally(ACTIONS, { from: granter })).not.to.be.reverted;
+      it('ignores the request and still cannot perform the requested action in any specific contract', async () => {
+        await expect(authorizer.renouncePermissionGlobally(ACTION_1, { from: granter })).not.to.be.reverted;
 
         expect(await authorizer.canPerform(ACTION_1, granter, NOT_WHERE)).to.be.false;
-        expect(await authorizer.canPerform(ACTION_2, granter, NOT_WHERE)).to.be.false;
+        expect(await authorizer.canPerform(ACTION_1, granter, WHERE_2)).to.be.false;
       });
     });
 
     context('when the sender has the permission granted', () => {
       context('when the sender has the permission granted for a specific contract', () => {
-        sharedBeforeEach('grant permissions', async () => {
-          await authorizer.grantPermissions(ACTIONS, granter, WHERE, { from: root });
+        sharedBeforeEach('grants the permission', async () => {
+          await authorizer.grantPermission(ACTION_1, granter, WHERE_1, { from: root });
         });
 
-        it('still can perform the requested actions for the requested contracts', async () => {
-          await authorizer.renouncePermissionsGlobally(ACTIONS, { from: granter });
+        it('still can perform the requested action for the requested contract', async () => {
+          await authorizer.renouncePermissionGlobally(ACTION_1, { from: granter });
 
           expect(await authorizer.canPerform(ACTION_1, granter, WHERE_1)).to.be.true;
-          expect(await authorizer.canPerform(ACTION_2, granter, WHERE_2)).to.be.true;
         });
 
-        it('still cannot perform the requested actions everywhere', async () => {
-          await authorizer.renouncePermissionsGlobally(ACTIONS, { from: granter });
+        it('still cannot perform the requested action everywhere', async () => {
+          await authorizer.renouncePermissionGlobally(ACTION_1, { from: granter });
 
           expect(await authorizer.canPerform(ACTION_1, granter, EVERYWHERE)).to.be.false;
           expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.false;
@@ -1329,22 +1290,22 @@ describe('TimelockAuthorizer', () => {
       });
 
       context('when the sender has the permission granted globally', () => {
-        sharedBeforeEach('grant permissions', async () => {
-          await authorizer.grantPermissionsGlobally(ACTIONS, granter, { from: root });
+        sharedBeforeEach('grants the permission', async () => {
+          await authorizer.grantPermissionGlobally(ACTION_1, granter, { from: root });
         });
 
         it('revokes the requested permissions everywhere', async () => {
-          await authorizer.renouncePermissionsGlobally(ACTIONS, { from: granter });
+          await authorizer.renouncePermissionGlobally(ACTION_1, { from: granter });
 
           expect(await authorizer.canPerform(ACTION_1, granter, EVERYWHERE)).to.be.false;
-          expect(await authorizer.canPerform(ACTION_2, granter, EVERYWHERE)).to.be.false;
+          expect(await authorizer.canPerform(ACTION_1, granter, WHERE_2)).to.be.false;
         });
 
-        it('still cannot perform the requested actions in any specific contract', async () => {
-          await authorizer.renouncePermissionsGlobally(ACTIONS, { from: granter });
+        it('still cannot perform the requested action in any specific contract', async () => {
+          await authorizer.renouncePermissionGlobally(ACTION_1, { from: granter });
 
           expect(await authorizer.canPerform(ACTION_1, granter, NOT_WHERE)).to.be.false;
-          expect(await authorizer.canPerform(ACTION_2, granter, NOT_WHERE)).to.be.false;
+          expect(await authorizer.canPerform(ACTION_1, granter, WHERE_2)).to.be.false;
         });
       });
     });
@@ -1385,7 +1346,7 @@ describe('TimelockAuthorizer', () => {
 
           context('when the sender has permission for the requested contract', () => {
             sharedBeforeEach('grant permission', async () => {
-              await authorizer.grantPermissions(action, granter, authenticatedContract, { from: root });
+              await authorizer.grantPermission(action, granter, authenticatedContract, { from: root });
             });
 
             context('when there is a delay set', () => {
@@ -1538,7 +1499,7 @@ describe('TimelockAuthorizer', () => {
 
           context('when the sender has permissions for another contract', () => {
             sharedBeforeEach('grant permission', async () => {
-              await authorizer.grantPermissions(action, granter, anotherAuthenticatedContract, { from: root });
+              await authorizer.grantPermission(action, granter, anotherAuthenticatedContract, { from: root });
             });
 
             it('reverts', async () => {
@@ -1550,7 +1511,7 @@ describe('TimelockAuthorizer', () => {
         context('when the sender has permissions for another action', () => {
           sharedBeforeEach('grant permission', async () => {
             action = await actionId(authenticatedContract, 'secondProtectedFunction');
-            await authorizer.grantPermissions(action, granter, authenticatedContract, { from: root });
+            await authorizer.grantPermission(action, granter, authenticatedContract, { from: root });
           });
 
           it('reverts', async () => {
@@ -1599,7 +1560,7 @@ describe('TimelockAuthorizer', () => {
 
       const protectedFunctionAction = await actionId(authenticatedContract, 'protectedFunction');
       await authorizer.scheduleAndExecuteDelayChange(protectedFunctionAction, delay, { from: root });
-      await authorizer.grantPermissions(protectedFunctionAction, granter, authenticatedContract, { from: root });
+      await authorizer.grantPermission(protectedFunctionAction, granter, authenticatedContract, { from: root });
     });
 
     const schedule = async (): Promise<number> => {
@@ -1746,7 +1707,7 @@ describe('TimelockAuthorizer', () => {
 
       const protectedFunctionAction = await actionId(authenticatedContract, 'protectedFunction');
       await authorizer.scheduleAndExecuteDelayChange(protectedFunctionAction, delay, { from: root });
-      await authorizer.grantPermissions(protectedFunctionAction, granter, authenticatedContract, { from: root });
+      await authorizer.grantPermission(protectedFunctionAction, granter, authenticatedContract, { from: root });
     });
 
     const schedule = async (): Promise<number> => {

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -237,53 +237,50 @@ export default class TimelockAuthorizer {
     return this.with(params).removeRevoker(this.toAddress(account), this.toAddress(wheres));
   }
 
-  async grantPermissions(
-    actions: NAry<string>,
+  async grantPermission(
+    action: string,
     account: Account,
-    wheres: NAry<Account>,
+    where: Account,
     params?: TxParams
   ): Promise<ContractTransaction> {
-    return this.with(params).grantPermissions(this.toList(actions), this.toAddress(account), this.toAddresses(wheres));
+    return this.with(params).grantPermission(action, this.toAddress(account), this.toAddress(where));
   }
 
-  async revokePermissions(
-    actions: NAry<string>,
+  async revokePermission(
+    action: string,
     account: Account,
-    wheres: NAry<Account>,
+    where: Account,
     params?: TxParams
   ): Promise<ContractTransaction> {
-    return this.with(params).revokePermissions(this.toList(actions), this.toAddress(account), this.toAddresses(wheres));
+    return this.with(params).revokePermission(action, this.toAddress(account), this.toAddress(where));
   }
 
-  async renouncePermissions(
-    actions: NAry<string>,
-    wheres: NAry<Account>,
+  async renouncePermission(
+    action: string,
+    where: Account,
     params?: TxParams
   ): Promise<ContractTransaction> {
-    return this.with(params).renouncePermissions(this.toList(actions), this.toAddresses(wheres));
+    return this.with(params).renouncePermissions(action, this.toAddress(where));
   }
 
-  async grantPermissionsGlobally(
-    actions: NAry<string>,
-    account: Account,
-    params?: TxParams
-  ): Promise<ContractTransaction> {
-    const wheres = this.toList(actions).map(() => TimelockAuthorizer.EVERYWHERE);
-    return this.with(params).grantPermissions(this.toList(actions), this.toAddress(account), wheres);
-  }
-
-  async revokePermissionsGlobally(
-    actions: NAry<string>,
+  async grantPermissionGlobally(
+    action: string,
     account: Account,
     params?: TxParams
   ): Promise<ContractTransaction> {
-    const wheres = this.toList(actions).map(() => TimelockAuthorizer.EVERYWHERE);
-    return this.with(params).revokePermissions(this.toList(actions), this.toAddress(account), wheres);
+    return this.with(params).grantPermission(action, this.toAddress(account), TimelockAuthorizer.EVERYWHERE);
   }
 
-  async renouncePermissionsGlobally(actions: NAry<string>, params: TxParams): Promise<ContractTransaction> {
-    const wheres = this.toList(actions).map(() => TimelockAuthorizer.EVERYWHERE);
-    return this.with(params).renouncePermissions(this.toList(actions), wheres);
+  async revokePermissionGlobally(
+    action: string,
+    account: Account,
+    params?: TxParams
+  ): Promise<ContractTransaction> {
+    return this.with(params).revokePermission(action, this.toAddress(account), TimelockAuthorizer.EVERYWHERE);
+  }
+
+  async renouncePermissionGlobally(action: string, params: TxParams): Promise<ContractTransaction> {
+    return this.with(params).renouncePermissions(action, TimelockAuthorizer.EVERYWHERE);
   }
 
   async scheduleAndExecuteDelayChange(action: string, delay: number, params?: TxParams): Promise<void> {

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -255,32 +255,20 @@ export default class TimelockAuthorizer {
     return this.with(params).revokePermission(action, this.toAddress(account), this.toAddress(where));
   }
 
-  async renouncePermission(
-    action: string,
-    where: Account,
-    params?: TxParams
-  ): Promise<ContractTransaction> {
-    return this.with(params).renouncePermissions(action, this.toAddress(where));
+  async renouncePermission(action: string, where: Account, params?: TxParams): Promise<ContractTransaction> {
+    return this.with(params).renouncePermission(action, this.toAddress(where));
   }
 
-  async grantPermissionGlobally(
-    action: string,
-    account: Account,
-    params?: TxParams
-  ): Promise<ContractTransaction> {
+  async grantPermissionGlobally(action: string, account: Account, params?: TxParams): Promise<ContractTransaction> {
     return this.with(params).grantPermission(action, this.toAddress(account), TimelockAuthorizer.EVERYWHERE);
   }
 
-  async revokePermissionGlobally(
-    action: string,
-    account: Account,
-    params?: TxParams
-  ): Promise<ContractTransaction> {
+  async revokePermissionGlobally(action: string, account: Account, params?: TxParams): Promise<ContractTransaction> {
     return this.with(params).revokePermission(action, this.toAddress(account), TimelockAuthorizer.EVERYWHERE);
   }
 
   async renouncePermissionGlobally(action: string, params: TxParams): Promise<ContractTransaction> {
-    return this.with(params).renouncePermissions(action, TimelockAuthorizer.EVERYWHERE);
+    return this.with(params).renouncePermission(action, TimelockAuthorizer.EVERYWHERE);
   }
 
   async scheduleAndExecuteDelayChange(action: string, delay: number, params?: TxParams): Promise<void> {

--- a/pvt/helpers/src/models/pools/base/BasePool.ts
+++ b/pvt/helpers/src/models/pools/base/BasePool.ts
@@ -202,13 +202,15 @@ export default class BasePool {
   private async grantPausePermissions(): Promise<void> {
     const pauseAction = await actionId(this.instance, 'pause');
     const unpauseAction = await actionId(this.instance, 'unpause');
-    await this.vault.grantPermissionsGlobally([pauseAction, unpauseAction]);
+    await this.vault.grantPermissionGlobally(pauseAction);
+    await this.vault.grantPermissionGlobally(unpauseAction);
   }
 
   private async grantRecoveryPermissions(grantee: SignerWithAddress): Promise<void> {
     const enableRecoveryAction = await actionId(this.instance, 'enableRecoveryMode');
     const disableRecoveryAction = await actionId(this.instance, 'disableRecoveryMode');
-    await this.vault.grantPermissionsGlobally([enableRecoveryAction, disableRecoveryAction], grantee);
+    await this.vault.grantPermissionGlobally(enableRecoveryAction, grantee);
+    await this.vault.grantPermissionGlobally(disableRecoveryAction, grantee);
   }
 
   private async getSigner(from?: SignerWithAddress): Promise<SignerWithAddress> {

--- a/pvt/helpers/src/models/pools/linear/LinearPool.ts
+++ b/pvt/helpers/src/models/pools/linear/LinearPool.ts
@@ -197,7 +197,8 @@ export default class LinearPool extends BasePool {
   async pause(): Promise<void> {
     const pauseAction = await actionId(this.instance, 'pause');
     const unpauseAction = await actionId(this.instance, 'unpause');
-    await this.vault.grantPermissionsGlobally([pauseAction, unpauseAction]);
+    await this.vault.grantPermissionGlobally(pauseAction);
+    await this.vault.grantPermissionGlobally(unpauseAction);
     await this.instance.pause();
   }
 }

--- a/pvt/helpers/src/models/vault/Vault.ts
+++ b/pvt/helpers/src/models/vault/Vault.ts
@@ -244,7 +244,7 @@ export default class Vault {
     const feesCollector = await this.getFeesCollector();
 
     if (this.authorizer && this.admin) {
-      await this.grantPermissionsGlobally([await actionId(feesCollector, 'setSwapFeePercentage')], this.admin);
+      await this.grantPermissionGlobally(await actionId(feesCollector, 'setSwapFeePercentage'), this.admin);
     }
 
     const sender = from || this.admin;
@@ -259,7 +259,7 @@ export default class Vault {
     const feesCollector = await this.getFeesCollector();
 
     if (this.authorizer && this.admin) {
-      await this.grantPermissionsGlobally([await actionId(feesCollector, 'setFlashLoanFeePercentage')], this.admin);
+      await this.grantPermissionGlobally(await actionId(feesCollector, 'setFlashLoanFeePercentage'), this.admin);
     }
 
     const sender = from || this.admin;
@@ -275,22 +275,22 @@ export default class Vault {
 
     await this.authorizer
       .connect(this.admin)
-      .grantPermissions([actionId(feeProvider, 'setFeeTypePercentage')], this.admin.address, [feeProvider.address]);
+      .grantPermission(actionId(feeProvider, 'setFeeTypePercentage'), this.admin.address, feeProvider.address);
 
-    await this.authorizer.connect(this.admin).grantPermissions(
-      ['setSwapFeePercentage', 'setFlashLoanFeePercentage'].map((fn) => actionId(feeCollector, fn)),
-      feeProvider.address,
-      [feeCollector.address, feeCollector.address]
-    );
+    await this.authorizer
+      .connect(this.admin)
+      .grantPermission(actionId(feeCollector, 'setSwapFeePercentage'), feeProvider.address, feeCollector.address);
+    await this.authorizer
+      .connect(this.admin)
+      .grantPermission(actionId(feeCollector, 'setFlashLoanFeePercentage'), feeProvider.address, feeCollector.address);
 
     await feeProvider.connect(this.admin).setFeeTypePercentage(feeType, bn(value));
   }
 
-  async grantPermissionsGlobally(actionIds: string[], to?: Account): Promise<ContractTransaction> {
+  async grantPermissionGlobally(actionId: string, to?: Account): Promise<ContractTransaction> {
     if (!this.authorizer || !this.admin) throw Error("Missing Vault's authorizer or admin instance");
     if (!to) to = await this._defaultSender();
-    const wheres = actionIds.map(() => ANY_ADDRESS);
-    return this.authorizer.connect(this.admin).grantPermissions(actionIds, TypesConverter.toAddress(to), wheres);
+    return this.authorizer.connect(this.admin).grantPermission(actionId, TypesConverter.toAddress(to), ANY_ADDRESS);
   }
 
   async setRelayerApproval(user: SignerWithAddress, relayer: Account, approval: boolean): Promise<ContractTransaction> {
@@ -308,11 +308,11 @@ export default class Vault {
   }
 
   async setAuthorizer(newAuthorizer: Account): Promise<ContractTransaction> {
-    // Needed to suppress lint warning. grantPermissionsGlobally will fail if there is no authorizer or admin
+    // Needed to suppress lint warning. grantPermissionGlobally will fail if there is no authorizer or admin
     const admin = this.admin ?? ZERO_ADDRESS;
 
     const action = await actionId(this.instance, 'setAuthorizer');
-    await this.grantPermissionsGlobally([action], admin);
+    await this.grantPermissionGlobally(action, admin);
 
     return this.instance.connect(admin).setAuthorizer(TypesConverter.toAddress(newAuthorizer));
   }


### PR DESCRIPTION
<!-- If this is deployment-related, please go the the Preview tab and select the appropriate sub-template. -->
<!-- Otherwise, delete everything before #Description -->

# Description

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

Many functions in Authorizer expect some higher level form of batching (e.g. via Gnosis Safe plugins). It doesn't make sense for `grantPermissions`, `revokePermissions`, and `renouncePermissions` to behave differently, and the need to craft arrays and keep them in sync makes calling it harder.

This PR removes batching from the following functions--`grantPermissions`, `revokePermissions`, and `renouncePermissions`--and adjust tests accordingly.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [x] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

Closes #2321

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
