### PR TITLE
Use create2 for pool factories

### DIFF
--- a/pkg/pool-stable/contracts/ComposableStablePoolFactory.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolFactory.sol
@@ -67,7 +67,8 @@ contract ComposableStablePoolFactory is IVersion, IPoolVersion, BasePoolFactory 
         uint256[] memory tokenRateCacheDurations,
         bool[] memory exemptFromYieldProtocolFeeFlags,
         uint256 swapFeePercentage,
-        address owner
+        address owner,
+        bytes32 salt
     ) external returns (ComposableStablePool) {
         (uint256 pauseWindowDuration, uint256 bufferPeriodDuration) = getPauseConfiguration();
         return
@@ -90,7 +91,8 @@ contract ComposableStablePoolFactory is IVersion, IPoolVersion, BasePoolFactory 
                             owner: owner,
                             version: getPoolVersion()
                         })
-                    )
+                    ),
+                    salt
                 )
             );
     }

--- a/pkg/pool-stable/test/ComposableStablePoolFactory.test.ts
+++ b/pkg/pool-stable/test/ComposableStablePoolFactory.test.ts
@@ -11,6 +11,7 @@ import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
 import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
 import { advanceTime, currentTimestamp, MONTH } from '@balancer-labs/v2-helpers/src/time';
+import { randomBytes } from 'ethers/lib/utils';
 
 describe('ComposableStablePoolFactory', function () {
   let vault: Vault, tokens: TokenList, factory: Contract;
@@ -76,7 +77,8 @@ describe('ComposableStablePoolFactory', function () {
       Array(tokens.length).fill(PRICE_RATE_CACHE_DURATION),
       protocolFeeExemptFlags,
       POOL_SWAP_FEE_PERCENTAGE,
-      owner.address
+      owner.address,
+      randomBytes(32)
     );
 
     const event = expectEvent.inReceipt(await receipt.wait(), 'PoolCreated');

--- a/pkg/pool-utils/contracts/factories/BasePoolFactory.sol
+++ b/pkg/pool-utils/contracts/factories/BasePoolFactory.sol
@@ -89,10 +89,10 @@ abstract contract BasePoolFactory is
         return _protocolFeeProvider;
     }
 
-    function _create(bytes memory constructorArgs) internal virtual override returns (address) {
+    function _create(bytes memory constructorArgs, bytes32 salt) internal virtual override returns (address) {
         _ensureEnabled();
 
-        address pool = super._create(constructorArgs);
+        address pool = super._create(constructorArgs, salt);
 
         _isPoolFromFactory[pool] = true;
 

--- a/pkg/pool-utils/contracts/test/MockPoolFactory.sol
+++ b/pkg/pool-utils/contracts/test/MockPoolFactory.sol
@@ -28,7 +28,7 @@ contract MockPoolFactory is BasePoolFactory {
     }
 
     function create() external returns (address) {
-        return _create("");
+        return _create("", "");
     }
 
     function getMaxPauseWindowDuration() external pure returns (uint256) {

--- a/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
@@ -49,7 +49,8 @@ contract WeightedPoolFactory is BasePoolFactory {
         uint256[] memory normalizedWeights,
         IRateProvider[] memory rateProviders,
         uint256 swapFeePercentage,
-        address owner
+        address owner,
+        bytes32 salt
     ) external returns (address) {
         (uint256 pauseWindowDuration, uint256 bufferPeriodDuration) = getPauseConfiguration();
 
@@ -70,7 +71,8 @@ contract WeightedPoolFactory is BasePoolFactory {
                     pauseWindowDuration,
                     bufferPeriodDuration,
                     owner
-                )
+                ),
+                salt
             );
     }
 }

--- a/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/lbp/LiquidityBootstrappingPoolFactory.sol
@@ -49,7 +49,8 @@ contract LiquidityBootstrappingPoolFactory is BasePoolFactory {
         uint256[] memory weights,
         uint256 swapFeePercentage,
         address owner,
-        bool swapEnabledOnStart
+        bool swapEnabledOnStart,
+        bytes32 salt
     ) external returns (address) {
         (uint256 pauseWindowDuration, uint256 bufferPeriodDuration) = getPauseConfiguration();
 
@@ -66,7 +67,8 @@ contract LiquidityBootstrappingPoolFactory is BasePoolFactory {
                     bufferPeriodDuration,
                     owner,
                     swapEnabledOnStart
-                )
+                ),
+                salt
             );
     }
 }

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
@@ -75,7 +75,8 @@ contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFact
     function create(
         ManagedPool.ManagedPoolParams memory params,
         ManagedPoolSettings.ManagedPoolSettingsParams memory settingsParams,
-        address owner
+        address owner,
+        bytes32 salt
     ) external returns (address pool) {
         (uint256 pauseWindowDuration, uint256 bufferPeriodDuration) = getPauseConfiguration();
 
@@ -88,6 +89,6 @@ contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFact
             version: getPoolVersion()
         });
 
-        return _create(abi.encode(params, configParams, settingsParams, owner));
+        return _create(abi.encode(params, configParams, settingsParams, owner), salt);
     }
 }

--- a/pkg/pool-weighted/test/LiquidityBootstrappingPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/LiquidityBootstrappingPoolFactory.test.ts
@@ -11,6 +11,7 @@ import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import { toNormalizedWeights } from '@balancer-labs/balancer-js';
 import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+import { randomBytes } from 'ethers/lib/utils';
 
 describe('LiquidityBootstrappingPoolFactory', function () {
   let tokens: TokenList;
@@ -40,7 +41,16 @@ describe('LiquidityBootstrappingPoolFactory', function () {
 
   async function createPool(swapEnabled = true): Promise<Contract> {
     const receipt = await (
-      await factory.create(NAME, SYMBOL, tokens.addresses, WEIGHTS, POOL_SWAP_FEE_PERCENTAGE, ZERO_ADDRESS, swapEnabled)
+      await factory.create(
+        NAME,
+        SYMBOL,
+        tokens.addresses,
+        WEIGHTS,
+        POOL_SWAP_FEE_PERCENTAGE,
+        ZERO_ADDRESS,
+        swapEnabled,
+        randomBytes(32)
+      )
     ).wait();
 
     const event = expectEvent.inReceipt(receipt, 'PoolCreated');

--- a/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
@@ -15,6 +15,7 @@ import { toNormalizedWeights } from '@balancer-labs/balancer-js';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { ManagedPoolParams } from '@balancer-labs/v2-helpers/src/models/pools/weighted/types';
 import { ProtocolFee } from '@balancer-labs/v2-helpers/src/models/vault/types';
+import { randomBytes } from 'ethers/lib/utils';
 
 describe('ManagedPoolFactory', function () {
   let tokens: TokenList;
@@ -94,7 +95,9 @@ describe('ManagedPoolFactory', function () {
       aumFeeId: ProtocolFee.AUM,
     };
 
-    const receipt = await (await factory.connect(manager).create(poolParams, settingsParams, manager.address)).wait();
+    const receipt = await (
+      await factory.connect(manager).create(poolParams, settingsParams, manager.address, randomBytes(32))
+    ).wait();
 
     const event = expectEvent.inReceipt(receipt, 'PoolCreated');
     return deployedAt('ManagedPool', event.args.pool);

--- a/pkg/pool-weighted/test/WeightedPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/WeightedPoolFactory.test.ts
@@ -13,6 +13,7 @@ import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import { toNormalizedWeights } from '@balancer-labs/balancer-js';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { randomBytes } from 'ethers/lib/utils';
 
 describe('WeightedPoolFactory', function () {
   let tokens: TokenList;
@@ -57,7 +58,8 @@ describe('WeightedPoolFactory', function () {
         WEIGHTS,
         rateProviders,
         POOL_SWAP_FEE_PERCENTAGE,
-        owner.address
+        owner.address,
+        randomBytes(32)
       )
     ).wait();
 

--- a/pkg/solidity-utils/contracts/helpers/BaseSplitCodeFactory.sol
+++ b/pkg/solidity-utils/contracts/helpers/BaseSplitCodeFactory.sol
@@ -165,15 +165,15 @@ abstract contract BaseSplitCodeFactory {
     }
 
     /**
-     * @dev Deploys a contract with constructor arguments. To create `constructorArgs`, call `abi.encode()` with the
-     * contract's constructor arguments, in order.
+     * @dev Deploys a contract with constructor arguments and a user-provided salt, using the create2 opcode.
+     * To create `constructorArgs`, call `abi.encode()` with the contract's constructor arguments, in order.
      */
-    function _create(bytes memory constructorArgs) internal virtual returns (address) {
+    function _create(bytes memory constructorArgs, bytes32 salt) internal virtual returns (address) {
         bytes memory creationCode = _getCreationCodeWithArgs(constructorArgs);
 
         address destination;
         assembly {
-            destination := create(0, add(creationCode, 32), mload(creationCode))
+            destination := create2(0, add(creationCode, 32), mload(creationCode), salt)
         }
 
         if (destination == address(0)) {

--- a/pkg/solidity-utils/contracts/test/MockSplitCodeFactory.sol
+++ b/pkg/solidity-utils/contracts/test/MockSplitCodeFactory.sol
@@ -36,8 +36,8 @@ contract MockSplitCodeFactory is BaseSplitCodeFactory {
         // solhint-disable-previous-line no-empty-blocks
     }
 
-    function create(bytes32 id) external returns (address) {
-        address destination = _create(abi.encode(id));
+    function create(bytes32 id, bytes32 salt) external returns (address) {
+        address destination = _create(abi.encode(id), salt);
         emit ContractCreated(destination);
 
         return destination;

--- a/pkg/solidity-utils/test/BaseSplitCodeFactory.test.ts
+++ b/pkg/solidity-utils/test/BaseSplitCodeFactory.test.ts
@@ -5,6 +5,9 @@ import { ethers } from 'hardhat';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { deploy, deployedAt, getArtifact } from '@balancer-labs/v2-helpers/src/contract';
 import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+import { ONES_BYTES32, ZERO_BYTES32 } from '@balancer-labs/v2-helpers/src/constants';
+import { takeSnapshot } from '@nomicfoundation/hardhat-network-helpers';
+import { randomBytes } from 'ethers/lib/utils';
 
 describe('BasePoolCodeFactory', function () {
   let factory: Contract;
@@ -34,13 +37,13 @@ describe('BasePoolCodeFactory', function () {
   });
 
   it('creates a contract', async () => {
-    const receipt = await (await factory.create(id)).wait();
+    const receipt = await (await factory.create(id, ZERO_BYTES32)).wait();
     expectEvent.inReceipt(receipt, 'ContractCreated');
   });
 
   context('when the creation reverts', () => {
     it('reverts and bubbles up revert reasons', async () => {
-      await expect(factory.create(INVALID_ID)).to.be.revertedWith('NON_ZERO_ID');
+      await expect(factory.create(INVALID_ID, ZERO_BYTES32)).to.be.revertedWith('NON_ZERO_ID');
     });
   });
 
@@ -48,7 +51,7 @@ describe('BasePoolCodeFactory', function () {
     let contract: string;
 
     sharedBeforeEach('create contract', async () => {
-      const receipt = await (await factory.create(id)).wait();
+      const receipt = await (await factory.create(id, ZERO_BYTES32)).wait();
       const event = expectEvent.inReceipt(receipt, 'ContractCreated');
 
       contract = event.args.destination;
@@ -60,9 +63,47 @@ describe('BasePoolCodeFactory', function () {
       expect(code).to.equal(artifact.deployedBytecode);
     });
 
+    it('cannot deploy twice with the same salt', async () => {
+      await expect(factory.create(id, ZERO_BYTES32)).to.be.reverted;
+    });
+
+    it('can deploy with a different salt', async () => {
+      await expect(factory.create(id, ONES_BYTES32)).to.not.be.reverted;
+    });
+
     it('passes constructor arguments correctly', async () => {
       const contractObject = await deployedAt('MockFactoryCreatedContract', contract);
       expect(await contractObject.getId()).to.equal(id);
+    });
+
+    it('generates the same address with the same salt and a different nonce', async () => {
+      // We need to deploy with a reference salt, then "rollback" to before this deployment,
+      // so that the address no longer has code (which would cause deployment to revert).
+      // Take a snapshot we can roll back to.
+      const snapshot = await takeSnapshot();
+
+      // Deploy with the reference salt and record the address.
+      let receipt = await (await factory.create(id, ONES_BYTES32)).wait();
+      let event = expectEvent.inReceipt(receipt, 'ContractCreated');
+
+      const targetAddress = event.args.destination;
+
+      // Roll back to before the deployment
+      await snapshot.restore();
+
+      // Deploy the same factory with random salts, to increase the nonce
+      receipt = await (await factory.create(id, randomBytes(32))).wait();
+      event = expectEvent.inReceipt(receipt, 'ContractCreated');
+      expect(event.args.destination).to.not.equal(targetAddress);
+
+      receipt = await (await factory.create(id, randomBytes(32))).wait();
+      event = expectEvent.inReceipt(receipt, 'ContractCreated');
+      expect(event.args.destination).to.not.equal(targetAddress);
+
+      // Use the same salt again; it should generate the same address
+      receipt = await (await factory.create(id, ONES_BYTES32)).wait();
+      event = expectEvent.inReceipt(receipt, 'ContractCreated');
+      expect(event.args.destination).to.equal(targetAddress);
     });
   });
 });

--- a/pkg/standalone-utils/contracts/test/MockRecoveryRateProviderPoolFactory.sol
+++ b/pkg/standalone-utils/contracts/test/MockRecoveryRateProviderPoolFactory.sol
@@ -35,7 +35,7 @@ contract MockRecoveryRateProviderPoolFactory is BasePoolFactory {
         // solhint-disable-previous-line no-empty-blocks
     }
 
-    function create(IRateProvider[] memory rateProviders) external returns (address) {
-        return _create(abi.encode(getVault(), rateProviders));
+    function create(IRateProvider[] memory rateProviders, bytes32 salt) external returns (address) {
+        return _create(abi.encode(getVault(), rateProviders), salt);
     }
 }

--- a/pkg/standalone-utils/test/PoolRecoveryHelper.test.ts
+++ b/pkg/standalone-utils/test/PoolRecoveryHelper.test.ts
@@ -9,6 +9,7 @@ import { randomAddress, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/const
 import { range } from 'lodash';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+import { randomBytes } from 'ethers/lib/utils';
 
 describe('PoolRecoveryHelper', function () {
   let vault: Vault;
@@ -113,8 +114,8 @@ describe('PoolRecoveryHelper', function () {
         )
       );
 
-      rateProvider = await deploy('MockRevertingRateProvider', { args: [] });
-      const receipt = await (await factories[1].create([ZERO_ADDRESS, rateProvider.address])).wait();
+      rateProvider = await deploy('MockRevertingRateProvider');
+      const receipt = await (await factories[1].create([ZERO_ADDRESS, rateProvider.address], randomBytes(32))).wait();
       const event = expectEvent.inReceipt(receipt, 'PoolCreated');
       pool = await deployedAt('MockRecoveryRateProviderPool', event.args.pool);
 

--- a/pvt/benchmarks/misc.ts
+++ b/pvt/benchmarks/misc.ts
@@ -7,7 +7,7 @@ import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
 import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { StablePoolEncoder, toNormalizedWeights, WeightedPoolEncoder } from '@balancer-labs/balancer-js';
-import { MAX_UINT256, ZERO_ADDRESS, MAX_WEIGHTED_TOKENS } from '@balancer-labs/v2-helpers/src/constants';
+import { MAX_UINT256, ZERO_ADDRESS, MAX_WEIGHTED_TOKENS, ZERO_BYTES32 } from '@balancer-labs/v2-helpers/src/constants';
 import { bn } from '@balancer-labs/v2-helpers/src/numbers';
 import { advanceTime, MONTH } from '@balancer-labs/v2-helpers/src/time';
 import { range } from 'lodash';
@@ -233,10 +233,12 @@ async function deployPoolFromFactory(
   let event;
 
   if (poolName == 'ManagedPool') {
-    receipt = await (await factory.connect(args.from).create(...args.parameters)).wait();
+    receipt = await (await factory.connect(args.from).create(...args.parameters, ZERO_BYTES32)).wait();
     event = receipt.events?.find((e) => e.event == 'PoolCreated');
   } else {
-    receipt = await (await factory.connect(args.from).create(name, symbol, ...args.parameters, ZERO_ADDRESS)).wait();
+    receipt = await (
+      await factory.connect(args.from).create(name, symbol, ...args.parameters, ZERO_ADDRESS, ZERO_BYTES32)
+    ).wait();
     event = receipt.events?.find((e) => e.event == 'PoolCreated');
   }
 

--- a/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
@@ -11,6 +11,7 @@ import { ManagedPoolParams, RawWeightedPoolDeployment, WeightedPoolDeployment, W
 import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { ProtocolFee } from '../../vault/types';
 import { MONTH } from '../../../time';
+import { randomBytes } from 'ethers/lib/utils';
 
 const NAME = 'Balancer Pool Token';
 const SYMBOL = 'BPT';
@@ -272,7 +273,8 @@ export default {
           weights,
           swapFeePercentage,
           owner,
-          swapEnabledOnStart
+          swapEnabledOnStart,
+          randomBytes(32)
         );
         const receipt = await tx.wait();
         const event = expectEvent.inReceipt(receipt, 'PoolCreated');
@@ -319,7 +321,7 @@ export default {
 
         const tx = await factory
           .connect(from || ZERO_ADDRESS)
-          .create(poolParams, settingsParams, from?.address || ZERO_ADDRESS);
+          .create(poolParams, settingsParams, from?.address || ZERO_ADDRESS, salt || randomBytes(32));
         const receipt = await tx.wait();
         const event = expectEvent.inReceipt(receipt, 'ManagedPoolCreated');
 
@@ -346,7 +348,8 @@ export default {
           weights,
           rateProviders,
           swapFeePercentage,
-          owner
+          owner,
+          randomBytes(32)
         );
         const receipt = await tx.wait();
         const event = expectEvent.inReceipt(receipt, 'PoolCreated');


### PR DESCRIPTION
# Description

Use create2 instead of create for pool factories. This eliminates dependence on the nonce, as the salt value can be chosen arbitrarily.

For reference:
The create opcode calculates the address based on the sender's address and transaction nonce:

`address = keccak256(rlp([sender_address,sender_nonce]))[12:]`

The create2 opcode calculates the address based on the sender's address, the initialization code of the contract (e.g., bytecode + construction arguments), and a salt:

`address = keccak256(0xff + sender_address + salt + keccak256(initialisation_code))[12:]`

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [X] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

