### PR TITLE
Fix flaky test

### DIFF
--- a/pkg/solidity-utils/test/WordCodec.test.ts
+++ b/pkg/solidity-utils/test/WordCodec.test.ts
@@ -5,6 +5,7 @@ import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import { bn, negate } from '@balancer-labs/v2-helpers/src/numbers';
 import { random } from 'lodash';
 import { ONES_BYTES32, ZERO_BYTES32 } from '@balancer-labs/v2-helpers/src/constants';
+import { hexZeroPad } from 'ethers/lib/utils';
 
 describe('WordCodec', () => {
   let lib: Contract;
@@ -162,7 +163,7 @@ describe('WordCodec', () => {
   });
 
   describe('insert', () => {
-    const word = bn(random(2 ** 255));
+    const word = hexZeroPad(bn(random(2 ** 255)).toHexString(), 32);
 
     describe('unsigned', () => {
       it('reverts with zero bit length', async () => {


### PR DESCRIPTION
This fixes the test failure uncovered in https://github.com/balancer/balancer-v2-monorepo/pull/2347, which was due to a `bytes32` string not having sufficient leading zeroes if we were unlucky, leading to an encode error. We now properly pad the string to make it a valid `bytes32` value.