### PR TITLE
StableMath equation comments

### DIFF
--- a/pkg/pool-stable/contracts/StableMath.sol
+++ b/pkg/pool-stable/contracts/StableMath.sol
@@ -135,7 +135,7 @@ library StableMath {
         // by = balance token out                                                                                    //
         // y = by - ay (finalBalanceOut)                                                                             //
         // D = invariant                                               D                     D^(n+1)                 //
-        // A = amplification coefficient               y^2 + ( S - ----------  - D) * y -  ------------- = 0         //
+        // A = amplification coefficient               y^2 + ( S + ----------  - D) * y -  ------------- = 0         //
         // n = number of tokens                                    (A * n^n)               A * n^2n * P              //
         // S = sum of final balances but y                                                                           //
         // P = product of final balances but y                                                                       //
@@ -175,7 +175,7 @@ library StableMath {
         // bx = balance token in                                                                                     //
         // x = bx + ax (finalBalanceIn)                                                                              //
         // D = invariant                                                D                     D^(n+1)                //
-        // A = amplification coefficient               x^2 + ( S - ----------  - D) * x -  ------------- = 0         //
+        // A = amplification coefficient               x^2 + ( S + ----------  - D) * x -  ------------- = 0         //
         // n = number of tokens                                     (A * n^n)               A * n^2n * P             //
         // S = sum of final balances but x                                                                           //
         // P = product of final balances but x                                                                       //


### PR DESCRIPTION
# Description

Somehow the StableMath equation comments for `_calcOutGivenIn` and `_calcInGivenOut` have been (ever so slightly) wrong since the V2 launch.

For reference, here is the [external documentation](https://docs.balancer.fi/reference/math/stable-math.html#trade-equations).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [X] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

Closes #2390 
