### PR TITLE
Disallow no-op calls for grantPermission, revokePermission, reno…

### DIFF
--- a/pkg/pool-utils/test/NewBasePool.test.ts
+++ b/pkg/pool-utils/test/NewBasePool.test.ts
@@ -379,11 +379,17 @@ describe('NewBasePool', function () {
         sharedBeforeEach('grant permission', async () => {
           const pauseAction = await actionId(pool, 'pause');
           const unpauseAction = await actionId(pool, 'unpause');
-          await authorizer.connect(admin).grantPermission(unpauseAction, sender.address, ANY_ADDRESS);
-          await authorizer.connect(admin).grantPermission(pauseAction, sender.address, ANY_ADDRESS);
-          await authorizer
-            .connect(admin)
-            .grantPermission(await actionId(minimalPool, 'pause'), sender.address, ANY_ADDRESS);
+          if (!(await authorizer.hasPermission(unpauseAction, sender.address, ANY_ADDRESS))) {
+            await authorizer.connect(admin).grantPermission(unpauseAction, sender.address, ANY_ADDRESS);
+          }
+          if (!(await authorizer.hasPermission(pauseAction, sender.address, ANY_ADDRESS))) {
+            await authorizer.connect(admin).grantPermission(pauseAction, sender.address, ANY_ADDRESS);
+          }
+          if (!(await authorizer.hasPermission(await actionId(minimalPool, 'pause'), sender.address, ANY_ADDRESS))) {
+            await authorizer
+              .connect(admin)
+              .grantPermission(await actionId(minimalPool, 'pause'), sender.address, ANY_ADDRESS);
+          }
         });
 
         itCanPause();

--- a/pkg/standalone-utils/test/CompoundV2Wrapping.test.ts
+++ b/pkg/standalone-utils/test/CompoundV2Wrapping.test.ts
@@ -65,11 +65,7 @@ describe('CompoundV2Wrapping', function () {
         actionId(vault.instance, action)
       )
     );
-    await Promise.all(
-      relayerActionIds.map((action) => {
-        vault.grantPermissionGlobally(action, relayer);
-      })
-    );
+    await Promise.all(relayerActionIds.map((action) => vault.grantPermissionGlobally(action, relayer)));
 
     // Approve relayer by sender
     await vault.setRelayerApproval(senderUser, relayer, true);

--- a/pkg/standalone-utils/test/EulerWrapping.test.ts
+++ b/pkg/standalone-utils/test/EulerWrapping.test.ts
@@ -74,11 +74,7 @@ describe('EulerWrapping', function () {
       )
     );
 
-    await Promise.all(
-      relayerActionIds.map((action) => {
-        vault.grantPermissionGlobally(action, relayer);
-      })
-    );
+    await Promise.all(relayerActionIds.map((action) => vault.grantPermissionGlobally(action, relayer)));
 
     // Approve relayer by sender
     await vault.setRelayerApproval(senderUser, relayer, true);

--- a/pkg/standalone-utils/test/GearboxWrapping.test.ts
+++ b/pkg/standalone-utils/test/GearboxWrapping.test.ts
@@ -67,11 +67,7 @@ describe('GearboxWrapping', function () {
         actionId(vault.instance, action)
       )
     );
-    await Promise.all(
-      relayerActionIds.map((action) => {
-        vault.grantPermissionGlobally(action, relayer);
-      })
-    );
+    await Promise.all(relayerActionIds.map((action) => vault.grantPermissionGlobally(action, relayer)));
 
     // Approve relayer by sender
     await vault.setRelayerApproval(senderUser, relayer, true);

--- a/pkg/standalone-utils/test/LidoWrapping.test.ts
+++ b/pkg/standalone-utils/test/LidoWrapping.test.ts
@@ -67,11 +67,7 @@ describe('LidoWrapping', function () {
         actionId(vault.instance, action)
       )
     );
-    await Promise.all(
-      relayerActionIds.map((action) => {
-        return vault.grantPermissionGlobally(action, relayer.address);
-      })
-    );
+    await Promise.all(relayerActionIds.map((action) => vault.grantPermissionGlobally(action, relayer.address)));
 
     // Approve relayer by sender
     await vault.setRelayerApproval(senderUser, relayer, true);

--- a/pkg/standalone-utils/test/TetuWrapping.test.ts
+++ b/pkg/standalone-utils/test/TetuWrapping.test.ts
@@ -69,11 +69,7 @@ describe('TetuWrapping', function () {
         actionId(vault.instance, action)
       )
     );
-    await Promise.all(
-      relayerActionIds.map((action) => {
-        vault.grantPermissionGlobally(action, relayer);
-      })
-    );
+    await Promise.all(relayerActionIds.map((action) => vault.grantPermissionGlobally(action, relayer)));
 
     // Approve relayer by sender
     await vault.setRelayerApproval(senderUser, relayer, true);

--- a/pkg/standalone-utils/test/VaultActionsRelayer.setup.ts
+++ b/pkg/standalone-utils/test/VaultActionsRelayer.setup.ts
@@ -43,11 +43,7 @@ export async function setupRelayerEnvironment(): Promise<{
     )
   );
 
-  await Promise.all(
-    relayerActionIds.map((action) => {
-      vault.grantPermissionGlobally(action, relayer);
-    })
-  );
+  await Promise.all(relayerActionIds.map((action) => vault.grantPermissionGlobally(action, relayer)));
 
   // Approve relayer by sender
   await vault.setRelayerApproval(user, relayer, true);

--- a/pkg/standalone-utils/test/YearnWrapping.test.ts
+++ b/pkg/standalone-utils/test/YearnWrapping.test.ts
@@ -65,11 +65,8 @@ describe('YearnWrapping', function () {
         actionId(vault.instance, action)
       )
     );
-    await Promise.all(
-      relayerActionIds.map((action) => {
-        vault.grantPermissionGlobally(action, relayer);
-      })
-    );
+    await Promise.all(relayerActionIds.map((action) => vault.grantPermissionGlobally(action, relayer)));
+
 
     // Approve relayer by sender
     await vault.setRelayerApproval(senderUser, relayer, true);

--- a/pkg/standalone-utils/test/YearnWrapping.test.ts
+++ b/pkg/standalone-utils/test/YearnWrapping.test.ts
@@ -67,7 +67,6 @@ describe('YearnWrapping', function () {
     );
     await Promise.all(relayerActionIds.map((action) => vault.grantPermissionGlobally(action, relayer)));
 
-
     // Approve relayer by sender
     await vault.setRelayerApproval(senderUser, relayer, true);
   });

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -69,7 +69,9 @@ contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
     mapping(bytes32 => uint256) private _revokeDelays;
 
     // External permissions
+    // keccak256(abi.encodePacked(actionId, account, where)) -> isGranted
     mapping(bytes32 => bool) private _isPermissionGranted;
+    // actionId -> delay (in seconds)
     mapping(bytes32 => uint256) private _delaysPerActionId;
 
     constructor(
@@ -347,10 +349,11 @@ contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
         }
 
         bytes32 permission = getPermissionId(actionId, account, where);
-        if (!_isPermissionGranted[permission]) {
-            _isPermissionGranted[permission] = true;
-            emit PermissionGranted(actionId, account, where);
-        }
+
+        require(!_isPermissionGranted[permission], "PERMISSION_ALREADY_GRANTED");
+
+        _isPermissionGranted[permission] = true;
+        emit PermissionGranted(actionId, account, where);
     }
 
     /**
@@ -445,10 +448,11 @@ contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
         address where
     ) private {
         bytes32 permission = getPermissionId(actionId, account, where);
-        if (_isPermissionGranted[permission]) {
-            _isPermissionGranted[permission] = false;
-            emit PermissionRevoked(actionId, account, where);
-        }
+
+        require(_isPermissionGranted[permission], "PERMISSION_NOT_GRANTED");
+
+        _isPermissionGranted[permission] = false;
+        emit PermissionRevoked(actionId, account, where);
     }
 
     function _getDelayChangeExecutionDelay(uint256 currentDelay, uint256 newDelay) private pure returns (uint256) {

--- a/pkg/vault/test/ExitPool.test.ts
+++ b/pkg/vault/test/ExitPool.test.ts
@@ -297,7 +297,9 @@ describe('Exit Pool', () => {
             context('when the relayer is not whitelisted by the authorizer', () => {
               sharedBeforeEach('revoke permission from relayer', async () => {
                 const action = await actionId(vault, 'exitPool');
-                await authorizer.connect(admin).revokePermission(action, relayer.address, ANY_ADDRESS);
+                if (await authorizer.hasPermission(action, relayer.address, ANY_ADDRESS)) {
+                  await authorizer.connect(admin).revokePermission(action, relayer.address, ANY_ADDRESS);
+                }
               });
 
               context('when the relayer is allowed by the user', () => {

--- a/pkg/vault/test/JoinPool.test.ts
+++ b/pkg/vault/test/JoinPool.test.ts
@@ -271,7 +271,9 @@ describe('Join Pool', () => {
                 context('when the relayer is not whitelisted by the authorizer', () => {
                   sharedBeforeEach('revoke permission from relayer', async () => {
                     const action = await actionId(vault, 'joinPool');
-                    await authorizer.connect(admin).revokePermission(action, relayer.address, ANY_ADDRESS);
+                    if (await authorizer.hasPermission(action, relayer.address, ANY_ADDRESS)) {
+                      await authorizer.connect(admin).revokePermission(action, relayer.address, ANY_ADDRESS);
+                    }
                   });
 
                   context('when the relayer is allowed by the user', () => {

--- a/pkg/vault/test/Swaps.test.ts
+++ b/pkg/vault/test/Swaps.test.ts
@@ -597,8 +597,12 @@ describe('Swaps', () => {
                             sharedBeforeEach('revoke permission from relayer', async () => {
                               const single = await actionId(vault, 'swap');
                               const batch = await actionId(vault, 'batchSwap');
-                              await authorizer.connect(admin).revokePermission(single, other.address, ANY_ADDRESS);
-                              await authorizer.connect(admin).revokePermission(batch, other.address, ANY_ADDRESS);
+                              if (await authorizer.hasPermission(single, other.address, ANY_ADDRESS)) {
+                                await authorizer.connect(admin).revokePermission(single, other.address, ANY_ADDRESS);
+                              }
+                              if (await authorizer.hasPermission(batch, other.address, ANY_ADDRESS)) {
+                                await authorizer.connect(admin).revokePermission(batch, other.address, ANY_ADDRESS);
+                              }
                             });
 
                             context('when the relayer is allowed by the user', () => {
@@ -1080,8 +1084,12 @@ describe('Swaps', () => {
                             sharedBeforeEach('revoke permission from relayer', async () => {
                               const single = await actionId(vault, 'swap');
                               const batch = await actionId(vault, 'batchSwap');
-                              await authorizer.connect(admin).revokePermission(single, other.address, ANY_ADDRESS);
-                              await authorizer.connect(admin).revokePermission(batch, other.address, ANY_ADDRESS);
+                              if (await authorizer.hasPermission(single, other.address, ANY_ADDRESS)) {
+                                await authorizer.connect(admin).revokePermission(single, other.address, ANY_ADDRESS);
+                              }
+                              if (await authorizer.hasPermission(batch, other.address, ANY_ADDRESS)) {
+                                await authorizer.connect(admin).revokePermission(batch, other.address, ANY_ADDRESS);
+                              }
                             });
 
                             context('when the relayer is allowed by the user', () => {

--- a/pkg/vault/test/VaultAuthorization.test.ts
+++ b/pkg/vault/test/VaultAuthorization.test.ts
@@ -149,7 +149,9 @@ describe('VaultAuthorization', function () {
       context('when the sender is not allowed by the authorizer', () => {
         sharedBeforeEach('revoke permission for sender', async () => {
           const action = await actionId(vault, 'setRelayerApproval');
-          await authorizer.connect(admin).revokePermission(action, sender.address, ANY_ADDRESS);
+          if (await authorizer.hasPermission(action, sender.address, ANY_ADDRESS)) {
+            await authorizer.connect(admin).revokePermission(action, sender.address, ANY_ADDRESS);
+          }
         });
 
         context('when the sender is approved by the user', () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizerPermissions.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerPermissions.test.ts
@@ -793,6 +793,7 @@ describe('TimelockAuthorizer permissions', () => {
       });
 
       it('can be executed after the expected delay', async () => {
+        // Grant the permission so we can later revoke it
         await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: root });
         const id = await authorizer.scheduleRevokePermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
 

--- a/pkg/vault/test/authorizer/TimelockAuthorizerPermissions.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerPermissions.test.ts
@@ -817,6 +817,7 @@ describe('TimelockAuthorizer permissions', () => {
       });
 
       it('does not revoke any other permissions when executed', async () => {
+        // Grant the permission so we can later revoke it
         await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: root });
         const id = await authorizer.scheduleRevokePermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
 

--- a/pkg/vault/test/authorizer/TimelockAuthorizerPermissions.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerPermissions.test.ts
@@ -296,8 +296,6 @@ describe('TimelockAuthorizer permissions', () => {
         });
 
         context('when the target has the permission for a contract', () => {
-          sharedBeforeEach('grant a permission', async () => {});
-
           it('cannot grant the same permission twice', async () => {
             await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter });
             await expect(authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter })).to.revertedWith(

--- a/pkg/vault/test/authorizer/TimelockAuthorizerPermissions.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerPermissions.test.ts
@@ -104,6 +104,7 @@ describe('TimelockAuthorizer permissions', () => {
               });
             });
           });
+
           context('when granting the permission for everywhere', () => {
             it('grants the permission to perform the requested action everywhere', async () => {
               await authorizer.grantPermissionGlobally(ACTION_1, user, { from: getSender() });
@@ -137,31 +138,12 @@ describe('TimelockAuthorizer permissions', () => {
           sharedBeforeEach('grant a permission', async () => {
             await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() });
           });
-          context('when granting the permission for a contract', () => {
-            it('ignores the request and can still perform the action', async () => {
-              await expect(authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() })).not.to.reverted;
-
-              expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
-            });
-
-            it('does not grant the permission to perform the requested action everywhere', async () => {
-              await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() });
-
-              expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
-            });
-
-            it('does not grant the permission to perform the requested action for other contracts', async () => {
-              await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() });
-
-              expect(await authorizer.canPerform(ACTION_1, user, NOT_WHERE)).to.be.false;
-              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
-            });
-
-            it('does not emit an event', async () => {
-              const tx = await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() });
-              expectEvent.notEmitted(await tx.wait(), 'PermissionGranted');
-            });
+          it('cannot grant the permission twice', async () => {
+            await expect(authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() })).to.be.revertedWith(
+              'PERMISSION_ALREADY_GRANTED'
+            );
           });
+
           context('when granting the permission for everywhere', () => {
             it('grants permission to perform the requested action everywhere', async () => {
               await authorizer.grantPermissionGlobally(ACTION_1, user, { from: getSender() });
@@ -229,26 +211,11 @@ describe('TimelockAuthorizer permissions', () => {
               });
             });
           });
-          context('when granting the permission for everywhere', () => {
-            it('ignores the request and can still perform the requested action everywhere', async () => {
-              await expect(authorizer.grantPermissionGlobally(ACTION_1, user, { from: getSender() })).not.to.be
-                .reverted;
 
-              expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.true;
-            });
-
-            it('ignores the request and can still perform the requested action in any specific contract', async () => {
-              await expect(authorizer.grantPermissionGlobally(ACTION_1, user, { from: getSender() })).not.to.be
-                .reverted;
-
-              expect(await authorizer.canPerform(ACTION_1, user, NOT_WHERE)).to.be.true;
-              expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
-            });
-
-            it('does not emit an event', async () => {
-              const tx = await authorizer.grantPermissionGlobally(ACTION_1, user, { from: getSender() });
-              expectEvent.notEmitted(await tx.wait(), 'PermissionGrantedGlobally');
-            });
+          it('cannot grant the permision twice', async () => {
+            await expect(authorizer.grantPermissionGlobally(ACTION_1, user, { from: getSender() })).to.revertedWith(
+              'PERMISSION_ALREADY_GRANTED'
+            );
           });
         });
       }
@@ -329,33 +296,13 @@ describe('TimelockAuthorizer permissions', () => {
         });
 
         context('when the target has the permission for a contract', () => {
-          sharedBeforeEach('grant a permission', async () => {
+          sharedBeforeEach('grant a permission', async () => {});
+
+          it('cannot grant the same permission twice', async () => {
             await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter });
-          });
-          context('when granting the permission for a contract', () => {
-            it('ignores the request and can still perform the action', async () => {
-              await expect(authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter })).not.to.reverted;
-
-              expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
-            });
-
-            it('does not grant the permission to perform the requested action everywhere', async () => {
-              await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter });
-
-              expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
-            });
-
-            it('does not grant the permission to perform the requested action for other contracts', async () => {
-              await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter });
-
-              expect(await authorizer.canPerform(ACTION_1, user, NOT_WHERE)).to.be.false;
-              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
-            });
-
-            it('does not emit an event', async () => {
-              const tx = await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter });
-              expectEvent.notEmitted(await tx.wait(), 'PermissionGranted');
-            });
+            await expect(authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter })).to.revertedWith(
+              'PERMISSION_ALREADY_GRANTED'
+            );
           });
         });
 
@@ -573,25 +520,20 @@ describe('TimelockAuthorizer permissions', () => {
 
       function itRevokesPermissionCorrectly(getSender: () => SignerWithAddress) {
         context('when the user does not have the permission', () => {
-          it('ignores the request and cannot perform the requested action everywhere', async () => {
-            await expect(authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: getSender() })).not.to.be
-              .reverted;
+          it('cannot revoke the permission', async () => {
+            await expect(
+              authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: getSender() })
+            ).to.be.revertedWith('PERMISSION_NOT_GRANTED');
+          });
 
+          it('cannot perform the requested action everywhere', async () => {
             expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
             expect(await authorizer.canPerform(ACTION_2, user, EVERYWHERE)).to.be.false;
           });
 
-          it('ignores the request and cannot perform the requested action in any specific contract', async () => {
-            await expect(authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: getSender() })).not.to.be
-              .reverted;
-
+          it('cannot perform the requested action in any specific contract', async () => {
             expect(await authorizer.canPerform(ACTION_1, user, NOT_WHERE)).to.be.false;
             expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
-          });
-
-          it('does not emit an event', async () => {
-            const tx = await authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: getSender() });
-            expectEvent.notEmitted(await tx.wait(), 'PermissionRevoked');
           });
         });
 
@@ -599,6 +541,7 @@ describe('TimelockAuthorizer permissions', () => {
           sharedBeforeEach('grants the permission', async () => {
             await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: root });
           });
+
           context('when revoking the permission for a contract', () => {
             it('revokes the requested permission for the requested contract', async () => {
               await authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: getSender() });
@@ -630,22 +573,19 @@ describe('TimelockAuthorizer permissions', () => {
           });
 
           context('when revoking the permission for a everywhere', () => {
-            it('still cannot perform the requested action everywhere', async () => {
-              await authorizer.revokePermissionGlobally(ACTION_1, user, { from: getSender() });
+            it('cannot revoke the permission', async () => {
+              await expect(
+                authorizer.revokePermissionGlobally(ACTION_1, user, { from: getSender() })
+              ).to.be.revertedWith('PERMISSION_NOT_GRANTED');
+            });
 
+            it('cannot perform the requested action everywhere', async () => {
               expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
               expect(await authorizer.canPerform(ACTION_2, user, EVERYWHERE)).to.be.false;
             });
 
-            it('still can perform the requested action for the previously granted permissions', async () => {
-              await authorizer.revokePermissionGlobally(ACTION_1, user, { from: getSender() });
-
+            it('can perform the requested action for the previously granted permissions', async () => {
               expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
-            });
-
-            it('does not emit an event', async () => {
-              const tx = await authorizer.revokePermissionGlobally(ACTION_1, user, { from: getSender() });
-              expectEvent.notEmitted(await tx.wait(), 'PermissionRevokedGlobally');
             });
           });
         });
@@ -654,25 +594,24 @@ describe('TimelockAuthorizer permissions', () => {
           sharedBeforeEach('grants the permissions', async () => {
             await authorizer.grantPermissionGlobally(ACTION_1, user, { from: root });
           });
-          context('when revoking the permission for a contract', () => {
-            it('still can perform the requested action for the requested contract', async () => {
-              await authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: getSender() });
 
+          context('when revoking the permission for a contract', () => {
+            it('cannot revoke the permission', async () => {
+              await expect(
+                authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: getSender() })
+              ).to.be.revertedWith('PERMISSION_NOT_GRANTED');
+            });
+
+            it('can perform the requested action for the requested contract', async () => {
               expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
               expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
             });
 
-            it('still can perform the requested action everywhere', async () => {
-              await authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: getSender() });
-
+            it('can perform the requested action everywhere', async () => {
               expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.true;
             });
-
-            it('does not emit an event', async () => {
-              const tx = await authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: getSender() });
-              expectEvent.notEmitted(await tx.wait(), 'PermissionRevoked');
-            });
           });
+
           context('when revoking the permission for a everywhere', () => {
             it('revokes the requested global permission and cannot perform the requested action everywhere', async () => {
               await authorizer.revokePermissionGlobally(ACTION_1, user, { from: getSender() });
@@ -725,25 +664,10 @@ describe('TimelockAuthorizer permissions', () => {
           );
         });
 
-        context('when the user does not have the permission', () => {
-          it('ignores the request and cannot perform the requested action everywhere', async () => {
-            await expect(authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: revoker })).not.to.be.reverted;
-
-            expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
-            expect(await authorizer.canPerform(ACTION_2, user, EVERYWHERE)).to.be.false;
-          });
-
-          it('ignores the request and cannot perform the requested action in any specific contract', async () => {
-            await expect(authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: revoker })).not.to.be.reverted;
-
-            expect(await authorizer.canPerform(ACTION_1, user, NOT_WHERE)).to.be.false;
-            expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
-          });
-
-          it('does not emit an event', async () => {
-            const tx = await authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: revoker });
-            expectEvent.notEmitted(await tx.wait(), 'PermissionRevoked');
-          });
+        it('cannot revoke the permission if it was not granted', async () => {
+          await expect(authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: root })).to.be.revertedWith(
+            'PERMISSION_NOT_GRANTED'
+          );
         });
 
         context('when the user has the permission for a contract', () => {
@@ -789,21 +713,20 @@ describe('TimelockAuthorizer permissions', () => {
 
           context('when revoking the permission for a contract', () => {
             it('still can perform the requested action for the requested contract', async () => {
-              await authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: revoker });
+              await expect(authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: revoker })).to.be.revertedWith(
+                'PERMISSION_NOT_GRANTED'
+              );
 
               expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
               expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
             });
 
             it('still can perform the requested action everywhere', async () => {
-              await authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: revoker });
+              await expect(authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: revoker })).to.be.revertedWith(
+                'PERMISSION_NOT_GRANTED'
+              );
 
               expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.true;
-            });
-
-            it('does not emit an event', async () => {
-              const tx = await authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: revoker });
-              expectEvent.notEmitted(await tx.wait(), 'PermissionRevoked');
             });
           });
         });
@@ -872,6 +795,7 @@ describe('TimelockAuthorizer permissions', () => {
       });
 
       it('can be executed after the expected delay', async () => {
+        await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: root });
         const id = await authorizer.scheduleRevokePermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
 
         await advanceTime(delay);
@@ -894,6 +818,7 @@ describe('TimelockAuthorizer permissions', () => {
       });
 
       it('does not revoke any other permissions when executed', async () => {
+        await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: root });
         const id = await authorizer.scheduleRevokePermission(ACTION_1, user, WHERE_1, [], { from: getSender() });
 
         await advanceTime(delay);
@@ -945,30 +870,34 @@ describe('TimelockAuthorizer permissions', () => {
     const delay = DAY;
     context('when the sender does not have the permission', () => {
       context('when renouncing the permission for a specific contract', () => {
-        it('ignores the request and still cannot perform the requested action everywhere', async () => {
-          await expect(authorizer.renouncePermission(ACTION_1, WHERE_1, { from: user })).not.to.be.reverted;
+        it('cannot renounce the permission if it was not granted', async () => {
+          await expect(authorizer.renouncePermission(ACTION_1, WHERE_1, { from: user })).to.be.revertedWith(
+            'PERMISSION_NOT_GRANTED'
+          );
+        });
 
+        it('cannot perform the requested action everywhere', async () => {
           expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
         });
 
-        it('ignores the request and still cannot perform the requested action in any specific contract', async () => {
-          await expect(authorizer.renouncePermission(ACTION_1, WHERE_1, { from: user })).not.to.be.reverted;
-
+        it('cannot perform the requested action in any specific contract', async () => {
           expect(await authorizer.canPerform(ACTION_1, user, NOT_WHERE)).to.be.false;
           expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
         });
       });
 
       context('when renouncing the permission for everywhere', () => {
-        it('ignores the request and still cannot perform the requested action everywhere', async () => {
-          await expect(authorizer.renouncePermissionGlobally(ACTION_1, { from: user })).not.to.be.reverted;
+        it('cannot renounce the permission if it was not granted', async () => {
+          await expect(authorizer.renouncePermissionGlobally(ACTION_1, { from: user })).to.be.revertedWith(
+            'PERMISSION_NOT_GRANTED'
+          );
+        });
 
+        it('cannot perform the requested action everywhere', async () => {
           expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
         });
 
-        it('ignores the request and still cannot perform the requested action in any specific contract', async () => {
-          await expect(authorizer.renouncePermissionGlobally(ACTION_1, { from: user })).not.to.be.reverted;
-
+        it('cannot perform the requested action in any specific contract', async () => {
           expect(await authorizer.canPerform(ACTION_1, user, NOT_WHERE)).to.be.false;
           expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.false;
         });
@@ -990,7 +919,7 @@ describe('TimelockAuthorizer permissions', () => {
           expect(await authorizer.canPerform(ACTION_2, user, WHERE_2)).to.be.false;
         });
 
-        it('still cannot perform the requested action everywhere', async () => {
+        it('cannot perform the requested action everywhere', async () => {
           await authorizer.renouncePermission(ACTION_1, WHERE_1, { from: user });
 
           expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
@@ -1012,16 +941,19 @@ describe('TimelockAuthorizer permissions', () => {
           expect(await authorizer.canPerform(ACTION_2, user, WHERE_2)).to.be.false;
         });
       });
-      context('when renouncing the permission for everywhere', () => {
-        it('still can perform the requested action for the requested contract', async () => {
-          await authorizer.renouncePermissionGlobally(ACTION_1, { from: user });
 
+      context('when renouncing the permission for everywhere', () => {
+        it('cannot renounce the permission if it was not granted', async () => {
+          await expect(authorizer.renouncePermissionGlobally(ACTION_1, { from: user })).to.be.revertedWith(
+            'PERMISSION_NOT_GRANTED'
+          );
+        });
+
+        it('can perform the requested action for the requested contract', async () => {
           expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
         });
 
-        it('still cannot perform the requested action everywhere', async () => {
-          await authorizer.renouncePermissionGlobally(ACTION_1, { from: user });
-
+        it('cannot perform the requested action everywhere', async () => {
           expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
           expect(await authorizer.canPerform(ACTION_2, user, EVERYWHERE)).to.be.false;
         });
@@ -1034,16 +966,18 @@ describe('TimelockAuthorizer permissions', () => {
       });
 
       context('when renouncing the permission for a specific contract', () => {
-        it('still can perform the requested actions for the requested contract', async () => {
-          await authorizer.renouncePermission(ACTION_1, WHERE_1, { from: user });
+        it('cannot renounce the permission if it was not granted', async () => {
+          await expect(authorizer.renouncePermission(ACTION_1, WHERE_1, { from: user })).to.be.revertedWith(
+            'PERMISSION_NOT_GRANTED'
+          );
+        });
 
+        it('can perform the requested actions for the requested contract', async () => {
           expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
           expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
         });
 
-        it('still can perform the requested action everywhere', async () => {
-          await authorizer.renouncePermission(ACTION_1, WHERE_1, { from: user });
-
+        it('can perform the requested action everywhere', async () => {
           expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.true;
           expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
         });

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -34,7 +34,7 @@ export default class TimelockAuthorizer {
     return this.instance.interface;
   }
 
-  async hasPermission(action: string, account: Account, where: Account): Promise<string> {
+  async hasPermission(action: string, account: Account, where: Account): Promise<boolean> {
     return this.instance.hasPermission(action, this.toAddress(account), this.toAddress(where));
   }
 

--- a/pvt/helpers/src/models/pools/base/BasePool.ts
+++ b/pvt/helpers/src/models/pools/base/BasePool.ts
@@ -202,15 +202,23 @@ export default class BasePool {
   private async grantPausePermissions(): Promise<void> {
     const pauseAction = await actionId(this.instance, 'pause');
     const unpauseAction = await actionId(this.instance, 'unpause');
-    await this.vault.grantPermissionGlobally(pauseAction);
-    await this.vault.grantPermissionGlobally(unpauseAction);
+    if (!(await this.vault.hasPermissionGlobally(pauseAction))) {
+      await this.vault.grantPermissionGlobally(pauseAction);
+    }
+    if (!(await this.vault.hasPermissionGlobally(unpauseAction))) {
+      await this.vault.grantPermissionGlobally(unpauseAction);
+    }
   }
 
   private async grantRecoveryPermissions(grantee: SignerWithAddress): Promise<void> {
     const enableRecoveryAction = await actionId(this.instance, 'enableRecoveryMode');
     const disableRecoveryAction = await actionId(this.instance, 'disableRecoveryMode');
-    await this.vault.grantPermissionGlobally(enableRecoveryAction, grantee);
-    await this.vault.grantPermissionGlobally(disableRecoveryAction, grantee);
+    if (!(await this.vault.hasPermissionGlobally(enableRecoveryAction, grantee))) {
+      await this.vault.grantPermissionGlobally(enableRecoveryAction, grantee);
+    }
+    if (!(await this.vault.hasPermissionGlobally(disableRecoveryAction, grantee))) {
+      await this.vault.grantPermissionGlobally(disableRecoveryAction, grantee);
+    }
   }
 
   private async getSigner(from?: SignerWithAddress): Promise<SignerWithAddress> {

--- a/pvt/helpers/src/models/pools/base/BasePool.ts
+++ b/pvt/helpers/src/models/pools/base/BasePool.ts
@@ -202,23 +202,15 @@ export default class BasePool {
   private async grantPausePermissions(): Promise<void> {
     const pauseAction = await actionId(this.instance, 'pause');
     const unpauseAction = await actionId(this.instance, 'unpause');
-    if (!(await this.vault.hasPermissionGlobally(pauseAction))) {
-      await this.vault.grantPermissionGlobally(pauseAction);
-    }
-    if (!(await this.vault.hasPermissionGlobally(unpauseAction))) {
-      await this.vault.grantPermissionGlobally(unpauseAction);
-    }
+    await this.vault.grantPermissionGloballyIfNeeded(pauseAction);
+    await this.vault.grantPermissionGloballyIfNeeded(unpauseAction);
   }
 
   private async grantRecoveryPermissions(grantee: SignerWithAddress): Promise<void> {
     const enableRecoveryAction = await actionId(this.instance, 'enableRecoveryMode');
     const disableRecoveryAction = await actionId(this.instance, 'disableRecoveryMode');
-    if (!(await this.vault.hasPermissionGlobally(enableRecoveryAction, grantee))) {
-      await this.vault.grantPermissionGlobally(enableRecoveryAction, grantee);
-    }
-    if (!(await this.vault.hasPermissionGlobally(disableRecoveryAction, grantee))) {
-      await this.vault.grantPermissionGlobally(disableRecoveryAction, grantee);
-    }
+    await this.vault.grantPermissionGloballyIfNeeded(enableRecoveryAction, grantee);
+    await this.vault.grantPermissionGloballyIfNeeded(disableRecoveryAction, grantee);
   }
 
   private async getSigner(from?: SignerWithAddress): Promise<SignerWithAddress> {

--- a/pvt/helpers/src/models/pools/linear/LinearPool.ts
+++ b/pvt/helpers/src/models/pools/linear/LinearPool.ts
@@ -197,8 +197,12 @@ export default class LinearPool extends BasePool {
   async pause(): Promise<void> {
     const pauseAction = await actionId(this.instance, 'pause');
     const unpauseAction = await actionId(this.instance, 'unpause');
-    await this.vault.grantPermissionGlobally(pauseAction);
-    await this.vault.grantPermissionGlobally(unpauseAction);
+    if (!(await this.vault.hasPermissionGlobally(pauseAction))) {
+      await this.vault.grantPermissionGlobally(pauseAction);
+    }
+    if (!(await this.vault.hasPermissionGlobally(unpauseAction))) {
+      await this.vault.grantPermissionGlobally(unpauseAction);
+    }
     await this.instance.pause();
   }
 }

--- a/pvt/helpers/src/models/pools/linear/LinearPool.ts
+++ b/pvt/helpers/src/models/pools/linear/LinearPool.ts
@@ -197,12 +197,8 @@ export default class LinearPool extends BasePool {
   async pause(): Promise<void> {
     const pauseAction = await actionId(this.instance, 'pause');
     const unpauseAction = await actionId(this.instance, 'unpause');
-    if (!(await this.vault.hasPermissionGlobally(pauseAction))) {
-      await this.vault.grantPermissionGlobally(pauseAction);
-    }
-    if (!(await this.vault.hasPermissionGlobally(unpauseAction))) {
-      await this.vault.grantPermissionGlobally(unpauseAction);
-    }
+    await this.vault.grantPermissionGloballyIfNeeded(pauseAction);
+    await this.vault.grantPermissionGloballyIfNeeded(unpauseAction);
     await this.instance.pause();
   }
 }


### PR DESCRIPTION
<!-- If this is deployment-related, please go the the Preview tab and select the appropriate sub-template. -->
<!-- Otherwise, delete everything before #Description -->

# Description

This pull request modifies the following functions of the TimelockAuthroizer:
* grantPermission
* revokePermission
* renouncePermission

Previously, these functions did not revert even if they did not modify any permission or make any changes. However, we have decided that no one should attempt to revoke or renounce a permission they do not have or grant permission to an account that already has it. Therefore, we now revert in these cases.

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [x] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

Closes #2379

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
