### PR TITLE
Remove `async` for `almostEqual` (array case).

### DIFF
--- a/pvt/common/setupTests.ts
+++ b/pvt/common/setupTests.ts
@@ -78,7 +78,7 @@ chai.use(function (chai, utils) {
   Assertion.addMethod('almostEqual', function (expectedValue: NAry<BigNumberish>, error?: BigNumberish) {
     if (Array.isArray(expectedValue)) {
       const actuals: BigNumberish[] = this._obj;
-      actuals.forEach(async (actual, i) => expectEqualWithError(actual, expectedValue[i], error));
+      actuals.forEach((actual, i) => expectEqualWithError(actual, expectedValue[i], error));
     } else {
       expectEqualWithError(this._obj, expectedValue, error);
     }
@@ -87,7 +87,7 @@ chai.use(function (chai, utils) {
   Assertion.addMethod('almostEqualFp', function (expectedValue: NAry<BigNumberish>, error?: BigNumberish) {
     if (Array.isArray(expectedValue)) {
       const actuals: BigNumberish[] = this._obj;
-      actuals.forEach(async (actual, i) => expectEqualWithError(actual, fp(expectedValue[i]), error));
+      actuals.forEach((actual, i) => expectEqualWithError(actual, fp(expectedValue[i]), error));
     } else {
       expectEqualWithError(this._obj, fp(expectedValue), error);
     }


### PR DESCRIPTION
# Description

This PR fixes `almostEqual` definition for arrays.
`expect(actualArray).to.be.almostEqual(expectedArray)` does not fail when it should without these changes.
Apparently we haven't used this feature in the codebase, but I found it useful for #2325.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A