### PR TITLE
Add new expected collisions to .gitignore

### DIFF
--- a/pkg/deployments/.gitignore
+++ b/pkg/deployments/.gitignore
@@ -1,4 +1,5 @@
 action-ids/**/new-collisions.json
+action-ids/**/updated-expected-collisions.json
 
 # Deployment outputs on local test networks
 test.json


### PR DESCRIPTION
Follow-up to https://github.com/balancer/balancer-v2-monorepo/pull/2359. Keeping the old ignore rule in case someone still has these files in their filesystem.