### PR TITLE
Remove reentrancy guard on TimelockAuthorizer

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -22,7 +22,6 @@ import "@balancer-labs/v2-interfaces/contracts/vault/IAuthorizer.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/InputHelpers.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
 import "./TimelockExecutionHelper.sol";
 import "./TimelockAuthorizerManagement.sol";
 
@@ -47,9 +46,9 @@ import "./TimelockAuthorizerManagement.sol";
  *   target contract (where). This identifier is called `permissionId` and is computed as
  *   `keccak256(actionId, account, where)`.
  *
- * Note that the TimelockAuthorizer doesn't make use of reentrancy guards on the majority of external functions.
+ * Note that the TimelockAuthorizer doesn't use reentrancy guard on its external functions.
  * The only function which makes an external non-view call (and so could initate a reentrancy attack) is `execute`
- * which executes a scheduled execution and so this is the only protected function.
+ * which executes a scheduled execution and protected by Checks-Effects-Interactions pattern.
  * In fact a number of the TimelockAuthorizer's functions may only be called through a scheduled execution so reentrancy
  * is necessary in order to be able to call these.
  */

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -48,7 +48,7 @@ import "./TimelockAuthorizerManagement.sol";
  *
  * Note that the TimelockAuthorizer doesn't use reentrancy guard on its external functions.
  * The only function which makes an external non-view call (and so could initate a reentrancy attack) is `execute`
- * which executes a scheduled execution and protected by Checks-Effects-Interactions pattern.
+ * which executes a scheduled execution, protected by the Checks-Effects-Interactions pattern.
  * In fact a number of the TimelockAuthorizer's functions may only be called through a scheduled execution so reentrancy
  * is necessary in order to be able to call these.
  */

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
@@ -289,7 +289,7 @@ abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer {
 
         // Note that this is the only place in the entire contract we perform a non-view call to an external contract,
         // i.e. this is the only context in which this contract can be re-entered, and by this point we've already
-        // completed all state transitions. Which satisfies the requirements of the Checks-Effects-Interactions pattern.
+        // completed all state transitions (in other words, we follow the Checks-Effects-Interactions pattern).
         // This results in the scheduled execution being marked as 'executed' during its execution, but that should not
         // be an issue.
         result = _executionHelper.execute(scheduledExecution.where, scheduledExecution.data);

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
@@ -289,7 +289,7 @@ abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer {
 
         // Note that this is the only place in the entire contract we perform a non-view call to an external contract,
         // i.e. this is the only context in which this contract can be re-entered, and by this point we've already
-        // completed all state transitions. Which satisfies requirements of Checks-Effects-Interactions pattern.
+        // completed all state transitions. Which satisfies the requirements of the Checks-Effects-Interactions pattern.
         // This results in the scheduled execution being marked as 'executed' during its execution, but that should not
         // be an issue.
         result = _executionHelper.execute(scheduledExecution.where, scheduledExecution.data);

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
@@ -21,7 +21,6 @@ import "@balancer-labs/v2-interfaces/contracts/vault/IAuthorizer.sol";
 import "@balancer-labs/v2-interfaces/contracts/vault/ITimelockAuthorizer.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
-import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
 import "./TimelockExecutionHelper.sol";
 
 /**
@@ -34,7 +33,7 @@ import "./TimelockExecutionHelper.sol";
  *
  * See `TimelockAuthorizer`
  */
-abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer, ReentrancyGuard {
+abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer {
     using Address for address;
 
     // solhint-disable-next-line const-name-snakecase
@@ -270,7 +269,7 @@ abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer, Reentranc
     /**
      * @inheritdoc ITimelockAuthorizer
      */
-    function execute(uint256 scheduledExecutionId) external override nonReentrant returns (bytes memory result) {
+    function execute(uint256 scheduledExecutionId) external override returns (bytes memory result) {
         require(scheduledExecutionId < _scheduledExecutions.length, "ACTION_DOES_NOT_EXIST");
 
         ITimelockAuthorizer.ScheduledExecution storage scheduledExecution = _scheduledExecutions[scheduledExecutionId];
@@ -290,7 +289,7 @@ abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer, Reentranc
 
         // Note that this is the only place in the entire contract we perform a non-view call to an external contract,
         // i.e. this is the only context in which this contract can be re-entered, and by this point we've already
-        // completed all state transitions.
+        // completed all state transitions. Which satisfies requirements of Checks-Effects-Interactions pattern.
         // This results in the scheduled execution being marked as 'executed' during its execution, but that should not
         // be an issue.
         result = _executionHelper.execute(scheduledExecution.where, scheduledExecution.data);


### PR DESCRIPTION
<!-- If this is deployment-related, please go the the Preview tab and select the appropriate sub-template. -->
<!-- Otherwise, delete everything before #Description -->

# Description

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

This PR removes ReentrancyGuard from the TimelockAuthorizer's `execute` function because it is secured by check-effects-interactions pattern. Other functions of TimelockAuthrorizer do not make external calls.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
~~- [ ] Tests are included for all code paths (Does not apply)~~
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

Closes #2381

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
