### PR TITLE
Batch Relayer: make deployable

### DIFF
--- a/pkg/standalone-utils/contracts/relayer/CompoundV2Wrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/CompoundV2Wrapping.sol
@@ -33,7 +33,7 @@ abstract contract CompoundV2Wrapping is IBaseRelayerLibrary {
         uint256 outputReference
     ) external payable {
         IERC20 mainToken = IERC20(wrappedToken.underlying());
-        amount = _resolveAmountPullTokenAndApproveSpender(mainToken, wrappedToken, amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(mainToken, address(wrappedToken), amount, sender);
 
         // The `mint` function deposits `amount` underlying tokens and transfers cTokens to the caller.
         // It returns an error code, where zero indicates success. Other error codes can be found here:

--- a/pkg/standalone-utils/contracts/relayer/CompoundV2Wrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/CompoundV2Wrapping.sol
@@ -33,7 +33,7 @@ abstract contract CompoundV2Wrapping is IBaseRelayerLibrary {
         uint256 outputReference
     ) external payable {
         IERC20 mainToken = IERC20(wrappedToken.underlying());
-        amount = _resolveAmountPullAndApproveToken(mainToken, wrappedToken, amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(mainToken, wrappedToken, amount, sender);
 
         // The `mint` function deposits `amount` underlying tokens and transfers cTokens to the caller.
         // It returns an error code, where zero indicates success. Other error codes can be found here:

--- a/pkg/standalone-utils/contracts/relayer/ERC4626Wrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/ERC4626Wrapping.sol
@@ -34,7 +34,7 @@ abstract contract ERC4626Wrapping is IBaseRelayerLibrary {
     ) external payable {
         IERC20 underlying = IERC20(wrappedToken.asset());
 
-        amount = _resolveAmountPullAndApproveToken(underlying, wrappedToken, amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(underlying, wrappedToken, amount, sender);
 
         uint256 result = wrappedToken.deposit(amount, recipient);
 

--- a/pkg/standalone-utils/contracts/relayer/ERC4626Wrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/ERC4626Wrapping.sol
@@ -34,7 +34,7 @@ abstract contract ERC4626Wrapping is IBaseRelayerLibrary {
     ) external payable {
         IERC20 underlying = IERC20(wrappedToken.asset());
 
-        amount = _resolveAmountPullTokenAndApproveSpender(underlying, wrappedToken, amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(underlying, address(wrappedToken), amount, sender);
 
         uint256 result = wrappedToken.deposit(amount, recipient);
 

--- a/pkg/standalone-utils/contracts/relayer/ERC4626Wrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/ERC4626Wrapping.sol
@@ -16,10 +16,6 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/solidity-utils/misc/IERC4626.sol";
-import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
-
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
 
 import "./IBaseRelayerLibrary.sol";
 
@@ -29,9 +25,6 @@ import "./IBaseRelayerLibrary.sol";
  * @dev All functions must be payable so they can be called from a multicall involving ETH
  */
 abstract contract ERC4626Wrapping is IBaseRelayerLibrary {
-    using Address for address payable;
-    using SafeERC20 for IERC20;
-
     function wrapERC4626(
         IERC4626 wrappedToken,
         address sender,
@@ -39,25 +32,13 @@ abstract contract ERC4626Wrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
-
         IERC20 underlying = IERC20(wrappedToken.asset());
 
-        // The wrap caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, underlying, amount);
-        }
+        amount = _resolveAmountPullAndApproveToken(underlying, wrappedToken, amount, sender);
 
-        underlying.safeApprove(address(wrappedToken), amount);
         uint256 result = wrappedToken.deposit(amount, recipient);
 
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, result);
-        }
+        _setChainedReference(outputReference, result);
     }
 
     function unwrapERC4626(
@@ -67,21 +48,10 @@ abstract contract ERC4626Wrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
-
-        // The unwrap caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, wrappedToken, amount);
-        }
+        amount = _resolveAmountAndPullToken(wrappedToken, amount, sender);
 
         uint256 result = wrappedToken.redeem(amount, recipient, address(this));
 
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, result);
-        }
+        _setChainedReference(outputReference, result);
     }
 }

--- a/pkg/standalone-utils/contracts/relayer/EulerWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/EulerWrapping.sol
@@ -38,7 +38,7 @@ abstract contract EulerWrapping is IBaseRelayerLibrary {
     ) external payable {
         IERC20 underlying = IERC20(wrappedToken.underlyingAsset());
 
-        amount = _resolveAmountPullAndApproveToken(underlying, IERC20(address(eulerProtocol)), amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(underlying, IERC20(address(eulerProtocol)), amount, sender);
 
         // Deposit MainToken into EulerToken
         // 0 for the Euler primary account

--- a/pkg/standalone-utils/contracts/relayer/EulerWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/EulerWrapping.sol
@@ -16,11 +16,6 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IEulerToken.sol";
-import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
-
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
-import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 
 import "./IBaseRelayerLibrary.sol";
 
@@ -30,10 +25,6 @@ import "./IBaseRelayerLibrary.sol";
  * @dev All functions must be payable so they can be called from a multicall involving ETH
  */
 abstract contract EulerWrapping is IBaseRelayerLibrary {
-    using Address for address payable;
-    using SafeERC20 for IERC20;
-    using FixedPoint for uint256;
-
     //solhint-disable-next-line private-vars-leading-underscore
     uint256 private constant MAX_UINT256 = type(uint256).max;
 
@@ -45,20 +36,11 @@ abstract contract EulerWrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
-
         IERC20 underlying = IERC20(wrappedToken.underlyingAsset());
 
-        // The wrap caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, underlying, amount);
-        }
+        amount = _resolveAmountPullAndApproveToken(underlying, IERC20(address(eulerProtocol)), amount, sender);
 
-        underlying.safeApprove(eulerProtocol, amount);
+        //underlying.safeApprove(eulerProtocol, amount);
 
         // Deposit MainToken into EulerToken
         // 0 for the Euler primary account
@@ -66,13 +48,7 @@ abstract contract EulerWrapping is IBaseRelayerLibrary {
 
         uint256 receivedWrappedAmount = wrappedToken.balanceOf(address(this));
 
-        if (recipient != address(this)) {
-            IERC20(wrappedToken).safeTransfer(recipient, receivedWrappedAmount);
-        }
-
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, receivedWrappedAmount);
-        }
+        _transferAndSetChainedReference(wrappedToken, recipient, receivedWrappedAmount, outputReference);
     }
 
     function unwrapEuler(
@@ -82,18 +58,7 @@ abstract contract EulerWrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
-
-        // The unwrap caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, wrappedToken, amount);
-        }
-
-        IERC20 mainToken = IERC20(wrappedToken.underlyingAsset());
+        amount = _resolveAmountAndPullToken(wrappedToken, amount, sender);
 
         // Euler offers two ways to withdraw:
         //     1. Calculate mainTokenOut via wrappedToken.convertBalanceToUnderlying(wrappedTokenAmount)
@@ -102,14 +67,9 @@ abstract contract EulerWrapping is IBaseRelayerLibrary {
         // The 0 argument is for the Euler primary account
         wrappedToken.withdraw(0, MAX_UINT256); //MAX_UINT256 forces option 2
 
+        IERC20 mainToken = IERC20(wrappedToken.underlyingAsset());
         uint256 withdrawnMainAmount = mainToken.balanceOf(address(this));
 
-        if (recipient != address(this)) {
-            mainToken.safeTransfer(recipient, withdrawnMainAmount);
-        }
-
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, withdrawnMainAmount);
-        }
+        _transferAndSetChainedReference(mainToken, recipient, withdrawnMainAmount, outputReference);
     }
 }

--- a/pkg/standalone-utils/contracts/relayer/EulerWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/EulerWrapping.sol
@@ -38,7 +38,7 @@ abstract contract EulerWrapping is IBaseRelayerLibrary {
     ) external payable {
         IERC20 underlying = IERC20(wrappedToken.underlyingAsset());
 
-        amount = _resolveAmountPullTokenAndApproveSpender(underlying, IERC20(address(eulerProtocol)), amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(underlying, eulerProtocol, amount, sender);
 
         // Deposit MainToken into EulerToken
         // 0 for the Euler primary account

--- a/pkg/standalone-utils/contracts/relayer/EulerWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/EulerWrapping.sol
@@ -40,8 +40,6 @@ abstract contract EulerWrapping is IBaseRelayerLibrary {
 
         amount = _resolveAmountPullAndApproveToken(underlying, IERC20(address(eulerProtocol)), amount, sender);
 
-        //underlying.safeApprove(eulerProtocol, amount);
-
         // Deposit MainToken into EulerToken
         // 0 for the Euler primary account
         wrappedToken.deposit(0, amount);

--- a/pkg/standalone-utils/contracts/relayer/GaugeActions.sol
+++ b/pkg/standalone-utils/contracts/relayer/GaugeActions.sol
@@ -48,7 +48,7 @@ abstract contract GaugeActions is IBaseRelayerLibrary {
         // We can query which token to pull and approve from the wrapper contract.
         IERC20 bptToken = gauge.lp_token();
 
-        amount = _resolveAmountPullTokenAndApproveSpender(bptToken, IERC20(address(gauge)), amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(bptToken, address(gauge), amount, sender);
 
         gauge.deposit(amount, recipient);
     }

--- a/pkg/standalone-utils/contracts/relayer/GaugeActions.sol
+++ b/pkg/standalone-utils/contracts/relayer/GaugeActions.sol
@@ -48,7 +48,7 @@ abstract contract GaugeActions is IBaseRelayerLibrary {
         // We can query which token to pull and approve from the wrapper contract.
         IERC20 bptToken = gauge.lp_token();
 
-        amount = _resolveAmountPullAndApproveToken(bptToken, IERC20(address(gauge)), amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(bptToken, IERC20(address(gauge)), amount, sender);
 
         gauge.deposit(amount, recipient);
     }

--- a/pkg/standalone-utils/contracts/relayer/GaugeActions.sol
+++ b/pkg/standalone-utils/contracts/relayer/GaugeActions.sol
@@ -17,9 +17,7 @@ pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IBalancerMinter.sol";
 import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IStakingLiquidityGauge.sol";
-import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
 
 import "./IBaseRelayerLibrary.sol";
@@ -29,7 +27,6 @@ import "./IBaseRelayerLibrary.sol";
  * @dev All functions must be payable so they can be called from a multicall involving ETH
  */
 abstract contract GaugeActions is IBaseRelayerLibrary {
-    using Address for address payable;
     using SafeERC20 for IERC20;
 
     IBalancerMinter private immutable _balancerMinter;
@@ -48,21 +45,11 @@ abstract contract GaugeActions is IBaseRelayerLibrary {
         address recipient,
         uint256 amount
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
-
         // We can query which token to pull and approve from the wrapper contract.
         IERC20 bptToken = gauge.lp_token();
 
-        // The deposit caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, bptToken, amount);
-        }
+        amount = _resolveAmountPullAndApproveToken(bptToken, IERC20(address(gauge)), amount, sender);
 
-        bptToken.safeApprove(address(gauge), amount);
         gauge.deposit(amount, recipient);
     }
 
@@ -72,16 +59,7 @@ abstract contract GaugeActions is IBaseRelayerLibrary {
         address recipient,
         uint256 amount
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
-
-        // The unwrap caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, IERC20(gauge), amount);
-        }
+        amount = _resolveAmountAndPullToken(gauge, amount, sender);
 
         // No approval is needed here, as the gauge Tokens are burned directly from the relayer's account.
         gauge.withdraw(amount);
@@ -98,9 +76,7 @@ abstract contract GaugeActions is IBaseRelayerLibrary {
     function gaugeMint(address[] calldata gauges, uint256 outputReference) external payable {
         uint256 balMinted = _balancerMinter.mintManyFor(gauges, msg.sender);
 
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, balMinted);
-        }
+        _setChainedReference(outputReference, balMinted);
     }
 
     function gaugeSetMinterApproval(

--- a/pkg/standalone-utils/contracts/relayer/GearboxWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/GearboxWrapping.sol
@@ -16,10 +16,6 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IGearboxDieselToken.sol";
-import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
-
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
 
 import "./IBaseRelayerLibrary.sol";
 
@@ -29,9 +25,6 @@ import "./IBaseRelayerLibrary.sol";
  * @dev All functions must be payable so they can be called from a multicall involving ETH
  */
 abstract contract GearboxWrapping is IBaseRelayerLibrary {
-    using Address for address payable;
-    using SafeERC20 for IERC20;
-
     function wrapGearbox(
         IGearboxDieselToken wrappedToken,
         address sender,
@@ -39,28 +32,16 @@ abstract contract GearboxWrapping is IBaseRelayerLibrary {
         uint256 mainAmount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(mainAmount)) {
-            mainAmount = _getChainedReferenceValue(mainAmount);
-        }
-
         IGearboxVault gearboxVault = IGearboxVault(wrappedToken.owner());
         IERC20 underlying = IERC20(gearboxVault.underlyingToken());
 
-        // The wrap caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, underlying, mainAmount);
-        }
-
         // Main Tokens are not deposited in the dieselToken address. Instead, they're deposited in a gearbox vault
-        underlying.safeApprove(address(gearboxVault), mainAmount);
+        mainAmount = _resolveAmountPullAndApproveToken(underlying, IERC20(address(gearboxVault)), mainAmount, sender);
+
         // The third argument of addLiquidity is a referral code, which will be always 0 for the relayer (no referee)
         gearboxVault.addLiquidity(mainAmount, recipient, 0);
 
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, gearboxVault.toDiesel(mainAmount));
-        }
+        _setChainedReference(outputReference, gearboxVault.toDiesel(mainAmount));
     }
 
     function unwrapGearbox(
@@ -70,24 +51,13 @@ abstract contract GearboxWrapping is IBaseRelayerLibrary {
         uint256 dieselAmount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(dieselAmount)) {
-            dieselAmount = _getChainedReferenceValue(dieselAmount);
-        }
-
-        // The unwrap caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, IERC20(address(wrappedToken)), dieselAmount);
-        }
+        dieselAmount = _resolveAmountAndPullToken(IERC20(address(wrappedToken)), dieselAmount, sender);
 
         // Main Tokens are not deposited in the dieselToken address. Instead, they're deposited in a gearbox vault.
         // Therefore, to remove liquidity, we withdraw tokens from the vault, and not from the wrapped token.
         IGearboxVault gearboxVault = IGearboxVault(wrappedToken.owner());
         gearboxVault.removeLiquidity(dieselAmount, recipient);
 
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, gearboxVault.fromDiesel(dieselAmount));
-        }
+        _setChainedReference(outputReference, gearboxVault.fromDiesel(dieselAmount));
     }
 }

--- a/pkg/standalone-utils/contracts/relayer/GearboxWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/GearboxWrapping.sol
@@ -36,7 +36,7 @@ abstract contract GearboxWrapping is IBaseRelayerLibrary {
         IERC20 underlying = IERC20(gearboxVault.underlyingToken());
 
         // Main Tokens are not deposited in the dieselToken address. Instead, they're deposited in a gearbox vault
-        mainAmount = _resolveAmountPullAndApproveToken(underlying, IERC20(address(gearboxVault)), mainAmount, sender);
+        mainAmount = _resolveAmountPullTokenAndApproveSpender(underlying, IERC20(address(gearboxVault)), mainAmount, sender);
 
         // The third argument of addLiquidity is a referral code, which will be always 0 for the relayer (no referee)
         gearboxVault.addLiquidity(mainAmount, recipient, 0);

--- a/pkg/standalone-utils/contracts/relayer/GearboxWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/GearboxWrapping.sol
@@ -36,7 +36,7 @@ abstract contract GearboxWrapping is IBaseRelayerLibrary {
         IERC20 underlying = IERC20(gearboxVault.underlyingToken());
 
         // Main Tokens are not deposited in the dieselToken address. Instead, they're deposited in a gearbox vault
-        mainAmount = _resolveAmountPullTokenAndApproveSpender(underlying, IERC20(address(gearboxVault)), mainAmount, sender);
+        mainAmount = _resolveAmountPullTokenAndApproveSpender(underlying, address(gearboxVault), mainAmount, sender);
 
         // The third argument of addLiquidity is a referral code, which will be always 0 for the relayer (no referee)
         gearboxVault.addLiquidity(mainAmount, recipient, 0);

--- a/pkg/standalone-utils/contracts/relayer/IBaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/relayer/IBaseRelayerLibrary.sol
@@ -61,13 +61,13 @@ abstract contract IBaseRelayerLibrary is AssetHelpers {
      */
     function _resolveAmountPullTokenAndApproveSpender(
         IERC20 token,
-        IERC20 wrappedToken,
+        address spender,
         uint256 amount,
         address sender
     ) internal returns (uint256 resolvedAmount) {
         resolvedAmount = _resolveAmountAndPullToken(token, amount, sender);
 
-        token.safeApprove(address(wrappedToken), resolvedAmount);
+        token.safeApprove(spender, resolvedAmount);
     }
 
     /**

--- a/pkg/standalone-utils/contracts/relayer/IBaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/relayer/IBaseRelayerLibrary.sol
@@ -115,7 +115,7 @@ abstract contract IBaseRelayerLibrary is AssetHelpers {
     }
 
     /**
-     * Check for a chained output reference, and encode the given `amount` if necessary.
+     * @dev Check for a chained output reference, and encode the given `amount` if necessary.
      * This is internal, since some wrappers call it independently.
      */
     function _setChainedReference(uint256 outputReference, uint256 amount) internal {

--- a/pkg/standalone-utils/contracts/relayer/IBaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/relayer/IBaseRelayerLibrary.sol
@@ -59,15 +59,15 @@ abstract contract IBaseRelayerLibrary is AssetHelpers {
      * pulls that amount of the `mainToken` to the relayer. Additionally, approve the `wrappedToken` to enable
      * wrapping operations.
      */
-    function _resolveAmountPullAndApproveToken(
-        IERC20 mainToken,
+    function _resolveAmountPullTokenAndApproveSpender(
+        IERC20 token,
         IERC20 wrappedToken,
         uint256 amount,
         address sender
     ) internal returns (uint256 resolvedAmount) {
-        resolvedAmount = _resolveAmountAndPullToken(mainToken, amount, sender);
+        resolvedAmount = _resolveAmountAndPullToken(token, amount, sender);
 
-        mainToken.safeApprove(address(wrappedToken), resolvedAmount);
+        token.safeApprove(address(wrappedToken), resolvedAmount);
     }
 
     /**

--- a/pkg/standalone-utils/contracts/relayer/IBaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/relayer/IBaseRelayerLibrary.sol
@@ -55,9 +55,10 @@ abstract contract IBaseRelayerLibrary is AssetHelpers {
     function _getChainedReferenceValue(uint256 ref) internal virtual returns (uint256);
 
     /**
-     * @dev This reuses `_resolveAmountAndPullToken` to adjust the `amount` if it is a chained reference, and
-     * pulls that amount of the `mainToken` to the relayer. Additionally, approve the `wrappedToken` to enable
-     * wrapping operations.
+     * @dev This reuses `_resolveAmountAndPullToken` to adjust the `amount` in case it is a chained reference,
+     * then pull that amount of `token` to the relayer. Additionally, it approves the `spender` to enable
+     * wrapping operations. The spender is usually a token, but could also be another kind of contract (e.g.,
+     * a protocol or gauge).
      */
     function _resolveAmountPullTokenAndApproveSpender(
         IERC20 token,
@@ -71,7 +72,7 @@ abstract contract IBaseRelayerLibrary is AssetHelpers {
     }
 
     /**
-     * @dev Extract the `amount` (if it is a chained reference), and pull that amount of the `token` to
+     * @dev Extract the `amount` (if it is a chained reference), and pull that amount of `token` to
      * this contract.
      */
     function _resolveAmountAndPullToken(

--- a/pkg/standalone-utils/contracts/relayer/LidoWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/LidoWrapping.sol
@@ -49,7 +49,7 @@ abstract contract LidoWrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        amount = _resolveAmountPullAndApproveToken(_stETH, IERC20(address(_wstETH)), amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(_stETH, IERC20(address(_wstETH)), amount, sender);
 
         uint256 result = IwstETH(_wstETH).wrap(amount);
 

--- a/pkg/standalone-utils/contracts/relayer/LidoWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/LidoWrapping.sol
@@ -49,7 +49,7 @@ abstract contract LidoWrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        amount = _resolveAmountPullTokenAndApproveSpender(_stETH, IERC20(address(_wstETH)), amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(_stETH, address(_wstETH), amount, sender);
 
         uint256 result = IwstETH(_wstETH).wrap(amount);
 

--- a/pkg/standalone-utils/contracts/relayer/LidoWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/LidoWrapping.sol
@@ -17,10 +17,8 @@ pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IstETH.sol";
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IwstETH.sol";
-import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
 
 import "./IBaseRelayerLibrary.sol";
 
@@ -31,7 +29,6 @@ import "./IBaseRelayerLibrary.sol";
  */
 abstract contract LidoWrapping is IBaseRelayerLibrary {
     using Address for address payable;
-    using SafeERC20 for IERC20;
 
     IstETH private immutable _stETH;
     IwstETH private immutable _wstETH;
@@ -52,27 +49,11 @@ abstract contract LidoWrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
+        amount = _resolveAmountPullAndApproveToken(_stETH, IERC20(address(_wstETH)), amount, sender);
 
-        // The wrap caller is the implicit token sender, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, _stETH, amount);
-        }
-
-        IERC20(_stETH).safeApprove(address(_wstETH), amount);
         uint256 result = IwstETH(_wstETH).wrap(amount);
 
-        if (recipient != address(this)) {
-            IERC20(_wstETH).safeTransfer(recipient, result);
-        }
-
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, result);
-        }
+        _transferAndSetChainedReference(_wstETH, recipient, result, outputReference);
     }
 
     function unwrapWstETH(
@@ -81,27 +62,12 @@ abstract contract LidoWrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
-
-        // The unwrap caller is the implicit token sender, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, _wstETH, amount);
-        }
+        amount = _resolveAmountAndPullToken(_wstETH, amount, sender);
 
         // No approval is needed here, as wstETH is burned directly from the relayer's account
         uint256 result = _wstETH.unwrap(amount);
 
-        if (recipient != address(this)) {
-            IERC20(_stETH).safeTransfer(recipient, result);
-        }
-
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, result);
-        }
+        _transferAndSetChainedReference(_stETH, recipient, result, outputReference);
     }
 
     function stakeETH(
@@ -109,19 +75,11 @@ abstract contract LidoWrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
+        amount = _resolveAmount(amount);
 
         uint256 result = _stETH.submit{ value: amount }(address(this));
 
-        if (recipient != address(this)) {
-            IERC20(_stETH).safeTransfer(recipient, result);
-        }
-
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, result);
-        }
+        _transferAndSetChainedReference(_stETH, recipient, result, outputReference);
     }
 
     function stakeETHAndWrap(
@@ -129,9 +87,7 @@ abstract contract LidoWrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
+        amount = _resolveAmount(amount);
 
         // We must query this separately, since the wstETH contract doesn't return how much wstETH is minted.
         uint256 result = _wstETH.getWstETHByStETH(amount);
@@ -143,12 +99,6 @@ abstract contract LidoWrapping is IBaseRelayerLibrary {
         // this function would have already reverted during the call to `getWstETHByStETH`, preventing loss of funds.
         payable(address(_wstETH)).sendValue(amount);
 
-        if (recipient != address(this)) {
-            IERC20(_wstETH).safeTransfer(recipient, result);
-        }
-
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, result);
-        }
+        _transferAndSetChainedReference(_wstETH, recipient, result, outputReference);
     }
 }

--- a/pkg/standalone-utils/contracts/relayer/ReaperWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/ReaperWrapping.sol
@@ -53,7 +53,7 @@ abstract contract ReaperWrapping is IBaseRelayerLibrary {
     ) external payable {
         IERC20 underlyingToken = IERC20(vaultToken.token());
 
-        amount = _resolveAmountPullTokenAndApproveSpender(underlyingToken, vaultToken, amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(underlyingToken, address(vaultToken), amount, sender);
 
         // Deposit the tokens into the vault
         vaultToken.deposit(amount);

--- a/pkg/standalone-utils/contracts/relayer/ReaperWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/ReaperWrapping.sol
@@ -53,7 +53,7 @@ abstract contract ReaperWrapping is IBaseRelayerLibrary {
     ) external payable {
         IERC20 underlyingToken = IERC20(vaultToken.token());
 
-        amount = _resolveAmountPullAndApproveToken(underlyingToken, vaultToken, amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(underlyingToken, vaultToken, amount, sender);
 
         // Deposit the tokens into the vault
         vaultToken.deposit(amount);

--- a/pkg/standalone-utils/contracts/relayer/ReaperWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/ReaperWrapping.sol
@@ -15,9 +15,6 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
-
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IReaperTokenVault.sol";
 
 import "./IBaseRelayerLibrary.sol";
@@ -28,9 +25,6 @@ import "./IBaseRelayerLibrary.sol";
  * @dev All functions must be payable so that it can be called as part of a multicall involving ETH
  */
 abstract contract ReaperWrapping is IBaseRelayerLibrary {
-    using Address for address payable;
-    using SafeERC20 for IERC20;
-
     function unwrapReaperVaultToken(
         IReaperTokenVault vaultToken,
         address sender,
@@ -38,31 +32,16 @@ abstract contract ReaperWrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
-
-        // The unwrap caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, vaultToken, amount);
-        }
-
-        IERC20 underlyingToken = IERC20(vaultToken.token());
+        amount = _resolveAmountAndPullToken(vaultToken, amount, sender);
 
         // Burn the rf shares and receive the underlying token.
         vaultToken.withdraw(amount);
 
+        IERC20 underlyingToken = IERC20(vaultToken.token());
         // Determine the amount of underlying returned for the shares burned.
         uint256 withdrawnAmount = underlyingToken.balanceOf(address(this));
 
-        // Send the shares to the recipient
-        underlyingToken.safeTransfer(recipient, withdrawnAmount);
-
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, withdrawnAmount);
-        }
+        _transferAndSetChainedReference(underlyingToken, recipient, withdrawnAmount, outputReference);
     }
 
     function wrapReaperVaultToken(
@@ -72,21 +51,9 @@ abstract contract ReaperWrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
-
         IERC20 underlyingToken = IERC20(vaultToken.token());
 
-        // The wrap caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, underlyingToken, amount);
-        }
-
-        // Approve the vault token to spend the amount specified in the wrap
-        underlyingToken.safeApprove(address(vaultToken), amount);
+        amount = _resolveAmountPullAndApproveToken(underlyingToken, vaultToken, amount, sender);
 
         // Deposit the tokens into the vault
         vaultToken.deposit(amount);
@@ -94,11 +61,6 @@ abstract contract ReaperWrapping is IBaseRelayerLibrary {
         // Determine the amount of shares gained from depositing
         uint256 sharesGained = vaultToken.balanceOf(address(this));
 
-        // Send the shares to the recipient
-        IERC20(vaultToken).safeTransfer(recipient, sharesGained);
-
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, sharesGained);
-        }
+        _transferAndSetChainedReference(vaultToken, recipient, sharesGained, outputReference);
     }
 }

--- a/pkg/standalone-utils/contracts/relayer/SiloWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/SiloWrapping.sol
@@ -38,7 +38,7 @@ abstract contract SiloWrapping is IBaseRelayerLibrary {
         // Initialize the corresponding Silo (Liquidity Pool)
         ISilo silo = wrappedToken.silo();
 
-        amount = _resolveAmountPullAndApproveToken(underlyingToken, IERC20(address(silo)), amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(underlyingToken, IERC20(address(silo)), amount, sender);
 
         // the collateralOnly param is set to false because we want to receive interest bearing shareTokens
         (, uint256 result) = silo.depositFor(address(underlyingToken), recipient, amount, false);

--- a/pkg/standalone-utils/contracts/relayer/SiloWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/SiloWrapping.sol
@@ -38,7 +38,7 @@ abstract contract SiloWrapping is IBaseRelayerLibrary {
         // Initialize the corresponding Silo (Liquidity Pool)
         ISilo silo = wrappedToken.silo();
 
-        amount = _resolveAmountPullTokenAndApproveSpender(underlyingToken, IERC20(address(silo)), amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(underlyingToken, address(silo), amount, sender);
 
         // the collateralOnly param is set to false because we want to receive interest bearing shareTokens
         (, uint256 result) = silo.depositFor(address(underlyingToken), recipient, amount, false);

--- a/pkg/standalone-utils/contracts/relayer/SiloWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/SiloWrapping.sol
@@ -17,10 +17,6 @@ pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/ISilo.sol";
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IShareToken.sol";
-import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
-
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
 
 import "./IBaseRelayerLibrary.sol";
 
@@ -30,9 +26,6 @@ import "./IBaseRelayerLibrary.sol";
  * @dev All functions must be payable so they can be called from a multicall involving ETH
  */
 abstract contract SiloWrapping is IBaseRelayerLibrary {
-    using Address for address payable;
-    using SafeERC20 for IERC20;
-
     function wrapShareToken(
         IShareToken wrappedToken,
         address sender,
@@ -40,30 +33,17 @@ abstract contract SiloWrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
-
         // Initialize the token we will be wrapping (underlying asset of shareToken)
         IERC20 underlyingToken = IERC20(wrappedToken.asset());
         // Initialize the corresponding Silo (Liquidity Pool)
         ISilo silo = wrappedToken.silo();
 
-        // The wrap caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, underlyingToken, amount);
-        }
-
-        underlyingToken.safeApprove(address(silo), amount);
+        amount = _resolveAmountPullAndApproveToken(underlyingToken, IERC20(address(silo)), amount, sender);
 
         // the collateralOnly param is set to false because we want to receive interest bearing shareTokens
         (, uint256 result) = silo.depositFor(address(underlyingToken), recipient, amount, false);
 
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, result);
-        }
+        _setChainedReference(outputReference, result);
     }
 
     function unwrapShareToken(
@@ -73,20 +53,11 @@ abstract contract SiloWrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
-        // Initialize the token we will be withdrawing
-        IERC20 underlyingToken = IERC20(wrappedToken.asset());
+        amount = _resolveAmountAndPullToken(wrappedToken, amount, sender);
+
         // Initialize the corresponding Silo (Liquidity Pool)
         ISilo silo = wrappedToken.silo();
-
-        // The wrap caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first them pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, wrappedToken, amount);
-        }
+        IERC20 underlyingToken = IERC20(wrappedToken.asset());
 
         // No approval is needed here, as the shareTokens are burned directly from the relayer's account.
         // Setting the amount to type(uint256).max informs Silo that we'd like to redeem all the relayer's shares.
@@ -95,12 +66,6 @@ abstract contract SiloWrapping is IBaseRelayerLibrary {
 
         uint256 result = underlyingToken.balanceOf(address(this));
 
-        if (recipient != address(this)) {
-            underlyingToken.safeTransfer(recipient, result);
-        }
-
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, result);
-        }
+        _transferAndSetChainedReference(underlyingToken, recipient, result, outputReference);
     }
 }

--- a/pkg/standalone-utils/contracts/relayer/TetuWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/TetuWrapping.sol
@@ -34,7 +34,7 @@ abstract contract TetuWrapping is IBaseRelayerLibrary {
     ) external payable {
         IERC20 underlying = IERC20(wrappedToken.underlying());
 
-        amount = _resolveAmountPullTokenAndApproveSpender(underlying, wrappedToken, amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(underlying, address(wrappedToken), amount, sender);
 
         wrappedToken.deposit(amount);
         uint256 receivedWrappedAmount = wrappedToken.balanceOf(address(this));

--- a/pkg/standalone-utils/contracts/relayer/TetuWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/TetuWrapping.sol
@@ -34,7 +34,7 @@ abstract contract TetuWrapping is IBaseRelayerLibrary {
     ) external payable {
         IERC20 underlying = IERC20(wrappedToken.underlying());
 
-        amount = _resolveAmountPullAndApproveToken(underlying, wrappedToken, amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(underlying, wrappedToken, amount, sender);
 
         wrappedToken.deposit(amount);
         uint256 receivedWrappedAmount = wrappedToken.balanceOf(address(this));

--- a/pkg/standalone-utils/contracts/relayer/TetuWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/TetuWrapping.sol
@@ -16,11 +16,7 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/ITetuSmartVault.sol";
-import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
-import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 import "./IBaseRelayerLibrary.sol";
 
 /**
@@ -29,10 +25,6 @@ import "./IBaseRelayerLibrary.sol";
  * @dev All functions must be payable so they can be called from a multicall involving ETH
  */
 abstract contract TetuWrapping is IBaseRelayerLibrary {
-    using Address for address payable;
-    using SafeERC20 for IERC20;
-    using FixedPoint for uint256;
-
     function wrapTetu(
         ITetuSmartVault wrappedToken,
         address sender,
@@ -40,30 +32,14 @@ abstract contract TetuWrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
-
         IERC20 underlying = IERC20(wrappedToken.underlying());
 
-        // The wrap caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, underlying, amount);
-        }
+        amount = _resolveAmountPullAndApproveToken(underlying, wrappedToken, amount, sender);
 
-        underlying.safeApprove(address(wrappedToken), amount);
         wrappedToken.deposit(amount);
         uint256 receivedWrappedAmount = wrappedToken.balanceOf(address(this));
 
-        if (recipient != address(this)) {
-            IERC20(wrappedToken).safeTransfer(recipient, receivedWrappedAmount);
-        }
-
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, receivedWrappedAmount);
-        }
+        _transferAndSetChainedReference(wrappedToken, recipient, receivedWrappedAmount, outputReference);
     }
 
     function unwrapTetu(
@@ -73,27 +49,12 @@ abstract contract TetuWrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
-
-        // The unwrap caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, wrappedToken, amount);
-        }
+        amount = _resolveAmountAndPullToken(wrappedToken, amount, sender);
 
         IERC20 mainToken = IERC20(wrappedToken.underlying());
         wrappedToken.withdraw(amount);
         uint256 withdrawnMainAmount = mainToken.balanceOf(address(this));
 
-        if (recipient != address(this)) {
-            mainToken.safeTransfer(recipient, withdrawnMainAmount);
-        }
-
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, withdrawnMainAmount);
-        }
+        _transferAndSetChainedReference(mainToken, recipient, withdrawnMainAmount, outputReference);
     }
 }

--- a/pkg/standalone-utils/contracts/relayer/UnbuttonWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/UnbuttonWrapping.sol
@@ -15,11 +15,7 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "@balancer-labs/v2-interfaces/contracts/solidity-utils/openzeppelin/IERC20.sol";
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IUnbuttonToken.sol";
-
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
 
 import "./IBaseRelayerLibrary.sol";
 
@@ -34,9 +30,6 @@ import "./IBaseRelayerLibrary.sol";
  *      Learn more: https://github.com/buttonwood-protocol/button-wrappers/blob/main/contracts/UnbuttonToken.sol
  */
 abstract contract UnbuttonWrapping is IBaseRelayerLibrary {
-    using Address for address payable;
-    using SafeERC20 for IERC20;
-
     /// @param wrapperToken The address of the wrapper.
     /// @param sender The address of sender.
     /// @param sender The address of recepient.
@@ -49,25 +42,13 @@ abstract contract UnbuttonWrapping is IBaseRelayerLibrary {
         uint256 uAmount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(uAmount)) {
-            uAmount = _getChainedReferenceValue(uAmount);
-        }
-
         IERC20 underlyingToken = IERC20(wrapperToken.underlying());
 
-        // The wrap caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, underlyingToken, uAmount);
-        }
+        uAmount = _resolveAmountPullAndApproveToken(underlyingToken, wrapperToken, uAmount, sender);
 
-        underlyingToken.safeApprove(address(wrapperToken), uAmount);
         uint256 mintAmount = wrapperToken.depositFor(recipient, uAmount);
 
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, mintAmount);
-        }
+        _setChainedReference(outputReference, mintAmount);
     }
 
     /// @param wrapperToken The address of the wrapper.
@@ -82,21 +63,10 @@ abstract contract UnbuttonWrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
-
-        // The wrap caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first them pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, wrapperToken, amount);
-        }
+        amount = _resolveAmountAndPullToken(wrapperToken, amount, sender);
 
         uint256 withdrawnUAmount = wrapperToken.burnTo(recipient, amount);
 
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, withdrawnUAmount);
-        }
+        _setChainedReference(outputReference, withdrawnUAmount);
     }
 }

--- a/pkg/standalone-utils/contracts/relayer/UnbuttonWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/UnbuttonWrapping.sol
@@ -44,7 +44,7 @@ abstract contract UnbuttonWrapping is IBaseRelayerLibrary {
     ) external payable {
         IERC20 underlyingToken = IERC20(wrapperToken.underlying());
 
-        uAmount = _resolveAmountPullTokenAndApproveSpender(underlyingToken, wrapperToken, uAmount, sender);
+        uAmount = _resolveAmountPullTokenAndApproveSpender(underlyingToken, address(wrapperToken), uAmount, sender);
 
         uint256 mintAmount = wrapperToken.depositFor(recipient, uAmount);
 

--- a/pkg/standalone-utils/contracts/relayer/UnbuttonWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/UnbuttonWrapping.sol
@@ -44,7 +44,7 @@ abstract contract UnbuttonWrapping is IBaseRelayerLibrary {
     ) external payable {
         IERC20 underlyingToken = IERC20(wrapperToken.underlying());
 
-        uAmount = _resolveAmountPullAndApproveToken(underlyingToken, wrapperToken, uAmount, sender);
+        uAmount = _resolveAmountPullTokenAndApproveSpender(underlyingToken, wrapperToken, uAmount, sender);
 
         uint256 mintAmount = wrapperToken.depositFor(recipient, uAmount);
 

--- a/pkg/standalone-utils/contracts/relayer/YearnWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/YearnWrapping.sol
@@ -34,7 +34,7 @@ abstract contract YearnWrapping is IBaseRelayerLibrary {
     ) external payable {
         IERC20 underlying = IERC20(wrappedToken.token());
 
-        amount = _resolveAmountPullTokenAndApproveSpender(underlying, wrappedToken, amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(underlying, address(wrappedToken), amount, sender);
 
         uint256 receivedWrappedAmount = wrappedToken.deposit(amount, recipient);
 

--- a/pkg/standalone-utils/contracts/relayer/YearnWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/YearnWrapping.sol
@@ -34,7 +34,7 @@ abstract contract YearnWrapping is IBaseRelayerLibrary {
     ) external payable {
         IERC20 underlying = IERC20(wrappedToken.token());
 
-        amount = _resolveAmountPullAndApproveToken(underlying, wrappedToken, amount, sender);
+        amount = _resolveAmountPullTokenAndApproveSpender(underlying, wrappedToken, amount, sender);
 
         uint256 receivedWrappedAmount = wrappedToken.deposit(amount, recipient);
 

--- a/pkg/standalone-utils/contracts/relayer/YearnWrapping.sol
+++ b/pkg/standalone-utils/contracts/relayer/YearnWrapping.sol
@@ -16,10 +16,6 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IYearnTokenVault.sol";
-import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
-
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
 
 import "./IBaseRelayerLibrary.sol";
 
@@ -29,9 +25,6 @@ import "./IBaseRelayerLibrary.sol";
  * @dev All functions must be payable so they can be called from a multicall involving ETH
  */
 abstract contract YearnWrapping is IBaseRelayerLibrary {
-    using Address for address payable;
-    using SafeERC20 for IERC20;
-
     function wrapYearn(
         IYearnTokenVault wrappedToken,
         address sender,
@@ -39,24 +32,13 @@ abstract contract YearnWrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
         IERC20 underlying = IERC20(wrappedToken.token());
 
-        // The wrap caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, underlying, amount);
-        }
+        amount = _resolveAmountPullAndApproveToken(underlying, wrappedToken, amount, sender);
 
-        underlying.safeApprove(address(wrappedToken), amount);
         uint256 receivedWrappedAmount = wrappedToken.deposit(amount, recipient);
 
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, receivedWrappedAmount);
-        }
+        _setChainedReference(outputReference, receivedWrappedAmount);
     }
 
     function unwrapYearn(
@@ -66,21 +48,10 @@ abstract contract YearnWrapping is IBaseRelayerLibrary {
         uint256 amount,
         uint256 outputReference
     ) external payable {
-        if (_isChainedReference(amount)) {
-            amount = _getChainedReferenceValue(amount);
-        }
-
-        // The unwrap caller is the implicit sender of tokens, so if the goal is for the tokens
-        // to be sourced from outside the relayer, we must first pull them here.
-        if (sender != address(this)) {
-            require(sender == msg.sender, "Incorrect sender");
-            _pullToken(sender, IERC20(address(wrappedToken)), amount);
-        }
+        amount = _resolveAmountAndPullToken(IERC20(address(wrappedToken)), amount, sender);
 
         uint256 mainAmount = wrappedToken.withdraw(amount, recipient);
 
-        if (_isChainedReference(outputReference)) {
-            _setChainedReferenceValue(outputReference, mainAmount);
-        }
+        _setChainedReference(outputReference, mainAmount);
     }
 }


### PR DESCRIPTION
# Description

Turns out that adding 12 new protocols to the BatchRelayer took up a little bytecode: over 26k!

Luckily they are all very similar - and even already had a common base contract - so a lot of the code could be factored out.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

