### PR TITLE
Revert on bad schedule data

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -310,12 +310,19 @@ contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
         // this scenario should be impossible: but this check is cheap so we enforce it here as well anyway.
         require(where != getTimelockExecutionHelper(), "ATTEMPTING_EXECUTION_HELPER_REENTRANCY");
 
-        bytes32 actionId = IAuthentication(where).getActionId(_decodeSelector(data));
+        // We require data to have a function selector
+        require(data.length >= 4, "DATA_TOO_SHORT");
+        // The bytes4 type is left-aligned and padded with zeros: we make use of that property to build the selector
+        bytes4 selector = bytes4(data[0]) | (bytes4(data[1]) >> 8) | (bytes4(data[2]) >> 16) | (bytes4(data[3]) >> 24);
+
+        bytes32 actionId = IAuthentication(where).getActionId(selector);
         require(hasPermission(actionId, msg.sender, where), "SENDER_DOES_NOT_HAVE_PERMISSION");
 
         uint256 delay = _delaysPerActionId[actionId];
         require(delay > 0, "DELAY_IS_NOT_SET");
 
+        // We do not check if `where` is a contract because it might not be upon
+        // scheduling but it may be deployed later.
         uint256 scheduledExecutionId = _scheduleWithDelay(where, data, delay, executors);
 
         emit ExecutionScheduled(actionId, scheduledExecutionId);
@@ -491,11 +498,5 @@ contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
     function _isDelayShorterThanSetAuthorizer(uint256 delay) private view returns (bool) {
         bytes32 setAuthorizerActionId = IAuthentication(getVault()).getActionId(IVault.setAuthorizer.selector);
         return delay <= _delaysPerActionId[setAuthorizerActionId];
-    }
-
-    function _decodeSelector(bytes memory data) internal pure returns (bytes4) {
-        // The bytes4 type is left-aligned and padded with zeros: we make use of that property to build the selector
-        if (data.length < 4) return bytes4(0);
-        return bytes4(data[0]) | (bytes4(data[1]) >> 8) | (bytes4(data[2]) >> 16) | (bytes4(data[3]) >> 24);
     }
 }

--- a/pkg/vault/test/authorizer/TimelockAuthorizerExecute.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerExecute.test.ts
@@ -209,12 +209,13 @@ describe('TimelockAuthorizer execute', () => {
     it('reverts if schedule for EOA', async () => {
       // we do not specify reason here because call to an EOA results in the following error:
       // Transaction reverted without a reason
-      await expect(authorizer.schedule(other.address, '0x00', [], { from: user })).to.be.reverted;
+
+      await expect(authorizer.schedule(other.address, functionData, [], { from: user })).to.be.reverted;
     });
 
     it('reverts if data is less than 4 bytes', async () => {
       await expect(authorizer.schedule(authenticatedContract.address, '0x00', [], { from: user })).to.be.revertedWith(
-        'SENDER_DOES_NOT_HAVE_PERMISSION'
+        'DATA_TOO_SHORT'
       );
     });
   });


### PR DESCRIPTION
<!-- If this is deployment-related, please go the the Preview tab and select the appropriate sub-template. -->
<!-- Otherwise, delete everything before #Description -->

# Description

This PR adds additional validation for the `data` parameter of the `schedule` method.  If `data` is less than 4 bytes we revert with 'DATA_TOO_SHORT' too short error.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

Closes #2380

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
