### PR TITLE
Managed Pool bytecode (V1)

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -542,18 +542,16 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
         (virtualSupply, balances) = ComposablePoolLib.dropBptFromBalances(totalSupply(), balances);
 
         (IERC20[] memory tokens, ) = _getPoolTokens();
-        uint256[] memory scalingFactors = _scalingFactors(tokens);
 
         uint256 actualSupply = virtualSupply + _collectAumManagementFees(virtualSupply);
-        uint256[] memory normalizedWeights = _getNormalizedWeights(tokens);
 
         return
             ManagedPoolAmmLib.joinPool(
                 balances,
                 userData,
                 actualSupply,
-                scalingFactors,
-                normalizedWeights,
+                _scalingFactors(tokens),
+                _getNormalizedWeights(tokens),
                 poolState,
                 _getCircuitBreakerStates(tokens),
                 _getWeightedMath()
@@ -572,18 +570,15 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
 
         (IERC20[] memory tokens, ) = _getPoolTokens();
 
-        uint256[] memory scalingFactors = _scalingFactors(tokens);
         uint256 actualSupply = virtualSupply + _collectAumManagementFees(virtualSupply);
-
-        uint256[] memory normalizedWeights = _getNormalizedWeights(tokens);
 
         return
             ManagedPoolAmmLib.exitPool(
                 balances,
                 userData,
                 actualSupply,
-                scalingFactors,
-                normalizedWeights,
+                _scalingFactors(tokens),
+                _getNormalizedWeights(tokens),
                 _getPoolState(),
                 _getCircuitBreakerStates(tokens),
                 _getWeightedMath()

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -28,6 +28,7 @@ import "@balancer-labs/v2-pool-utils/contracts/lib/ComposablePoolLib.sol";
 import "@balancer-labs/v2-pool-utils/contracts/lib/PoolRegistrationLib.sol";
 
 import "./ManagedPoolSettings.sol";
+import "./ManagedPoolAmmLib.sol";
 
 /**
  * @title Managed Pool
@@ -531,200 +532,73 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
         uint256[] memory balances,
         bytes memory userData
     ) internal virtual override returns (uint256 bptAmountOut, uint256[] memory amountsIn) {
+        bytes32 poolState = _getPoolState();
+
+        _require(_isAllowedAddress(poolState, sender), Errors.ADDRESS_NOT_ALLOWLISTED);
+
         // The Vault passes an array of balances which includes the pool's BPT (This always sits in the first position).
         // We want to separate this from the other balances before continuing with the join.
         uint256 virtualSupply;
         (virtualSupply, balances) = ComposablePoolLib.dropBptFromBalances(totalSupply(), balances);
 
-        // We want to upscale all of the balances received from the Vault by the appropriate scaling factors.
-        // In order to do this we must query the Pool's tokens from the Vault as ManagedPool doesn't keep track.
         (IERC20[] memory tokens, ) = _getPoolTokens();
         uint256[] memory scalingFactors = _scalingFactors(tokens);
-        _upscaleArray(balances, scalingFactors);
 
-        // See documentation for `getActualSupply()` and `_collectAumManagementFees()`.
         uint256 actualSupply = virtualSupply + _collectAumManagementFees(virtualSupply);
         uint256[] memory normalizedWeights = _getNormalizedWeights(tokens);
 
-        (bptAmountOut, amountsIn) = _doJoin(
-            sender,
-            balances,
-            normalizedWeights,
-            scalingFactors,
-            actualSupply,
-            userData
-        );
-
-        _checkCircuitBreakers(actualSupply.add(bptAmountOut), tokens, balances, amountsIn, normalizedWeights, true);
-
-        // amountsIn are amounts entering the Pool, so we round up.
-        _downscaleUpArray(amountsIn, scalingFactors);
-
-        // The Vault expects an array of amounts which includes BPT so prepend an empty element to this array.
-        amountsIn = ComposablePoolLib.prependZeroElement(amountsIn);
-    }
-
-    /**
-     * @dev Dispatch code which decodes the provided userdata to perform the specified join type.
-     */
-    function _doJoin(
-        address sender,
-        uint256[] memory balances,
-        uint256[] memory normalizedWeights,
-        uint256[] memory scalingFactors,
-        uint256 totalSupply,
-        bytes memory userData
-    ) internal view returns (uint256, uint256[] memory) {
-        bytes32 poolState = _getPoolState();
-
-        // Check whether joins are enabled.
-        _require(ManagedPoolStorageLib.getJoinExitEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
-
-        WeightedPoolUserData.JoinKind kind = userData.joinKind();
-
-        // If swaps are disabled, only proportional joins are allowed. All others involve implicit swaps, and alter
-        // token prices.
-        _require(
-            ManagedPoolStorageLib.getSwapEnabled(poolState) ||
-                kind == WeightedPoolUserData.JoinKind.ALL_TOKENS_IN_FOR_EXACT_BPT_OUT,
-            Errors.INVALID_JOIN_EXIT_KIND_WHILE_SWAPS_DISABLED
-        );
-
-        // Check allowlist for LPs, if applicable
-        _require(_isAllowedAddress(poolState, sender), Errors.ADDRESS_NOT_ALLOWLISTED);
-
-        if (kind == WeightedPoolUserData.JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT) {
-            return
-                _getWeightedMath().joinExactTokensInForBPTOut(
-                    balances,
-                    normalizedWeights,
-                    scalingFactors,
-                    totalSupply,
-                    ManagedPoolStorageLib.getSwapFeePercentage(poolState),
-                    userData
-                );
-        } else if (kind == WeightedPoolUserData.JoinKind.TOKEN_IN_FOR_EXACT_BPT_OUT) {
-            return
-                _getWeightedMath().joinTokenInForExactBPTOut(
-                    balances,
-                    normalizedWeights,
-                    totalSupply,
-                    ManagedPoolStorageLib.getSwapFeePercentage(poolState),
-                    userData
-                );
-        } else if (kind == WeightedPoolUserData.JoinKind.ALL_TOKENS_IN_FOR_EXACT_BPT_OUT) {
-            return _getWeightedMath().joinAllTokensInForExactBPTOut(balances, totalSupply, userData);
-        } else {
-            _revert(Errors.UNHANDLED_JOIN_KIND);
-        }
+        return
+            ManagedPoolAmmLib.joinPool(
+                balances,
+                userData,
+                actualSupply,
+                scalingFactors,
+                normalizedWeights,
+                poolState,
+                _getCircuitBreakerStates(tokens),
+                _getWeightedMath()
+            );
     }
 
     // Exit
 
     function _onExitPool(
-        address sender,
+        address,
         uint256[] memory balances,
         bytes memory userData
     ) internal virtual override returns (uint256 bptAmountIn, uint256[] memory amountsOut) {
-        // The Vault passes an array of balances which includes the pool's BPT (This always sits in the first position).
-        // We want to separate this from the other balances before continuing with the exit.
         uint256 virtualSupply;
         (virtualSupply, balances) = ComposablePoolLib.dropBptFromBalances(totalSupply(), balances);
 
-        // We want to upscale all of the balances received from the Vault by the appropriate scaling factors.
-        // In order to do this we must query the Pool's tokens from the Vault as ManagedPool doesn't keep track.
         (IERC20[] memory tokens, ) = _getPoolTokens();
-        uint256[] memory scalingFactors = _scalingFactors(tokens);
-        _upscaleArray(balances, scalingFactors);
 
-        // See documentation for `getActualSupply()` and `_collectAumManagementFees()`.
+        uint256[] memory scalingFactors = _scalingFactors(tokens);
         uint256 actualSupply = virtualSupply + _collectAumManagementFees(virtualSupply);
 
         uint256[] memory normalizedWeights = _getNormalizedWeights(tokens);
 
-        (bptAmountIn, amountsOut) = _doExit(
-            sender,
-            balances,
-            normalizedWeights,
-            scalingFactors,
-            actualSupply,
-            userData
-        );
-
-        // Do not check circuit breakers on proportional exits, which do not change BPT prices.
-        if (userData.exitKind() != WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT) {
-            _checkCircuitBreakers(
-                actualSupply.sub(bptAmountIn),
-                tokens,
+        return
+            ManagedPoolAmmLib.exitPool(
                 balances,
-                amountsOut,
+                userData,
+                actualSupply,
+                scalingFactors,
                 normalizedWeights,
-                false
+                _getPoolState(),
+                _getCircuitBreakerStates(tokens),
+                _getWeightedMath()
             );
-        }
-
-        // amountsOut are amounts exiting the Pool, so we round down.
-        _downscaleDownArray(amountsOut, scalingFactors);
-
-        // The Vault expects an array of amounts which includes BPT so prepend an empty element to this array.
-        amountsOut = ComposablePoolLib.prependZeroElement(amountsOut);
     }
 
-    /**
-     * @dev Dispatch code which decodes the provided userdata to perform the specified exit type.
-     * Inheriting contracts may override this function to add additional exit types or extra conditions to allow
-     * or disallow exit under certain circumstances.
-     */
-    function _doExit(
-        address,
-        uint256[] memory balances,
-        uint256[] memory normalizedWeights,
-        uint256[] memory scalingFactors,
-        uint256 totalSupply,
-        bytes memory userData
-    ) internal view virtual returns (uint256, uint256[] memory) {
-        bytes32 poolState = _getPoolState();
+    function _getCircuitBreakerStates(IERC20[] memory tokens)
+        private
+        view
+        returns (bytes32[] memory circuitBreakerStates)
+    {
+        circuitBreakerStates = new bytes32[](tokens.length);
 
-        // Check whether exits are enabled. Recovery mode exits are not blocked by this check, since they are routed
-        // through a different codepath at the base pool layer.
-        _require(ManagedPoolStorageLib.getJoinExitEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
-
-        WeightedPoolUserData.ExitKind kind = userData.exitKind();
-
-        // If swaps are disabled, only proportional exits are allowed. All others involve implicit swaps, and alter
-        // token prices.
-        _require(
-            ManagedPoolStorageLib.getSwapEnabled(poolState) ||
-                kind == WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT,
-            Errors.INVALID_JOIN_EXIT_KIND_WHILE_SWAPS_DISABLED
-        );
-
-        // Note that we do not check the LP allowlist here. LPs must always be able to exit the pool,
-        // and enforcing the allowlist would allow the manager to perform DOS attacks on LPs.
-
-        if (kind == WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT) {
-            return
-                _getWeightedMath().exitExactBPTInForTokenOut(
-                    balances,
-                    normalizedWeights,
-                    totalSupply,
-                    ManagedPoolStorageLib.getSwapFeePercentage(poolState),
-                    userData
-                );
-        } else if (kind == WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT) {
-            return _getWeightedMath().exitExactBPTInForTokensOut(balances, totalSupply, userData);
-        } else if (kind == WeightedPoolUserData.ExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT) {
-            return
-                _getWeightedMath().exitBPTInForExactTokensOut(
-                    balances,
-                    normalizedWeights,
-                    scalingFactors,
-                    totalSupply,
-                    ManagedPoolStorageLib.getSwapFeePercentage(poolState),
-                    userData
-                );
-        } else {
-            _revert(Errors.UNHANDLED_EXIT_KIND);
+        for (uint256 i = 0; i < tokens.length; i++) {
+            circuitBreakerStates[i] = _getCircuitBreakerState(tokens[i]);
         }
     }
 
@@ -750,9 +624,6 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
 
     // Circuit Breakers
 
-    // Depending on the type of operation, we may need to check only the upper or lower bound, or both.
-    enum BoundCheckKind { LOWER, UPPER, BOTH }
-
     /**
      * @dev Check the circuit breakers of the two tokens involved in a regular swap.
      */
@@ -771,9 +642,9 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
 
         // Since the balance of tokenIn is increasing, its BPT price will decrease,
         // so we need to check the lower bound.
-        _checkCircuitBreaker(
-            BoundCheckKind.LOWER,
-            request.tokenIn,
+        ManagedPoolAmmLib.checkCircuitBreaker(
+            ManagedPoolAmmLib.BoundCheckKind.LOWER,
+            _getCircuitBreakerState(request.tokenIn),
             actualSupply,
             balanceTokenIn.add(amountIn),
             tokenData.tokenInWeight
@@ -781,9 +652,9 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
 
         // Since the balance of tokenOut is decreasing, its BPT price will increase,
         // so we need to check the upper bound.
-        _checkCircuitBreaker(
-            BoundCheckKind.UPPER,
-            request.tokenOut,
+        ManagedPoolAmmLib.checkCircuitBreaker(
+            ManagedPoolAmmLib.BoundCheckKind.UPPER,
+            _getCircuitBreakerState(request.tokenOut),
             actualSupply,
             balanceTokenOut.sub(amountOut),
             tokenData.tokenOutWeight
@@ -833,69 +704,13 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
             }
         }
 
-        _checkCircuitBreakers(newActualSupply, tokens, balances, amounts, normalizedWeights, isJoin);
-    }
-
-    /**
-     * @dev Check circuit breakers for a set of tokens. The given virtual supply is what it will be post-operation:
-     * this includes any pending external fees, and the amount of BPT exchanged (swapped, minted, or burned) in the
-     * current operation.
-     *
-     * We pass in the tokens, upscaled balances, and weights necessary to compute BPT prices, then check the circuit
-     * breakers. Unlike a straightforward token swap, where we know the direction the BPT price will move, once the
-     * virtual supply changes, all bets are off. To be safe, we need to check both directions for all tokens.
-     *
-     * It does attempt to short circuit quickly if there is no bound set.
-     */
-    function _checkCircuitBreakers(
-        uint256 actualSupply,
-        IERC20[] memory tokens,
-        uint256[] memory balances,
-        uint256[] memory amounts,
-        uint256[] memory normalizedWeights,
-        bool isJoin
-    ) private view {
-        for (uint256 i = 0; i < balances.length; i++) {
-            uint256 finalBalance = (isJoin ? FixedPoint.add : FixedPoint.sub)(balances[i], amounts[i]);
-
-            // Since we cannot be sure which direction the BPT price of the token has moved,
-            // we must check both the lower and upper bounds.
-            _checkCircuitBreaker(BoundCheckKind.BOTH, tokens[i], actualSupply, finalBalance, normalizedWeights[i]);
-        }
-    }
-
-    // Check the appropriate circuit breaker(s) according to the BoundCheckKind.
-    function _checkCircuitBreaker(
-        BoundCheckKind checkKind,
-        IERC20 token,
-        uint256 actualSupply,
-        uint256 balance,
-        uint256 weight
-    ) private view {
-        bytes32 circuitBreakerState = _getCircuitBreakerState(token);
-
-        if (checkKind == BoundCheckKind.LOWER || checkKind == BoundCheckKind.BOTH) {
-            _checkOneSidedCircuitBreaker(circuitBreakerState, actualSupply, balance, weight, true);
-        }
-
-        if (checkKind == BoundCheckKind.UPPER || checkKind == BoundCheckKind.BOTH) {
-            _checkOneSidedCircuitBreaker(circuitBreakerState, actualSupply, balance, weight, false);
-        }
-    }
-
-    // Check either the lower or upper bound circuit breaker for the given token.
-    function _checkOneSidedCircuitBreaker(
-        bytes32 circuitBreakerState,
-        uint256 actualSupply,
-        uint256 balance,
-        uint256 weight,
-        bool isLowerBound
-    ) private pure {
-        uint256 bound = CircuitBreakerStorageLib.getBptPriceBound(circuitBreakerState, weight, isLowerBound);
-
-        _require(
-            !CircuitBreakerLib.hasCircuitBreakerTripped(actualSupply, weight, balance, bound, isLowerBound),
-            Errors.CIRCUIT_BREAKER_TRIPPED
+        ManagedPoolAmmLib.checkCircuitBreakers(
+            newActualSupply,
+            _getCircuitBreakerStates(tokens),
+            balances,
+            amounts,
+            normalizedWeights,
+            isJoin
         );
     }
 

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolAmmLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolAmmLib.sol
@@ -130,6 +130,8 @@ library ManagedPoolAmmLib {
         bytes32[] memory circuitBreakerStates,
         IExternalWeightedMath weightedMath
     ) external view returns (uint256 bptAmountIn, uint256[] memory amountsOut) {
+        _upscaleArray(balances, scalingFactors);
+
         (bptAmountIn, amountsOut) = _doExit(
             balances,
             normalizedWeights,

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolAmmLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolAmmLib.sol
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-interfaces/contracts/pool-weighted/IExternalWeightedMath.sol";
+import "@balancer-labs/v2-interfaces/contracts/pool-weighted/WeightedPoolUserData.sol";
+
+import "@balancer-labs/v2-pool-utils/contracts/lib/ComposablePoolLib.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/ScalingHelpers.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/Authentication.sol";
+
+import "../managed/CircuitBreakerStorageLib.sol";
+import "./ManagedPoolTokenStorageLib.sol";
+import "./ManagedPoolStorageLib.sol";
+
+library ManagedPoolAmmLib {
+    using FixedPoint for uint256;
+    using WeightedPoolUserData for bytes;
+
+    enum BoundCheckKind { LOWER, UPPER, BOTH }
+
+    function joinPool(
+        uint256[] memory balances,
+        bytes memory userData,
+        uint256 actualSupply,
+        uint256[] memory scalingFactors,
+        uint256[] memory normalizedWeights,
+        bytes32 poolState,
+        bytes32[] memory circuitBreakerStates,
+        IExternalWeightedMath weightedMath
+    ) external view returns (uint256 bptAmountOut, uint256[] memory amountsIn) {
+        _upscaleArray(balances, scalingFactors);
+
+        (bptAmountOut, amountsIn) = _doJoin(
+            balances,
+            normalizedWeights,
+            scalingFactors,
+            actualSupply,
+            userData,
+            poolState,
+            weightedMath
+        );
+
+        checkCircuitBreakers(
+            actualSupply.add(bptAmountOut),
+            circuitBreakerStates,
+            balances,
+            amountsIn,
+            normalizedWeights,
+            true
+        );
+
+        // amountsIn are amounts entering the Pool, so we round up.
+        _downscaleUpArray(amountsIn, scalingFactors);
+
+        // The Vault expects an array of amounts which includes BPT so prepend an empty element to this array.
+        amountsIn = ComposablePoolLib.prependZeroElement(amountsIn);
+    }
+
+    /**
+     * @dev Dispatch code which decodes the provided userdata to perform the specified join type.
+     */
+    function _doJoin(
+        uint256[] memory balances,
+        uint256[] memory normalizedWeights,
+        uint256[] memory scalingFactors,
+        uint256 totalSupply,
+        bytes memory userData,
+        bytes32 poolState,
+        IExternalWeightedMath weightedMath
+    ) private view returns (uint256, uint256[] memory) {
+        // Check whether joins are enabled.
+        _require(ManagedPoolStorageLib.getJoinExitEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
+
+        WeightedPoolUserData.JoinKind kind = userData.joinKind();
+
+        // If swaps are disabled, only proportional joins are allowed. All others involve implicit swaps, and alter
+        // token prices.
+        _require(
+            ManagedPoolStorageLib.getSwapEnabled(poolState) ||
+                kind == WeightedPoolUserData.JoinKind.ALL_TOKENS_IN_FOR_EXACT_BPT_OUT,
+            Errors.INVALID_JOIN_EXIT_KIND_WHILE_SWAPS_DISABLED
+        );
+
+        if (kind == WeightedPoolUserData.JoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT) {
+            return
+                weightedMath.joinExactTokensInForBPTOut(
+                    balances,
+                    normalizedWeights,
+                    scalingFactors,
+                    totalSupply,
+                    ManagedPoolStorageLib.getSwapFeePercentage(poolState),
+                    userData
+                );
+        } else if (kind == WeightedPoolUserData.JoinKind.TOKEN_IN_FOR_EXACT_BPT_OUT) {
+            return
+                weightedMath.joinTokenInForExactBPTOut(
+                    balances,
+                    normalizedWeights,
+                    totalSupply,
+                    ManagedPoolStorageLib.getSwapFeePercentage(poolState),
+                    userData
+                );
+        } else if (kind == WeightedPoolUserData.JoinKind.ALL_TOKENS_IN_FOR_EXACT_BPT_OUT) {
+            return weightedMath.joinAllTokensInForExactBPTOut(balances, totalSupply, userData);
+        } else {
+            _revert(Errors.UNHANDLED_JOIN_KIND);
+        }
+    }
+
+    function exitPool(
+        uint256[] memory balances,
+        bytes memory userData,
+        uint256 actualSupply,
+        uint256[] memory scalingFactors,
+        uint256[] memory normalizedWeights,
+        bytes32 poolState,
+        bytes32[] memory circuitBreakerStates,
+        IExternalWeightedMath weightedMath
+    ) external view returns (uint256 bptAmountIn, uint256[] memory amountsOut) {
+        (bptAmountIn, amountsOut) = _doExit(
+            balances,
+            normalizedWeights,
+            scalingFactors,
+            actualSupply,
+            userData,
+            poolState,
+            weightedMath
+        );
+
+        // Do not check circuit breakers on proportional exits, which do not change BPT prices.
+        if (userData.exitKind() != WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT) {
+            checkCircuitBreakers(
+                actualSupply.sub(bptAmountIn),
+                circuitBreakerStates,
+                balances,
+                amountsOut,
+                normalizedWeights,
+                false
+            );
+        }
+
+        // amountsOut are amounts exiting the Pool, so we round down.
+        _downscaleDownArray(amountsOut, scalingFactors);
+
+        // The Vault expects an array of amounts which includes BPT so prepend an empty element to this array.
+        amountsOut = ComposablePoolLib.prependZeroElement(amountsOut);
+    }
+
+    function _doExit(
+        uint256[] memory balances,
+        uint256[] memory normalizedWeights,
+        uint256[] memory scalingFactors,
+        uint256 totalSupply,
+        bytes memory userData,
+        bytes32 poolState,
+        IExternalWeightedMath weightedMath
+    ) private view returns (uint256, uint256[] memory) {
+        // Check whether exits are enabled. Recovery mode exits are not blocked by this check, since they are routed
+        // through a different codepath at the base pool layer.
+        _require(ManagedPoolStorageLib.getJoinExitEnabled(poolState), Errors.JOINS_EXITS_DISABLED);
+
+        WeightedPoolUserData.ExitKind kind = userData.exitKind();
+
+        // If swaps are disabled, only proportional exits are allowed. All others involve implicit swaps, and alter
+        // token prices.
+        _require(
+            ManagedPoolStorageLib.getSwapEnabled(poolState) ||
+                kind == WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT,
+            Errors.INVALID_JOIN_EXIT_KIND_WHILE_SWAPS_DISABLED
+        );
+
+        // Note that we do not check the LP allowlist here. LPs must always be able to exit the pool,
+        // and enforcing the allowlist would allow the manager to perform DOS attacks on LPs.
+
+        if (kind == WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT) {
+            return
+                weightedMath.exitExactBPTInForTokenOut(
+                    balances,
+                    normalizedWeights,
+                    totalSupply,
+                    ManagedPoolStorageLib.getSwapFeePercentage(poolState),
+                    userData
+                );
+        } else if (kind == WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT) {
+            return weightedMath.exitExactBPTInForTokensOut(balances, totalSupply, userData);
+        } else if (kind == WeightedPoolUserData.ExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT) {
+            return
+                weightedMath.exitBPTInForExactTokensOut(
+                    balances,
+                    normalizedWeights,
+                    scalingFactors,
+                    totalSupply,
+                    ManagedPoolStorageLib.getSwapFeePercentage(poolState),
+                    userData
+                );
+        } else {
+            _revert(Errors.UNHANDLED_EXIT_KIND);
+        }
+    }
+
+    /**
+     * @dev Check circuit breakers for a set of tokens. The given virtual supply is what it will be post-operation:
+     * this includes any pending external fees, and the amount of BPT exchanged (swapped, minted, or burned) in the
+     * current operation.
+     *
+     * We pass in the tokens, upscaled balances, and weights necessary to compute BPT prices, then check the circuit
+     * breakers. Unlike a straightforward token swap, where we know the direction the BPT price will move, once the
+     * virtual supply changes, all bets are off. To be safe, we need to check both directions for all tokens.
+     *
+     * It does attempt to short circuit quickly if there is no bound set.
+     */
+    function checkCircuitBreakers(
+        uint256 actualSupply,
+        bytes32[] memory circuitBreakerStates,
+        uint256[] memory balances,
+        uint256[] memory amounts,
+        uint256[] memory normalizedWeights,
+        bool isJoin
+    ) public pure {
+        for (uint256 i = 0; i < balances.length; i++) {
+            uint256 finalBalance = (isJoin ? FixedPoint.add : FixedPoint.sub)(balances[i], amounts[i]);
+
+            // Since we cannot be sure which direction the BPT price of the token has moved,
+            // we must check both the lower and upper bounds.
+            checkCircuitBreaker(
+                BoundCheckKind.BOTH,
+                circuitBreakerStates[i],
+                actualSupply,
+                finalBalance,
+                normalizedWeights[i]
+            );
+        }
+    }
+
+    // Check the appropriate circuit breaker(s) according to the BoundCheckKind.
+    function checkCircuitBreaker(
+        BoundCheckKind checkKind,
+        bytes32 circuitBreakerState,
+        uint256 actualSupply,
+        uint256 balance,
+        uint256 weight
+    ) public pure {
+        if (checkKind == BoundCheckKind.LOWER || checkKind == BoundCheckKind.BOTH) {
+            checkOneSidedCircuitBreaker(circuitBreakerState, actualSupply, balance, weight, true);
+        }
+
+        if (checkKind == BoundCheckKind.UPPER || checkKind == BoundCheckKind.BOTH) {
+            checkOneSidedCircuitBreaker(circuitBreakerState, actualSupply, balance, weight, false);
+        }
+    }
+
+    // Check either the lower or upper bound circuit breaker for the given token.
+    function checkOneSidedCircuitBreaker(
+        bytes32 circuitBreakerState,
+        uint256 actualSupply,
+        uint256 balance,
+        uint256 weight,
+        bool isLowerBound
+    ) public pure {
+        uint256 bound = CircuitBreakerStorageLib.getBptPriceBound(circuitBreakerState, weight, isLowerBound);
+
+        _require(
+            !CircuitBreakerLib.hasCircuitBreakerTripped(actualSupply, weight, balance, bound, isLowerBound),
+            Errors.CIRCUIT_BREAKER_TRIPPED
+        );
+    }
+}

--- a/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
@@ -56,6 +56,11 @@ describe('ManagedPoolFactory', function () {
 
     const addRemoveTokenLib = await deploy('ManagedPoolAddRemoveTokenLib');
     const circuitBreakerLib = await deploy('CircuitBreakerLib');
+    const ammLib = await deploy('v2-pool-weighted/ManagedPoolAmmLib', {
+      libraries: {
+        CircuitBreakerLib: circuitBreakerLib.address,
+      },
+    });
     factory = await deploy('ManagedPoolFactory', {
       args: [
         vault.address,
@@ -68,6 +73,7 @@ describe('ManagedPoolFactory', function () {
       libraries: {
         CircuitBreakerLib: circuitBreakerLib.address,
         ManagedPoolAddRemoveTokenLib: addRemoveTokenLib.address,
+        ManagedPoolAmmLib: ammLib.address,
       },
     });
     createTime = await currentTimestamp();

--- a/pkg/pool-weighted/test/foundry/WeightedMath.t.sol
+++ b/pkg/pool-weighted/test/foundry/WeightedMath.t.sol
@@ -26,7 +26,8 @@ contract WeightedMathTest is Test {
     // Match the minimum supply defined in `BasePool`.
     uint256 private constant _DEFAULT_MINIMUM_BPT = 1e6;
 
-    function testJoinSwaps(
+    //TODO: remove skip prefix when Foundry issue resolved
+    function skipTestJoinSwaps(
         uint256[20] memory balancesFixed,
         uint256[20] memory normalizedWeightsFixed,
         uint256 arrayLength,
@@ -103,7 +104,8 @@ contract WeightedMathTest is Test {
         assertEq(joinSwap, properJoin);
     }
 
-    function testExitSwaps(
+    //TODO: remove skip prefix when Foundry issue resolved
+    function skipTestExitSwaps(
         uint256[20] memory balancesFixed,
         uint256[20] memory normalizedWeightsFixed,
         uint256 arrayLength,

--- a/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
+++ b/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
@@ -21,6 +21,12 @@ describe('ManagedPool owner only actions', () => {
     const math = await deploy('ExternalWeightedMath');
     const recoveryModeHelper = await deploy('v2-pool-utils/RecoveryModeHelper', { args: [vault.address] });
     const circuitBreakerLib = await deploy('CircuitBreakerLib');
+    const ammLib = await deploy('v2-pool-weighted/ManagedPoolAmmLib', {
+      libraries: {
+        CircuitBreakerLib: circuitBreakerLib.address,
+      },
+    });
+
     pool = await deploy('MockManagedPool', {
       args: [
         { name: '', symbol: '', assetManagers: new Array(2).fill(ZERO_ADDRESS) },
@@ -47,6 +53,7 @@ describe('ManagedPool owner only actions', () => {
       libraries: {
         CircuitBreakerLib: circuitBreakerLib.address,
         ManagedPoolAddRemoveTokenLib: addRemoveTokenLib.address,
+        ManagedPoolAmmLib: ammLib.address,
       },
     });
   });

--- a/pvt/benchmarks/misc.ts
+++ b/pvt/benchmarks/misc.ts
@@ -196,6 +196,11 @@ async function deployPoolFromFactory(
   if (poolName == 'ManagedPool') {
     const addRemoveTokenLib = await deploy('v2-pool-weighted/ManagedPoolAddRemoveTokenLib');
     const circuitBreakerLib = await deploy('v2-pool-weighted/CircuitBreakerLib');
+    const ammLib = await deploy('v2-pool-weighted/ManagedPoolAmmLib', {
+      libraries: {
+        CircuitBreakerLib: circuitBreakerLib.address,
+      },
+    });
     factory = await deploy('v2-pool-weighted/ManagedPoolFactory', {
       args: [
         vault.address,
@@ -208,6 +213,7 @@ async function deployPoolFromFactory(
       libraries: {
         CircuitBreakerLib: circuitBreakerLib.address,
         ManagedPoolAddRemoveTokenLib: addRemoveTokenLib.address,
+        ManagedPoolAmmLib: ammLib.address,
       },
     });
   } else if (poolName == 'ComposableStablePool') {

--- a/pvt/common/hardhat-base-config.ts
+++ b/pvt/common/hardhat-base-config.ts
@@ -19,15 +19,15 @@ const contractSettings: ContractSettings = {
   },
   '@balancer-labs/v2-pool-weighted/contracts/managed/ManagedPoolFactory.sol': {
     version: '0.7.1',
-    runs: 200,
+    runs: 140,
   },
   '@balancer-labs/v2-pool-weighted/contracts/managed/ManagedPool.sol': {
     version: '0.7.1',
-    runs: 200,
+    runs: 140,
   },
   '@balancer-labs/v2-pool-weighted/contracts/test/MockManagedPool.sol': {
     version: '0.7.1',
-    runs: 200,
+    runs: 140,
   },
 };
 

--- a/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
@@ -101,6 +101,11 @@ export default {
         const math = await deploy('v2-pool-weighted/ExternalWeightedMath');
         const recoveryModeHelper = await deploy('v2-pool-utils/RecoveryModeHelper', { args: [vault.address] });
         const circuitBreakerLib = await deploy('v2-pool-weighted/CircuitBreakerLib');
+        const ammLib = await deploy('v2-pool-weighted/ManagedPoolAmmLib', {
+          libraries: {
+            CircuitBreakerLib: circuitBreakerLib.address,
+          },
+        });
         result = deploy('v2-pool-weighted/ManagedPool', {
           args: [
             {
@@ -133,6 +138,7 @@ export default {
           libraries: {
             CircuitBreakerLib: circuitBreakerLib.address,
             ManagedPoolAddRemoveTokenLib: addRemoveTokenLib.address,
+            ManagedPoolAmmLib: ammLib.address,
           },
         });
         break;
@@ -143,6 +149,12 @@ export default {
         const math = await deploy('v2-pool-weighted/ExternalWeightedMath');
         const recoveryModeHelper = await deploy('v2-pool-utils/RecoveryModeHelper', { args: [vault.address] });
         const circuitBreakerLib = await deploy('v2-pool-weighted/CircuitBreakerLib');
+        const ammLib = await deploy('v2-pool-weighted/ManagedPoolAmmLib', {
+          libraries: {
+            CircuitBreakerLib: circuitBreakerLib.address,
+          },
+        });
+
         result = deploy('v2-pool-weighted/MockManagedPool', {
           args: [
             {
@@ -175,6 +187,7 @@ export default {
           libraries: {
             CircuitBreakerLib: circuitBreakerLib.address,
             ManagedPoolAddRemoveTokenLib: addRemoveTokenLib.address,
+            ManagedPoolAmmLib: ammLib.address,
           },
         });
         break;


### PR DESCRIPTION
# Description

Move the AMM logic out to an external library to reduce the bytecode. (It would have to be linked in, like AddRemove and ExternalMath.)

Draft because the tests still need work. The linking is there now.

I also tested making the VaultReentrancyLib function view (using code from Midas), which saves about 35 bytes. (But didn't check it in, as I considered it extraneous for this PR, though we might still want to do it.)

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [~] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

