### PR TITLE
Managed Pool bytecode (V2)

### DIFF
--- a/pkg/interfaces/contracts/pool-utils/IVaultReentrancyLib.sol
+++ b/pkg/interfaces/contracts/pool-utils/IVaultReentrancyLib.sol
@@ -32,5 +32,5 @@ interface IVaultReentrancyLib {
      * here (https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345), those functions are unsafe,
      * and subject to manipulation that may result in loss of funds.
      */
-    function ensureNotInVaultContext() external;
+    function ensureNotInVaultContext() external view;
 }

--- a/pkg/interfaces/contracts/pool-utils/IVaultReentrancyLib.sol
+++ b/pkg/interfaces/contracts/pool-utils/IVaultReentrancyLib.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+
+/**
+ * @notice Simple interface to retrieve the version of a deployed contract.
+ */
+interface IVaultReentrancyLib {
+    /**\
+     * @dev Ensure we are not in a Vault context when this function is called, by attempting a no-op internal
+     * balance operation. If we are already in a Vault transaction (e.g., a swap, join, or exit), the Vault's
+     * reentrancy protection will cause this function to revert.
+     *
+     * The exact function call doesn't really matter: we're just trying to trigger the Vault reentrancy check
+     * (and not hurt anything in case it works). An empty operation array with no specific operation at all works
+     * for that purpose, and is also the least expensive in terms of gas and bytecode size.
+     *
+     * Call this at the top of any function that can cause a state change in a pool and is either public itself,
+     * or called by a public function *outside* a Vault operation (e.g., join, exit, or swap).
+     *
+     * If this is *not* called in functions that are vulnerable to the read-only reentrancy issue described
+     * here (https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345), those functions are unsafe,
+     * and subject to manipulation that may result in loss of funds.
+     */
+    function ensureNotInVaultContext() external;
+}

--- a/pkg/interfaces/contracts/pool-weighted/IComposablePoolTokenLib.sol
+++ b/pkg/interfaces/contracts/pool-weighted/IComposablePoolTokenLib.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+
+import "../solidity-utils/openzeppelin/IERC20.sol";
+
+interface IComposablePoolTokenLib {
+    function getPoolTokens() external view returns (IERC20[] memory, uint256[] memory);
+}

--- a/pkg/interfaces/contracts/pool-weighted/IComposablePoolTokenLib.sol
+++ b/pkg/interfaces/contracts/pool-weighted/IComposablePoolTokenLib.sol
@@ -20,4 +20,7 @@ interface IComposablePoolTokenLib {
     function getVirtualSupply() external view returns (uint256);
 
     function getPoolTokens() external view returns (IERC20[] memory, uint256[] memory);
+
+    // Called by the pool on initialization, to ensure the contract passed in is configured correctly.
+    function validatePool(address pool) external;
 }

--- a/pkg/interfaces/contracts/pool-weighted/IComposablePoolTokenLib.sol
+++ b/pkg/interfaces/contracts/pool-weighted/IComposablePoolTokenLib.sol
@@ -17,5 +17,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "../solidity-utils/openzeppelin/IERC20.sol";
 
 interface IComposablePoolTokenLib {
+    function getVirtualSupply() external view returns (uint256);
+
     function getPoolTokens() external view returns (IERC20[] memory, uint256[] memory);
 }

--- a/pkg/interfaces/contracts/pool-weighted/IManagedPoolOwnerOnlyLib.sol
+++ b/pkg/interfaces/contracts/pool-weighted/IManagedPoolOwnerOnlyLib.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+interface IManagedPoolOwnerOnlyLib {
+    function isOwnerOnlyAction(bytes32 actionId) external view returns (bool);
+}

--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -104,6 +104,8 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, NewBas
     // [ recovery | swap  fee | upper target |  lower target | reserved ]
     // [ MSB                                                        LSB ]
 
+    IVaultReentrancyLib private immutable _vaultReentrancyLib;
+
     uint256 private constant _TARGET_SCALING = 1e18;
 
     uint256 private constant _TARGET_BITS = 32;
@@ -142,7 +144,7 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, NewBas
      * @dev Reverts if called in the middle of a Vault operation; has no effect otherwise.
      */
     function _ensureNotInVaultContext() private {
-        VaultReentrancyLib.ensureNotInVaultContext(getVault());
+        _getVaultReentrancyLib().ensureNotInVaultContext();
     }
 
     constructor(
@@ -192,6 +194,12 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, NewBas
 
         // Set the initial swap fee percentage.
         _setSwapFeePercentage(swapFeePercentage);
+
+        _vaultReentrancyLib = new VaultReentrancyLib(vault);
+    }
+
+    function _getVaultReentrancyLib() private view returns (IVaultReentrancyLib) {
+        return _vaultReentrancyLib;
     }
 
     /**

--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -143,7 +143,7 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, NewBas
     /**
      * @dev Reverts if called in the middle of a Vault operation; has no effect otherwise.
      */
-    function _ensureNotInVaultContext() private {
+    function _ensureNotInVaultContext() private view {
         _getVaultReentrancyLib().ensureNotInVaultContext();
     }
 

--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -144,7 +144,7 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, NewBas
      * @dev Reverts if called in the middle of a Vault operation; has no effect otherwise.
      */
     function _ensureNotInVaultContext() private view {
-        _getVaultReentrancyLib().ensureNotInVaultContext();
+        _vaultReentrancyLib.ensureNotInVaultContext();
     }
 
     constructor(
@@ -196,10 +196,6 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, NewBas
         _setSwapFeePercentage(swapFeePercentage);
 
         _vaultReentrancyLib = new VaultReentrancyLib(vault);
-    }
-
-    function _getVaultReentrancyLib() private view returns (IVaultReentrancyLib) {
-        return _vaultReentrancyLib;
     }
 
     /**

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -104,6 +104,7 @@ contract ComposableStablePool is
         ComposableStablePoolStorage(_extractStorageParams(params))
         ComposableStablePoolRates(_extractRatesParams(params))
         ProtocolFeeCache(
+            params.vault,
             params.protocolFeeProvider,
             ProviderFeeIDs({ swap: ProtocolFeeType.SWAP, yield: ProtocolFeeType.YIELD, aum: ProtocolFeeType.AUM })
         )

--- a/pkg/pool-stable/contracts/ComposableStablePool.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePool.sol
@@ -73,6 +73,7 @@ contract ComposableStablePool is
     struct NewPoolParams {
         IVault vault;
         IProtocolFeePercentagesProvider protocolFeeProvider;
+        IVaultReentrancyLib vaultReentrancyLib;
         string name;
         string symbol;
         IERC20[] tokens;
@@ -104,7 +105,7 @@ contract ComposableStablePool is
         ComposableStablePoolStorage(_extractStorageParams(params))
         ComposableStablePoolRates(_extractRatesParams(params))
         ProtocolFeeCache(
-            params.vault,
+            params.vaultReentrancyLib,
             params.protocolFeeProvider,
             ProviderFeeIDs({ swap: ProtocolFeeType.SWAP, yield: ProtocolFeeType.YIELD, aum: ProtocolFeeType.AUM })
         )

--- a/pkg/pool-stable/contracts/ComposableStablePoolFactory.sol
+++ b/pkg/pool-stable/contracts/ComposableStablePoolFactory.sol
@@ -27,6 +27,8 @@ contract ComposableStablePoolFactory is IVersion, IPoolVersion, BasePoolFactory 
     string private _version;
     string private _poolVersion;
 
+    IVaultReentrancyLib private immutable _vaultReentrancyLib;
+
     constructor(
         IVault vault,
         IProtocolFeePercentagesProvider protocolFeeProvider,
@@ -45,6 +47,9 @@ contract ComposableStablePoolFactory is IVersion, IPoolVersion, BasePoolFactory 
     {
         _version = factoryVersion;
         _poolVersion = poolVersion;
+
+        // Create in the factory to ensure it uses the same Vault as the pools.
+        _vaultReentrancyLib = new VaultReentrancyLib(vault);
     }
 
     function version() external view override returns (string memory) {
@@ -53,6 +58,10 @@ contract ComposableStablePoolFactory is IVersion, IPoolVersion, BasePoolFactory 
 
     function getPoolVersion() public view override returns (string memory) {
         return _poolVersion;
+    }
+
+    function getVaultReentrancyLib() external view returns (IVaultReentrancyLib) {
+        return _vaultReentrancyLib;
     }
 
     /**
@@ -78,6 +87,7 @@ contract ComposableStablePoolFactory is IVersion, IPoolVersion, BasePoolFactory 
                         ComposableStablePool.NewPoolParams({
                             vault: getVault(),
                             protocolFeeProvider: getProtocolFeePercentagesProvider(),
+                            vaultReentrancyLib: _vaultReentrancyLib,
                             name: name,
                             symbol: symbol,
                             tokens: tokens,

--- a/pkg/pool-stable/contracts/test/MockComposableStablePoolProtocolFees.sol
+++ b/pkg/pool-stable/contracts/test/MockComposableStablePoolProtocolFees.sol
@@ -43,6 +43,7 @@ contract MockComposableStablePoolProtocolFees is ComposableStablePoolProtocolFee
             })
         )
         ProtocolFeeCache(
+            vault,
             protocolFeeProvider,
             ProviderFeeIDs({ swap: ProtocolFeeType.SWAP, yield: ProtocolFeeType.YIELD, aum: ProtocolFeeType.AUM })
         )

--- a/pkg/pool-stable/contracts/test/MockComposableStablePoolProtocolFees.sol
+++ b/pkg/pool-stable/contracts/test/MockComposableStablePoolProtocolFees.sol
@@ -43,7 +43,7 @@ contract MockComposableStablePoolProtocolFees is ComposableStablePoolProtocolFee
             })
         )
         ProtocolFeeCache(
-            vault,
+            new VaultReentrancyLib(vault),
             protocolFeeProvider,
             ProviderFeeIDs({ swap: ProtocolFeeType.SWAP, yield: ProtocolFeeType.YIELD, aum: ProtocolFeeType.AUM })
         )

--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -122,7 +122,6 @@ abstract contract BasePool is
         BalancerPoolToken(name, symbol, vault)
         BasePoolAuthorization(owner)
         TemporarilyPausable(pauseWindowDuration, bufferPeriodDuration)
-        RecoveryMode(vault)
     {
         _require(tokens.length >= _MIN_TOKENS, Errors.MIN_TOKENS);
         _require(tokens.length <= _getMaxTokens(), Errors.MAX_TOKENS);

--- a/pkg/pool-utils/contracts/NewBasePool.sol
+++ b/pkg/pool-utils/contracts/NewBasePool.sol
@@ -83,7 +83,6 @@ abstract contract NewBasePool is
         BalancerPoolToken(name, symbol, vault)
         BasePoolAuthorization(owner)
         TemporarilyPausable(pauseWindowDuration, bufferPeriodDuration)
-        RecoveryMode(vault)
     {
         // Set immutable state variables - these cannot be read from during construction
         _poolId = poolId;

--- a/pkg/pool-utils/contracts/RecoveryMode.sol
+++ b/pkg/pool-utils/contracts/RecoveryMode.sol
@@ -17,7 +17,6 @@ pragma solidity ^0.7.0;
 import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/BasePoolUserData.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/IRecoveryMode.sol";
-import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
 
@@ -48,18 +47,12 @@ abstract contract RecoveryMode is IRecoveryMode, BasePoolAuthorization {
     using FixedPoint for uint256;
     using BasePoolUserData for bytes;
 
-    IVault private immutable _vault;
-
     /**
      * @dev Reverts if the contract is in Recovery Mode.
      */
     modifier whenNotInRecoveryMode() {
         _ensureNotInRecoveryMode();
         _;
-    }
-
-    constructor(IVault vault) {
-        _vault = vault;
     }
 
     /**
@@ -138,11 +131,4 @@ abstract contract RecoveryMode is IRecoveryMode, BasePoolAuthorization {
         uint256 totalSupply,
         bytes memory userData
     ) internal virtual returns (uint256, uint256[] memory);
-
-    /**
-     * @dev Keep a reference to the Vault, for use in reentrancy protection function calls that require it.
-     */
-    function _getVault() internal view returns (IVault) {
-        return _vault;
-    }
 }

--- a/pkg/pool-utils/contracts/external-fees/ProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/external-fees/ProtocolFeeCache.sol
@@ -178,7 +178,6 @@ abstract contract ProtocolFeeCache is IProtocolFeeCache, RecoveryMode {
         emit ProtocolFeePercentageCacheUpdated(feeCache);
     }
 
-
     // Needed for access by derived pools.
     function _getVaultReentrancyLib() internal view returns (IVaultReentrancyLib) {
         return _vaultReentrancyLib;

--- a/pkg/pool-utils/contracts/external-fees/ProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/external-fees/ProtocolFeeCache.sol
@@ -81,7 +81,11 @@ abstract contract ProtocolFeeCache is IProtocolFeeCache, RecoveryMode {
 
     bytes32 private _feeCache;
 
-    constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, ProviderFeeIDs memory providerFeeIDs) {
+    constructor(
+        IVaultReentrancyLib vaultReentrancyLib,
+        IProtocolFeePercentagesProvider protocolFeeProvider,
+        ProviderFeeIDs memory providerFeeIDs
+    ) {
         _protocolFeeProvider = protocolFeeProvider;
 
         bytes32 feeIds = WordCodec.encodeUint(providerFeeIDs.swap, _SWAP_FEE_ID_OFFSET, _FEE_TYPE_ID_WIDTH) |
@@ -92,7 +96,7 @@ abstract contract ProtocolFeeCache is IProtocolFeeCache, RecoveryMode {
 
         _updateProtocolFeeCache(protocolFeeProvider, feeIds);
 
-        _vaultReentrancyLib = new VaultReentrancyLib(vault);
+        _vaultReentrancyLib = vaultReentrancyLib;
     }
 
     /**
@@ -138,7 +142,7 @@ abstract contract ProtocolFeeCache is IProtocolFeeCache, RecoveryMode {
 
     /// @inheritdoc IProtocolFeeCache
     function updateProtocolFeePercentageCache() external override {
-        _getVaultReentrancyLib().ensureNotInVaultContext();
+        _vaultReentrancyLib.ensureNotInVaultContext();
 
         _beforeProtocolFeeCacheUpdate();
 
@@ -174,6 +178,8 @@ abstract contract ProtocolFeeCache is IProtocolFeeCache, RecoveryMode {
         emit ProtocolFeePercentageCacheUpdated(feeCache);
     }
 
+
+    // Needed for access by derived pools.
     function _getVaultReentrancyLib() internal view returns (IVaultReentrancyLib) {
         return _vaultReentrancyLib;
     }

--- a/pkg/pool-utils/contracts/lib/VaultReentrancyLib.sol
+++ b/pkg/pool-utils/contracts/lib/VaultReentrancyLib.sol
@@ -33,8 +33,14 @@ contract VaultReentrancyLib is IVaultReentrancyLib {
 
     /// @inheritdoc IVaultReentrancyLib
     function ensureNotInVaultContext() external view override {
-        //IVault.UserBalanceOp[] memory noop = new IVault.UserBalanceOp[](0);
-        //_vault.manageUserBalance(noop);
+        // Perform the following operation to trigger the Vault's reentrancy guard.
+        // Use a static call so that it can be a view function (even though the
+        // function is non-view).
+        //
+        // IVault.UserBalanceOp[] memory noop = new IVault.UserBalanceOp[](0);
+        // _vault.manageUserBalance(noop);
+
+        // solhint-disable-next-line var-name-mixedcase
         bytes32 REENTRANCY_ERROR_HASH = keccak256(abi.encodeWithSignature("Error(string)", "BAL#400"));
 
         // read-only re-entrancy protection - this call is always unsuccessful but we need to make sure

--- a/pkg/pool-utils/contracts/lib/VaultReentrancyLib.sol
+++ b/pkg/pool-utils/contracts/lib/VaultReentrancyLib.sol
@@ -43,9 +43,8 @@ contract VaultReentrancyLib is IVaultReentrancyLib {
         // solhint-disable-next-line var-name-mixedcase
         bytes32 REENTRANCY_ERROR_HASH = keccak256(abi.encodeWithSignature("Error(string)", "BAL#400"));
 
-        // read-only re-entrancy protection - we are making a static call on a non-view function. It will either
-        // "succeed" (return with no transaction), or revert. if it reverts, we need to make sure it didn't fail
-        // due to a re-entrancy attack.
+        // read-only re-entrancy protection - this call is always unsuccessful but we need to make sure
+        // it didn't fail due to a re-entrancy attack
         (, bytes memory revertData) = address(_vault).staticcall(
             abi.encodeWithSelector(_vault.manageUserBalance.selector, new address[](0))
         );

--- a/pkg/pool-utils/contracts/lib/VaultReentrancyLib.sol
+++ b/pkg/pool-utils/contracts/lib/VaultReentrancyLib.sol
@@ -43,8 +43,9 @@ contract VaultReentrancyLib is IVaultReentrancyLib {
         // solhint-disable-next-line var-name-mixedcase
         bytes32 REENTRANCY_ERROR_HASH = keccak256(abi.encodeWithSignature("Error(string)", "BAL#400"));
 
-        // read-only re-entrancy protection - this call is always unsuccessful but we need to make sure
-        // it didn't fail due to a re-entrancy attack
+        // read-only re-entrancy protection - we are making a static call on a non-view function. It will either
+        // "succeed" (return with no transaction), or revert. if it reverts, we need to make sure it didn't fail
+        // due to a re-entrancy attack.
         (, bytes memory revertData) = address(_vault).staticcall(
             abi.encodeWithSelector(_vault.manageUserBalance.selector, new address[](0))
         );

--- a/pkg/pool-utils/contracts/lib/VaultReentrancyLib.sol
+++ b/pkg/pool-utils/contracts/lib/VaultReentrancyLib.sol
@@ -13,28 +13,25 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity >=0.7.0 <0.9.0;
+pragma experimental ABIEncoderV2;
 
+import "@balancer-labs/v2-interfaces/contracts/pool-utils/IVaultReentrancyLib.sol";
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 
-library VaultReentrancyLib {
-    /**
-     * @dev Ensure we are not in a Vault context when this function is called, by attempting a no-op internal
-     * balance operation. If we are already in a Vault transaction (e.g., a swap, join, or exit), the Vault's
-     * reentrancy protection will cause this function to revert.
-     *
-     * The exact function call doesn't really matter: we're just trying to trigger the Vault reentrancy check
-     * (and not hurt anything in case it works). An empty operation array with no specific operation at all works
-     * for that purpose, and is also the least expensive in terms of gas and bytecode size.
-     *
-     * Call this at the top of any function that can cause a state change in a pool and is either public itself,
-     * or called by a public function *outside* a Vault operation (e.g., join, exit, or swap).
-     *
-     * If this is *not* called in functions that are vulnerable to the read-only reentrancy issue described
-     * here (https://forum.balancer.fi/t/reentrancy-vulnerability-scope-expanded/4345), those functions are unsafe,
-     * and subject to manipulation that may result in loss of funds.
-     */
-    function ensureNotInVaultContext(IVault vault) internal {
+contract VaultReentrancyLib is IVaultReentrancyLib {
+    IVault private immutable _vault;
+
+    constructor(IVault vault) {
+        _vault = vault;
+    }
+
+    function getVault() external view returns (IVault) {
+        return _vault;
+    }
+
+    /// @inheritdoc IVaultReentrancyLib
+    function ensureNotInVaultContext() external override {
         IVault.UserBalanceOp[] memory noop = new IVault.UserBalanceOp[](0);
-        vault.manageUserBalance(noop);
+        _vault.manageUserBalance(noop);
     }
 }

--- a/pkg/pool-utils/contracts/test/MockBasePool.sol
+++ b/pkg/pool-utils/contracts/test/MockBasePool.sol
@@ -170,9 +170,4 @@ contract MockBasePool is BasePool {
         emit RecoveryModeExit(totalSupply, balances, bptAmountIn);
         return (bptAmountIn, balances);
     }
-
-    // Access the vault from RecoveryMode
-    function vault() external view returns (IVault) {
-        return _getVault();
-    }
 }

--- a/pkg/pool-utils/contracts/test/MockNewBasePool.sol
+++ b/pkg/pool-utils/contracts/test/MockNewBasePool.sol
@@ -157,9 +157,4 @@ contract MockNewBasePool is NewBasePool {
         emit RecoveryModeExit(totalSupply, balances, bptAmountIn);
         return (bptAmountIn, balances);
     }
-
-    // Access the vault from RecoveryMode
-    function vault() external view returns (IVault) {
-        return _getVault();
-    }
 }

--- a/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
@@ -24,7 +24,7 @@ contract MockProtocolFeeCache is ProtocolFeeCache, MockRecoveryModeStorage {
     constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, ProviderFeeIDs memory providerFeeIDs)
         Authentication(bytes32(uint256(address(this))))
         BasePoolAuthorization(msg.sender)
-        ProtocolFeeCache(vault, protocolFeeProvider, providerFeeIDs)
+        ProtocolFeeCache(new VaultReentrancyLib(vault), protocolFeeProvider, providerFeeIDs)
     {
         // solhint-disable-previous-line no-empty-blocks
     }

--- a/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
+++ b/pkg/pool-utils/contracts/test/MockProtocolFeeCache.sol
@@ -24,8 +24,7 @@ contract MockProtocolFeeCache is ProtocolFeeCache, MockRecoveryModeStorage {
     constructor(IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, ProviderFeeIDs memory providerFeeIDs)
         Authentication(bytes32(uint256(address(this))))
         BasePoolAuthorization(msg.sender)
-        ProtocolFeeCache(protocolFeeProvider, providerFeeIDs)
-        MockRecoveryModeStorage(vault)
+        ProtocolFeeCache(vault, protocolFeeProvider, providerFeeIDs)
     {
         // solhint-disable-previous-line no-empty-blocks
     }
@@ -46,10 +45,6 @@ contract MockProtocolFeeCache is ProtocolFeeCache, MockRecoveryModeStorage {
 
     function _getAuthorizer() internal pure override returns (IAuthorizer) {
         return IAuthorizer(address(0));
-    }
-
-    function vault() external view returns (IVault) {
-        return _getVault();
     }
 
     function _doRecoveryModeExit(

--- a/pkg/pool-utils/contracts/test/MockRecoveryModeStorage.sol
+++ b/pkg/pool-utils/contracts/test/MockRecoveryModeStorage.sol
@@ -21,10 +21,6 @@ import "../RecoveryMode.sol";
 abstract contract MockRecoveryModeStorage is RecoveryMode {
     bool private _recoveryMode;
 
-    constructor (IVault vault) RecoveryMode(vault) {
-        // solhint-disable-previous-line no-empty-blocks
-    }
-
     /**
      * @notice Returns whether the pool is in Recovery Mode.
      */

--- a/pkg/pool-utils/contracts/test/MockReentrancyPool.sol
+++ b/pkg/pool-utils/contracts/test/MockReentrancyPool.sol
@@ -30,6 +30,7 @@ contract MockReentrancyPool is BaseGeneralPool {
     using WeightedPoolUserData for bytes;
 
     uint256 private immutable _totalTokens;
+    IVaultReentrancyLib private immutable _vaultReentrancyLib;
 
     event ProtectedFunctionCalled();
 
@@ -59,6 +60,7 @@ contract MockReentrancyPool is BaseGeneralPool {
         )
     {
         _totalTokens = tokens.length;
+        _vaultReentrancyLib = new VaultReentrancyLib(vault);
     }
 
     /**
@@ -66,7 +68,7 @@ contract MockReentrancyPool is BaseGeneralPool {
      * during a Vault operation (join/swap/exit).
      */
     function protectedFunction() public {
-        VaultReentrancyLib.ensureNotInVaultContext(getVault());
+        _vaultReentrancyLib.ensureNotInVaultContext();
 
         emit ProtectedFunctionCalled();
     }

--- a/pkg/pool-utils/test/BasePool.test.ts
+++ b/pkg/pool-utils/test/BasePool.test.ts
@@ -537,10 +537,6 @@ describe('BasePool', function () {
         sender = other;
       });
 
-      it('stores the vault (in RecoveryMode contract)', async () => {
-        expect(await pool.vault()).to.equal(vault.address);
-      });
-
       context('when the sender does not have the recovery mode permission in the authorizer', () => {
         itRevertsWithUnallowedSender();
       });

--- a/pkg/pool-utils/test/NewBasePool.test.ts
+++ b/pkg/pool-utils/test/NewBasePool.test.ts
@@ -489,10 +489,6 @@ describe('NewBasePool', function () {
         sender = other;
       });
 
-      it('stores the vault (in RecoveryMode contract)', async () => {
-        expect(await pool.vault()).to.equal(vault.address);
-      });
-
       context('when the sender does not have the recovery mode permission in the authorizer', () => {
         itRevertsWithUnallowedSender();
       });

--- a/pkg/pool-utils/test/ProtocolFeeCache.test.ts
+++ b/pkg/pool-utils/test/ProtocolFeeCache.test.ts
@@ -109,10 +109,6 @@ describe('ProtocolFeeCache', () => {
         from: admin,
       });
     });
-
-    it('stores the Vault', async () => {
-      expect(await protocolFeeCache.vault()).to.eq(vault.address);
-    });
   });
 
   function itTestsProtocolFeePercentages(providerFeeIds: ProviderFeeIDs): void {

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -59,7 +59,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
     uint256 internal immutable _normalizedWeight6;
     uint256 internal immutable _normalizedWeight7;
 
-    struct NewPoolParams {
+    struct WeightedPoolParams {
         string name;
         string symbol;
         IERC20[] tokens;
@@ -69,29 +69,34 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
         uint256 swapFeePercentage;
     }
 
+    struct WeightedPoolConfigParams {
+        IVault vault;
+        IProtocolFeePercentagesProvider protocolFeeProvider;
+        IVaultReentrancyLib vaultReentrancyLib;
+        uint256 pauseWindowDuration;
+        uint256 bufferPeriodDuration;
+    }
+
     constructor(
-        NewPoolParams memory params,
-        IVault vault,
-        IProtocolFeePercentagesProvider protocolFeeProvider,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration,
+        WeightedPoolParams memory params,
+        WeightedPoolConfigParams memory configParams,
         address owner
     )
         BaseWeightedPool(
-            vault,
+            configParams.vault,
             params.name,
             params.symbol,
             params.tokens,
             params.assetManagers,
             params.swapFeePercentage,
-            pauseWindowDuration,
-            bufferPeriodDuration,
+            configParams.pauseWindowDuration,
+            configParams.bufferPeriodDuration,
             owner,
             false
         )
         ProtocolFeeCache(
-            vault,
-            protocolFeeProvider,
+            configParams.vaultReentrancyLib,
+            configParams.protocolFeeProvider,
             ProviderFeeIDs({ swap: ProtocolFeeType.SWAP, yield: ProtocolFeeType.YIELD, aum: ProtocolFeeType.AUM })
         )
         WeightedPoolProtocolFees(params.tokens.length, params.rateProviders)

--- a/pkg/pool-weighted/contracts/WeightedPool.sol
+++ b/pkg/pool-weighted/contracts/WeightedPool.sol
@@ -90,6 +90,7 @@ contract WeightedPool is BaseWeightedPool, WeightedPoolProtocolFees {
             false
         )
         ProtocolFeeCache(
+            vault,
             protocolFeeProvider,
             ProviderFeeIDs({ swap: ProtocolFeeType.SWAP, yield: ProtocolFeeType.YIELD, aum: ProtocolFeeType.AUM })
         )

--- a/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/WeightedPoolFactory.sol
@@ -22,6 +22,8 @@ import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolFactory.sol";
 import "./WeightedPool.sol";
 
 contract WeightedPoolFactory is BasePoolFactory {
+    IVaultReentrancyLib private immutable _vaultReentrancyLib;
+
     constructor(
         IVault vault,
         IProtocolFeePercentagesProvider protocolFeeProvider,
@@ -36,7 +38,7 @@ contract WeightedPoolFactory is BasePoolFactory {
             type(WeightedPool).creationCode
         )
     {
-        // solhint-disable-previous-line no-empty-blocks
+        _vaultReentrancyLib = new VaultReentrancyLib(vault);
     }
 
     /**
@@ -57,7 +59,7 @@ contract WeightedPoolFactory is BasePoolFactory {
         return
             _create(
                 abi.encode(
-                    WeightedPool.NewPoolParams({
+                    WeightedPool.WeightedPoolParams({
                         name: name,
                         symbol: symbol,
                         tokens: tokens,
@@ -66,10 +68,13 @@ contract WeightedPoolFactory is BasePoolFactory {
                         assetManagers: new address[](tokens.length), // Don't allow asset managers,
                         swapFeePercentage: swapFeePercentage
                     }),
-                    getVault(),
-                    getProtocolFeePercentagesProvider(),
-                    pauseWindowDuration,
-                    bufferPeriodDuration,
+                    WeightedPool.WeightedPoolConfigParams({
+                        vault: getVault(),
+                        protocolFeeProvider: getProtocolFeePercentagesProvider(),
+                        vaultReentrancyLib: _vaultReentrancyLib,
+                        pauseWindowDuration: pauseWindowDuration,
+                        bufferPeriodDuration: bufferPeriodDuration
+                    }),
                     owner
                 ),
                 salt

--- a/pkg/pool-weighted/contracts/managed/ComposablePoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ComposablePoolTokenLib.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-interfaces/contracts/pool-weighted/IComposablePoolTokenLib.sol";
+
+import "./ManagedPool.sol";
+
+contract ComposablePoolTokenLib is IComposablePoolTokenLib {
+    IVault private immutable _vault;
+    bytes32 private immutable _poolId;
+
+    constructor(ManagedPool pool) {
+        _vault = pool.getVault();
+        _poolId = pool.getPoolId();
+    }
+
+    function getPoolTokens() external view override returns (IERC20[] memory, uint256[] memory) {
+        (IERC20[] memory registeredTokens, uint256[] memory registeredBalances, ) = _vault.getPoolTokens(_poolId);
+
+        return ComposablePoolLib.dropBpt(registeredTokens, registeredBalances);
+    }
+}

--- a/pkg/pool-weighted/contracts/managed/ComposablePoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ComposablePoolTokenLib.sol
@@ -23,7 +23,11 @@ contract ComposablePoolTokenLib is IComposablePoolTokenLib {
     IERC20 private immutable _pool;
     bytes32 private immutable _poolId;
 
-    constructor(IERC20 pool, IVault vault, bytes32 poolId) {
+    constructor(
+        IERC20 pool,
+        IVault vault,
+        bytes32 poolId
+    ) {
         _pool = pool;
         _vault = vault;
         _poolId = poolId;

--- a/pkg/pool-weighted/contracts/managed/ComposablePoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ComposablePoolTokenLib.sol
@@ -15,7 +15,7 @@
 pragma solidity ^0.7.0;
 
 import "@balancer-labs/v2-interfaces/contracts/pool-weighted/IComposablePoolTokenLib.sol";
-
+import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol";
 import "./ManagedPool.sol";
 
 contract ComposablePoolTokenLib is IComposablePoolTokenLib {
@@ -45,5 +45,14 @@ contract ComposablePoolTokenLib is IComposablePoolTokenLib {
         // This ensures that `cash + managed` cannot overflow and the Pool's balance of BPT cannot exceed the total
         // supply so we cannot underflow either.
         return _pool.totalSupply() - (cash + managed);
+    }
+
+    function validatePool(address pool) external view override {
+        ManagedPool managedPool = ManagedPool(pool);
+
+        _require(
+            pool == address(_pool) && managedPool.getVault() == _vault && managedPool.getPoolId() == _poolId,
+            Errors.SHOULD_NOT_HAPPEN
+        );
     }
 }

--- a/pkg/pool-weighted/contracts/managed/ComposablePoolTokenLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ComposablePoolTokenLib.sol
@@ -20,13 +20,13 @@ import "./ManagedPool.sol";
 
 contract ComposablePoolTokenLib is IComposablePoolTokenLib {
     IVault private immutable _vault;
-    bytes32 private immutable _poolId;
     IERC20 private immutable _pool;
+    bytes32 private immutable _poolId;
 
-    constructor(ManagedPool pool) {
+    constructor(IERC20 pool, IVault vault, bytes32 poolId) {
         _pool = pool;
-        _vault = pool.getVault();
-        _poolId = pool.getPoolId();
+        _vault = vault;
+        _poolId = poolId;
     }
 
     function getPoolTokens() external view override returns (IERC20[] memory, uint256[] memory) {

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -74,6 +74,7 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
         IProtocolFeePercentagesProvider protocolFeeProvider;
         IExternalWeightedMath weightedMath;
         IRecoveryModeHelper recoveryModeHelper;
+        IManagedPoolOwnerOnlyLib ownerOnlyLib;
         uint256 pauseWindowDuration;
         uint256 bufferPeriodDuration;
         string version;
@@ -99,7 +100,7 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
             configParams.bufferPeriodDuration,
             owner
         )
-        ManagedPoolSettings(settingsParams, configParams.protocolFeeProvider)
+        ManagedPoolSettings(settingsParams, configParams.protocolFeeProvider, configParams.ownerOnlyLib)
     {
         _weightedMath = configParams.weightedMath;
         _recoveryModeHelper = configParams.recoveryModeHelper;

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -117,7 +117,10 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
         _version = configParams.version;
     }
 
-    // This requires the poolId, which is not accessible during construction
+    /**
+     * @dev This must be called after deployment (e.g., by the factory). The poolId is immutable, and therefore
+     * not available during construction.
+     */
     function initComposablePoolTokenLib() external {
         if (_composablePoolTokenLib == IComposablePoolTokenLib(0)) {
             _composablePoolTokenLib = new ComposablePoolTokenLib(IERC20(this), getVault(), getPoolId());

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -18,6 +18,7 @@ pragma experimental ABIEncoderV2;
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/IVersion.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/IRecoveryModeHelper.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-weighted/IExternalWeightedMath.sol";
+import "@balancer-labs/v2-interfaces/contracts/pool-weighted/IComposablePoolTokenLib.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-weighted/WeightedPoolUserData.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/math/FixedPoint.sol";
@@ -28,6 +29,7 @@ import "@balancer-labs/v2-pool-utils/contracts/lib/ComposablePoolLib.sol";
 import "@balancer-labs/v2-pool-utils/contracts/lib/PoolRegistrationLib.sol";
 
 import "./ManagedPoolSettings.sol";
+import "./ComposablePoolTokenLib.sol";
 
 /**
  * @title Managed Pool
@@ -61,6 +63,8 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
     uint256 private constant _PREMINTED_TOKEN_BALANCE = 2**(111);
     IExternalWeightedMath private immutable _weightedMath;
     IRecoveryModeHelper private immutable _recoveryModeHelper;
+    IComposablePoolTokenLib private immutable _composablePoolTokenLib;
+
     string private _version;
 
     struct ManagedPoolParams {
@@ -104,6 +108,7 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
     {
         _weightedMath = configParams.weightedMath;
         _recoveryModeHelper = configParams.recoveryModeHelper;
+        _composablePoolTokenLib = new ComposablePoolTokenLib(this);
         _version = configParams.version;
     }
 
@@ -743,10 +748,7 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
      * internal functions outside of the swap/join/exit hooks.
      */
     function _getPoolTokens() internal view override returns (IERC20[] memory, uint256[] memory) {
-        (IERC20[] memory registeredTokens, uint256[] memory registeredBalances, ) = getVault().getPoolTokens(
-            getPoolId()
-        );
-        return ComposablePoolLib.dropBpt(registeredTokens, registeredBalances);
+        return _composablePoolTokenLib.getPoolTokens();
     }
 
     // Circuit Breakers

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -63,7 +63,7 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
     uint256 private constant _PREMINTED_TOKEN_BALANCE = 2**(111);
     IExternalWeightedMath private immutable _weightedMath;
     IRecoveryModeHelper private immutable _recoveryModeHelper;
-    IComposablePoolTokenLib private immutable _composablePoolTokenLib;
+    IComposablePoolTokenLib private _composablePoolTokenLib;
 
     string private _version;
 
@@ -108,8 +108,14 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
     {
         _weightedMath = configParams.weightedMath;
         _recoveryModeHelper = configParams.recoveryModeHelper;
-        _composablePoolTokenLib = new ComposablePoolTokenLib(this);
         _version = configParams.version;
+    }
+
+    // This requires the poolId, which is not accessible during construction
+    function initComposablePoolTokenLib() external {
+        if (_composablePoolTokenLib == IComposablePoolTokenLib(0)) {
+            _composablePoolTokenLib = new ComposablePoolTokenLib(IERC20(this), getVault(), getPoolId());
+        }
     }
 
     function version() external view override returns (string memory) {

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -104,7 +104,12 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
             configParams.bufferPeriodDuration,
             owner
         )
-        ManagedPoolSettings(settingsParams, configParams.vault, configParams.protocolFeeProvider, configParams.ownerOnlyLib)
+        ManagedPoolSettings(
+            settingsParams,
+            configParams.vault,
+            configParams.protocolFeeProvider,
+            configParams.ownerOnlyLib
+        )
     {
         _weightedMath = configParams.weightedMath;
         _recoveryModeHelper = configParams.recoveryModeHelper;
@@ -133,6 +138,7 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
     function _getComposablePoolTokenLib() internal view returns (IComposablePoolTokenLib) {
         return _composablePoolTokenLib;
     }
+
     // Virtual Supply
 
     /**

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -76,6 +76,7 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
     struct ManagedPoolConfigParams {
         IVault vault;
         IProtocolFeePercentagesProvider protocolFeeProvider;
+        IVaultReentrancyLib vaultReentrancyLib;
         IExternalWeightedMath weightedMath;
         IRecoveryModeHelper recoveryModeHelper;
         IManagedPoolOwnerOnlyLib ownerOnlyLib;
@@ -106,8 +107,8 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
         )
         ManagedPoolSettings(
             settingsParams,
-            configParams.vault,
             configParams.protocolFeeProvider,
+            configParams.vaultReentrancyLib,
             configParams.ownerOnlyLib
         )
     {

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -121,9 +121,13 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
      * @dev This must be called after deployment (e.g., by the factory). The poolId is immutable, and therefore
      * not available during construction.
      */
-    function initComposablePoolTokenLib() external {
+    function initComposablePoolTokenLib(IComposablePoolTokenLib composablePoolTokenLib) external {
         if (_composablePoolTokenLib == IComposablePoolTokenLib(0)) {
-            _composablePoolTokenLib = new ComposablePoolTokenLib(IERC20(this), getVault(), getPoolId());
+            // This has to be deployed outside the pool to keep it external.
+            // Ensure the configuration matches.
+            composablePoolTokenLib.validatePool(address(this));
+
+            _composablePoolTokenLib = composablePoolTokenLib;
         }
     }
 

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -124,6 +124,9 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
         return _recoveryModeHelper;
     }
 
+    function _getComposablePoolTokenLib() internal view returns (IComposablePoolTokenLib) {
+        return _composablePoolTokenLib;
+    }
     // Virtual Supply
 
     /**
@@ -138,11 +141,7 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
      * inputs, which is the preferred approach whenever possible, as it avoids extra calls to the Vault.
      */
     function _getVirtualSupply() internal view override returns (uint256) {
-        (uint256 cash, uint256 managed, , ) = getVault().getPoolTokenInfo(getPoolId(), IERC20(this));
-        // We don't need to use SafeMath here as the Vault restricts token balances to be less than 2**112.
-        // This ensures that `cash + managed` cannot overflow and the Pool's balance of BPT cannot exceed the total
-        // supply so we cannot underflow either.
-        return totalSupply() - (cash + managed);
+        return _getComposablePoolTokenLib().getVirtualSupply();
     }
 
     // Swap Hooks
@@ -748,7 +747,7 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
      * internal functions outside of the swap/join/exit hooks.
      */
     function _getPoolTokens() internal view override returns (IERC20[] memory, uint256[] memory) {
-        return _composablePoolTokenLib.getPoolTokens();
+        return _getComposablePoolTokenLib().getPoolTokens();
     }
 
     // Circuit Breakers

--- a/pkg/pool-weighted/contracts/managed/ManagedPool.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPool.sol
@@ -104,7 +104,7 @@ contract ManagedPool is IVersion, ManagedPoolSettings {
             configParams.bufferPeriodDuration,
             owner
         )
-        ManagedPoolSettings(settingsParams, configParams.protocolFeeProvider, configParams.ownerOnlyLib)
+        ManagedPoolSettings(settingsParams, configParams.vault, configParams.protocolFeeProvider, configParams.ownerOnlyLib)
     {
         _weightedMath = configParams.weightedMath;
         _recoveryModeHelper = configParams.recoveryModeHelper;

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
@@ -41,7 +41,9 @@ import "../ExternalWeightedMath.sol";
 contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFactory {
     IExternalWeightedMath private immutable _weightedMath;
     IRecoveryModeHelper private immutable _recoveryModeHelper;
+    IVaultReentrancyLib private immutable _vaultReentrancyLib;
     IManagedPoolOwnerOnlyLib private immutable _ownerOnlyLib;
+
     string private _poolVersion;
 
     constructor(
@@ -63,6 +65,7 @@ contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFact
     {
         _weightedMath = new ExternalWeightedMath();
         _recoveryModeHelper = new RecoveryModeHelper(vault);
+        _vaultReentrancyLib = new VaultReentrancyLib(vault);
         _ownerOnlyLib = new ManagedPoolOwnerOnlyLib(address(this));
         _poolVersion = poolVersion;
     }
@@ -77,6 +80,10 @@ contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFact
 
     function getRecoveryModeHelper() external view returns (IRecoveryModeHelper) {
         return _recoveryModeHelper;
+    }
+
+    function getVaultReentrancyLib() external view returns (IVaultReentrancyLib) {
+        return _vaultReentrancyLib;
     }
 
     function getOwnerOnlyLib() external view returns (IManagedPoolOwnerOnlyLib) {
@@ -97,6 +104,7 @@ contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFact
         ManagedPool.ManagedPoolConfigParams memory configParams = ManagedPool.ManagedPoolConfigParams({
             vault: getVault(),
             protocolFeeProvider: getProtocolFeePercentagesProvider(),
+            vaultReentrancyLib: _vaultReentrancyLib,
             weightedMath: _weightedMath,
             recoveryModeHelper: _recoveryModeHelper,
             ownerOnlyLib: _ownerOnlyLib,

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
@@ -23,6 +23,7 @@ import "@balancer-labs/v2-pool-utils/contracts/RecoveryModeHelper.sol";
 import "@balancer-labs/v2-pool-utils/contracts/Version.sol";
 
 import "./ManagedPool.sol";
+import "./ManagedPoolOwnerOnlyLib.sol";
 import "../ExternalWeightedMath.sol";
 
 /**
@@ -40,6 +41,7 @@ import "../ExternalWeightedMath.sol";
 contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFactory {
     IExternalWeightedMath private immutable _weightedMath;
     IRecoveryModeHelper private immutable _recoveryModeHelper;
+    IManagedPoolOwnerOnlyLib private immutable _ownerOnlyLib;
     string private _poolVersion;
 
     constructor(
@@ -61,6 +63,7 @@ contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFact
     {
         _weightedMath = new ExternalWeightedMath();
         _recoveryModeHelper = new RecoveryModeHelper(vault);
+        _ownerOnlyLib = new ManagedPoolOwnerOnlyLib(address(this));
         _poolVersion = poolVersion;
     }
 
@@ -92,6 +95,7 @@ contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFact
             protocolFeeProvider: getProtocolFeePercentagesProvider(),
             weightedMath: _weightedMath,
             recoveryModeHelper: _recoveryModeHelper,
+            ownerOnlyLib: _ownerOnlyLib,
             pauseWindowDuration: pauseWindowDuration,
             bufferPeriodDuration: bufferPeriodDuration,
             version: getPoolVersion()

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
@@ -115,6 +115,8 @@ contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFact
 
         pool = _create(abi.encode(params, configParams, settingsParams, owner), salt);
 
+        // This deploys the ComposablePoolTokenLib for this pool. Has to be done after construction,
+        // so that the poolId is available.
         ManagedPool(pool).initComposablePoolTokenLib();
     }
 }

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
@@ -101,6 +101,8 @@ contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFact
             version: getPoolVersion()
         });
 
-        return _create(abi.encode(params, configParams, settingsParams, owner), salt);
+        pool = _create(abi.encode(params, configParams, settingsParams, owner), salt);
+
+        ManagedPool(pool).initComposablePoolTokenLib();
     }
 }

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
@@ -79,6 +79,10 @@ contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFact
         return _recoveryModeHelper;
     }
 
+    function getOwnerOnlyLib() external view returns (IManagedPoolOwnerOnlyLib) {
+        return _ownerOnlyLib;
+    }
+
     /**
      * @dev Deploys a new `ManagedPool`. The owner should be a contract, deployed by another factory.
      */

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
@@ -117,6 +117,12 @@ contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFact
 
         // This deploys the ComposablePoolTokenLib for this pool. Has to be done after construction,
         // so that the poolId is available.
-        ManagedPool(pool).initComposablePoolTokenLib();
+        IComposablePoolTokenLib composablePoolTokenLib = new ComposablePoolTokenLib(
+            IERC20(pool),
+            getVault(),
+            ManagedPool(pool).getPoolId()
+        );
+
+        ManagedPool(pool).initComposablePoolTokenLib(composablePoolTokenLib);
     }
 }

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolOwnerOnlyLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolOwnerOnlyLib.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-interfaces/contracts/pool-weighted/IManagedPoolOwnerOnlyLib.sol";
+
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/Authentication.sol";
+
+contract ManagedPoolOwnerOnlyLib is IManagedPoolOwnerOnlyLib {
+    bytes32 private immutable _actionIdDisambiguator;
+
+    // The disambiguator for a pool will be the pool's factory
+    constructor(address actionIdDisambiguator) {
+        _actionIdDisambiguator = bytes32(uint256(actionIdDisambiguator));
+    }
+
+    function isOwnerOnlyAction(bytes32 actionId) external view override returns (bool) {
+       return
+            (actionId == getActionId(bytes4(keccak256(bytes("updateWeightsGradually(uint256,uint256,uint256[],uint256[]"))))) ||
+            (actionId == getActionId(bytes4(keccak256(bytes("updateSwapFeeGradually(uint256,uint256,uint256,uint256)"))))) ||
+            (actionId == getActionId(bytes4(keccak256(bytes("setJoinExitEnabled(bool)"))))) ||
+            (actionId == getActionId(bytes4(keccak256(bytes("setSwapEnabled(bool)"))))) ||
+            (actionId == getActionId(bytes4(keccak256(bytes("addAllowedAddress(address)"))))) ||
+            (actionId == getActionId(bytes4(keccak256(bytes("removeAllowedAddress(address)"))))) ||
+            (actionId == getActionId(bytes4(keccak256(bytes("setMustAllowlistLPs(bool)"))))) ||
+            (actionId == getActionId(bytes4(keccak256(bytes("addToken(address,address,uint256,uint256,address)"))))) ||
+            (actionId == getActionId(bytes4(keccak256(bytes("removeToken(address,uint256,address)"))))) ||
+            (actionId == getActionId(bytes4(keccak256(bytes("setManagementAumFeePercentage(uint256)"))))) ||
+            (actionId == getActionId(bytes4(keccak256(bytes("setCircuitBreakers(address[],uint256[],uint256[],uint256[])")))));
+    }
+
+    function getActionId(bytes4 selector) private view returns (bytes32) {
+        // Each external function is dynamically assigned an action identifier as the hash of the disambiguator and the
+        // function selector. Disambiguation is necessary to avoid potential collisions in the function selectors of
+        // multiple contracts.
+        return keccak256(abi.encodePacked(_actionIdDisambiguator, selector));
+    }
+}

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolOwnerOnlyLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolOwnerOnlyLib.sol
@@ -16,8 +16,6 @@ pragma solidity ^0.7.0;
 
 import "@balancer-labs/v2-interfaces/contracts/pool-weighted/IManagedPoolOwnerOnlyLib.sol";
 
-import "@balancer-labs/v2-solidity-utils/contracts/helpers/Authentication.sol";
-
 contract ManagedPoolOwnerOnlyLib is IManagedPoolOwnerOnlyLib {
     bytes32 private immutable _actionIdDisambiguator;
 
@@ -28,7 +26,7 @@ contract ManagedPoolOwnerOnlyLib is IManagedPoolOwnerOnlyLib {
 
     function isOwnerOnlyAction(bytes32 actionId) external view override returns (bool) {
        return
-            (actionId == getActionId(bytes4(keccak256(bytes("updateWeightsGradually(uint256,uint256,uint256[],uint256[]"))))) ||
+            (actionId == getActionId(bytes4(keccak256(bytes("updateWeightsGradually(uint256,uint256,address[],uint256[]"))))) ||
             (actionId == getActionId(bytes4(keccak256(bytes("updateSwapFeeGradually(uint256,uint256,uint256,uint256)"))))) ||
             (actionId == getActionId(bytes4(keccak256(bytes("setJoinExitEnabled(bool)"))))) ||
             (actionId == getActionId(bytes4(keccak256(bytes("setSwapEnabled(bool)"))))) ||

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolOwnerOnlyLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolOwnerOnlyLib.sol
@@ -25,21 +25,23 @@ contract ManagedPoolOwnerOnlyLib is IManagedPoolOwnerOnlyLib {
     }
 
     function isOwnerOnlyAction(bytes32 actionId) external view override returns (bool) {
-       return
-            (actionId == getActionId(bytes4(keccak256(bytes("updateWeightsGradually(uint256,uint256,address[],uint256[]"))))) ||
-            (actionId == getActionId(bytes4(keccak256(bytes("updateSwapFeeGradually(uint256,uint256,uint256,uint256)"))))) ||
-            (actionId == getActionId(bytes4(keccak256(bytes("setJoinExitEnabled(bool)"))))) ||
-            (actionId == getActionId(bytes4(keccak256(bytes("setSwapEnabled(bool)"))))) ||
-            (actionId == getActionId(bytes4(keccak256(bytes("addAllowedAddress(address)"))))) ||
-            (actionId == getActionId(bytes4(keccak256(bytes("removeAllowedAddress(address)"))))) ||
-            (actionId == getActionId(bytes4(keccak256(bytes("setMustAllowlistLPs(bool)"))))) ||
-            (actionId == getActionId(bytes4(keccak256(bytes("addToken(address,address,uint256,uint256,address)"))))) ||
-            (actionId == getActionId(bytes4(keccak256(bytes("removeToken(address,uint256,address)"))))) ||
-            (actionId == getActionId(bytes4(keccak256(bytes("setManagementAumFeePercentage(uint256)"))))) ||
-            (actionId == getActionId(bytes4(keccak256(bytes("setCircuitBreakers(address[],uint256[],uint256[],uint256[])")))));
+        // solhint-disable max-line-length
+        // prettier-ignore
+        return
+            (actionId ==_getActionId(bytes4(keccak256(bytes("updateWeightsGradually(uint256,uint256,address[],uint256[]"))))) ||
+            (actionId == _getActionId(bytes4(keccak256(bytes("updateSwapFeeGradually(uint256,uint256,uint256,uint256)"))))) ||
+            (actionId == _getActionId(bytes4(keccak256(bytes("setJoinExitEnabled(bool)"))))) ||
+            (actionId == _getActionId(bytes4(keccak256(bytes("setSwapEnabled(bool)"))))) ||
+            (actionId == _getActionId(bytes4(keccak256(bytes("addAllowedAddress(address)"))))) ||
+            (actionId == _getActionId(bytes4(keccak256(bytes("removeAllowedAddress(address)"))))) ||
+            (actionId == _getActionId(bytes4(keccak256(bytes("setMustAllowlistLPs(bool)"))))) ||
+            (actionId == _getActionId(bytes4(keccak256(bytes("addToken(address,address,uint256,uint256,address)"))))) ||
+            (actionId == _getActionId(bytes4(keccak256(bytes("removeToken(address,uint256,address)"))))) ||
+            (actionId == _getActionId(bytes4(keccak256(bytes("setManagementAumFeePercentage(uint256)"))))) ||
+            (actionId == _getActionId(bytes4(keccak256(bytes("setCircuitBreakers(address[],uint256[],uint256[],uint256[])")))));
     }
 
-    function getActionId(bytes4 selector) private view returns (bytes32) {
+    function _getActionId(bytes4 selector) private view returns (bytes32) {
         // Each external function is dynamically assigned an action identifier as the hash of the disambiguator and the
         // function selector. Disambiguation is necessary to avoid potential collisions in the function selectors of
         // multiple contracts.

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolOwnerOnlyLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolOwnerOnlyLib.sol
@@ -28,7 +28,7 @@ contract ManagedPoolOwnerOnlyLib is IManagedPoolOwnerOnlyLib {
         // solhint-disable max-line-length
         // prettier-ignore
         return
-            (actionId == _getActionId(bytes4(keccak256(bytes("updateWeightsGradually(uint256,uint256,address[],uint256[]"))))) ||
+            (actionId == _getActionId(bytes4(keccak256(bytes("updateWeightsGradually(uint256,uint256,address[],uint256[])"))))) ||
             (actionId == _getActionId(bytes4(keccak256(bytes("updateSwapFeeGradually(uint256,uint256,uint256,uint256)"))))) ||
             (actionId == _getActionId(bytes4(keccak256(bytes("setJoinExitEnabled(bool)"))))) ||
             (actionId == _getActionId(bytes4(keccak256(bytes("setSwapEnabled(bool)"))))) ||

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolOwnerOnlyLib.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolOwnerOnlyLib.sol
@@ -28,7 +28,7 @@ contract ManagedPoolOwnerOnlyLib is IManagedPoolOwnerOnlyLib {
         // solhint-disable max-line-length
         // prettier-ignore
         return
-            (actionId ==_getActionId(bytes4(keccak256(bytes("updateWeightsGradually(uint256,uint256,address[],uint256[]"))))) ||
+            (actionId == _getActionId(bytes4(keccak256(bytes("updateWeightsGradually(uint256,uint256,address[],uint256[]"))))) ||
             (actionId == _getActionId(bytes4(keccak256(bytes("updateSwapFeeGradually(uint256,uint256,uint256,uint256)"))))) ||
             (actionId == _getActionId(bytes4(keccak256(bytes("setJoinExitEnabled(bool)"))))) ||
             (actionId == _getActionId(bytes4(keccak256(bytes("setSwapEnabled(bool)"))))) ||

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -122,18 +122,18 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
     /**
      * @dev Reverts if called in the middle of a Vault operation; has no effect otherwise.
      */
-    function _ensureNotInVaultContext() private {
+    function _ensureNotInVaultContext() private view {
         _getVaultReentrancyLib().ensureNotInVaultContext();
     }
 
     constructor(
         ManagedPoolSettingsParams memory params,
-        IVault vault,
         IProtocolFeePercentagesProvider protocolFeeProvider,
+        IVaultReentrancyLib vaultReentrancyLib,
         IManagedPoolOwnerOnlyLib ownerOnlyLib
     )
         ProtocolFeeCache(
-            vault,
+            vaultReentrancyLib,
             protocolFeeProvider,
             ProviderFeeIDs({ swap: ProtocolFeeType.SWAP, yield: ProtocolFeeType.YIELD, aum: params.aumFeeId })
         )

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -123,11 +123,12 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
      * @dev Reverts if called in the middle of a Vault operation; has no effect otherwise.
      */
     function _ensureNotInVaultContext() private {
-        VaultReentrancyLib.ensureNotInVaultContext(getVault());
+        _getVaultReentrancyLib().ensureNotInVaultContext();
     }
 
-    constructor(ManagedPoolSettingsParams memory params, IProtocolFeePercentagesProvider protocolFeeProvider, IManagedPoolOwnerOnlyLib ownerOnlyLib)
+    constructor(ManagedPoolSettingsParams memory params, IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, IManagedPoolOwnerOnlyLib ownerOnlyLib)
         ProtocolFeeCache(
+            vault,
             protocolFeeProvider,
             ProviderFeeIDs({ swap: ProtocolFeeType.SWAP, yield: ProtocolFeeType.YIELD, aum: params.aumFeeId })
         )

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -126,7 +126,12 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
         _getVaultReentrancyLib().ensureNotInVaultContext();
     }
 
-    constructor(ManagedPoolSettingsParams memory params, IVault vault, IProtocolFeePercentagesProvider protocolFeeProvider, IManagedPoolOwnerOnlyLib ownerOnlyLib)
+    constructor(
+        ManagedPoolSettingsParams memory params,
+        IVault vault,
+        IProtocolFeePercentagesProvider protocolFeeProvider,
+        IManagedPoolOwnerOnlyLib ownerOnlyLib
+    )
         ProtocolFeeCache(
             vault,
             protocolFeeProvider,
@@ -879,7 +884,7 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
     }
 
     // Misc
-    
+
     /**
      * @dev Enumerates all ownerOnly functions in Managed Pool.
      */

--- a/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolSettings.sol
@@ -878,7 +878,6 @@ abstract contract ManagedPoolSettings is NewBasePool, ProtocolFeeCache, IManaged
     }
 
     // Misc
-    // bytes4 selector = bytes4(keccak256(bytes("foo(uint256,bool)")));
     
     /**
      * @dev Enumerates all ownerOnly functions in Managed Pool.

--- a/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
@@ -51,7 +51,7 @@ contract MockManagedPoolSettings is ManagedPoolSettings {
             30 days,
             owner
         )
-        ManagedPoolSettings(settingsParams, configParams.vault, configParams.protocolFeeProvider, configParams.ownerOnlyLib)
+        ManagedPoolSettings(settingsParams, configParams.protocolFeeProvider, new VaultReentrancyLib(configParams.vault), configParams.ownerOnlyLib)
     {
         _weightedMath = configParams.weightedMath;
         _recoveryModeHelper = configParams.recoveryModeHelper;

--- a/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
+++ b/pkg/pool-weighted/contracts/test/MockManagedPoolSettings.sol
@@ -44,23 +44,27 @@ contract MockManagedPoolSettings is ManagedPoolSettings {
     )
         NewBasePool(
             configParams.vault,
-            PoolRegistrationLib.registerPoolWithAssetManagers(
-                configParams.vault,
-                IVault.PoolSpecialization.MINIMAL_SWAP_INFO,
-                settingsParams.tokens,
-                assetManagers
-            ),
+            _registeredPoolId(configParams.vault, settingsParams.tokens, assetManagers),
             "MockManagedPoolName",
             "MockManagedPoolSymbol",
             90 days,
             30 days,
             owner
         )
-        ManagedPoolSettings(settingsParams, configParams.protocolFeeProvider, configParams.ownerOnlyLib)
+        ManagedPoolSettings(settingsParams, configParams.vault, configParams.protocolFeeProvider, configParams.ownerOnlyLib)
     {
         _weightedMath = configParams.weightedMath;
         _recoveryModeHelper = configParams.recoveryModeHelper;
         _ownerOnlyLib = configParams.ownerOnlyLib;
+    }
+
+    function _registeredPoolId(IVault vault, IERC20[] memory tokens, address[] memory assetManagers) private returns (bytes32) {
+        return PoolRegistrationLib.registerPoolWithAssetManagers(
+                vault,
+                IVault.PoolSpecialization.MINIMAL_SWAP_INFO,
+                tokens,
+                assetManagers
+            );
     }
 
     function getVirtualSupply() external view returns (uint256) {

--- a/pkg/pool-weighted/contracts/test/MockWeightedPool.sol
+++ b/pkg/pool-weighted/contracts/test/MockWeightedPool.sol
@@ -19,13 +19,10 @@ import "../WeightedPool.sol";
 
 contract MockWeightedPool is WeightedPool {
     constructor(
-        NewPoolParams memory params,
-        IVault vault,
-        IProtocolFeePercentagesProvider protocolFeeProvider,
-        uint256 pauseWindowDuration,
-        uint256 bufferPeriodDuration,
+        WeightedPoolParams memory params,
+        WeightedPoolConfigParams memory configParams,
         address owner
-    ) WeightedPool(params, vault, protocolFeeProvider, pauseWindowDuration, bufferPeriodDuration, owner) {
+    ) WeightedPool(params, configParams, owner) {
         // solhint-disable-previous-line no-empty-blocks
     }
 

--- a/pkg/pool-weighted/contracts/test/MockWeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/test/MockWeightedPoolProtocolFees.sol
@@ -46,6 +46,7 @@ contract MockWeightedPoolProtocolFees is WeightedPoolProtocolFees {
             false
         )
         ProtocolFeeCache(
+            vault,
             protocolFeeProvider,
             ProviderFeeIDs({ swap: ProtocolFeeType.SWAP, yield: ProtocolFeeType.YIELD, aum: ProtocolFeeType.AUM })
         )

--- a/pkg/pool-weighted/contracts/test/MockWeightedPoolProtocolFees.sol
+++ b/pkg/pool-weighted/contracts/test/MockWeightedPoolProtocolFees.sol
@@ -46,7 +46,7 @@ contract MockWeightedPoolProtocolFees is WeightedPoolProtocolFees {
             false
         )
         ProtocolFeeCache(
-            vault,
+            new VaultReentrancyLib(vault),
             protocolFeeProvider,
             ProviderFeeIDs({ swap: ProtocolFeeType.SWAP, yield: ProtocolFeeType.YIELD, aum: ProtocolFeeType.AUM })
         )

--- a/pkg/pool-weighted/package.json
+++ b/pkg/pool-weighted/package.json
@@ -51,6 +51,7 @@
     "ethereum-waffle": "^3.4.4",
     "ethers": "^5.7.2",
     "hardhat": "^2.12.5",
+    "hardhat-contract-sizer": "^2.8.0",
     "hardhat-ignore-warnings": "^0.2.4",
     "lodash.frompairs": "^4.0.1",
     "lodash.pick": "^4.4.0",

--- a/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
@@ -110,10 +110,6 @@ describe('ManagedPoolFactory', function () {
       pool = await createPool();
     });
 
-    it.only('works', () => {
-      expect(true).to.be.true;
-    });
-    
     it('sets the vault', async () => {
       expect(await pool.getVault()).to.equal(vault.address);
     });

--- a/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
@@ -110,6 +110,10 @@ describe('ManagedPoolFactory', function () {
       pool = await createPool();
     });
 
+    it.only('works', () => {
+      expect(true).to.be.true;
+    });
+    
     it('sets the vault', async () => {
       expect(await pool.getVault()).to.equal(vault.address);
     });

--- a/pkg/pool-weighted/test/WeightedPool.test.ts
+++ b/pkg/pool-weighted/test/WeightedPool.test.ts
@@ -116,6 +116,7 @@ describe('WeightedPool', function () {
 
     sharedBeforeEach('deploy pool', async () => {
       const vault = await Vault.create();
+      const vaultReentrancyLib = await deploy('v2-pool-utils/VaultReentrancyLib', { args: [vault.address] });
 
       pool = await deploy('MockWeightedPool', {
         args: [
@@ -128,11 +129,13 @@ describe('WeightedPool', function () {
             assetManagers: new Array(2).fill(ZERO_ADDRESS),
             swapFeePercentage: POOL_SWAP_FEE_PERCENTAGE,
           },
-
-          vault.address,
-          vault.getFeesProvider().address,
-          0,
-          0,
+          {
+            vault: vault.address,
+            protocolFeeProvider: vault.getFeesProvider().address,
+            vaultReentrancyLib: vaultReentrancyLib.address,
+            pauseWindowDuration: 0,
+            bufferPeriodDuration: 0,
+          },
           ZERO_ADDRESS,
         ],
       });

--- a/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
+++ b/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
@@ -29,7 +29,6 @@ describe('ManagedPool owner only actions', () => {
         ManagedPoolAddRemoveTokenLib: addRemoveTokenLib.address,
       },
     });
-    const ownerOnlyLib = await deploy('ManagedPoolOwnerOnlyLib', { args: [factory.address] });
     pool = await deploy('MockManagedPool', {
       args: [
         { name: '', symbol: '', assetManagers: new Array(2).fill(ZERO_ADDRESS) },
@@ -38,7 +37,7 @@ describe('ManagedPool owner only actions', () => {
           protocolFeeProvider: vault.getFeesProvider().address,
           weightedMath: math.address,
           recoveryModeHelper: recoveryModeHelper.address,
-          ownerOnlyLib: ownerOnlyLib.address,
+          ownerOnlyLib: await factory.getOwnerOnlyLib(),
           pauseWindowDuration: 0,
           bufferPeriodDuration: 0,
           version: '',

--- a/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
+++ b/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
@@ -21,24 +21,19 @@ describe('ManagedPool owner only actions', () => {
     const math = await deploy('ExternalWeightedMath');
     const recoveryModeHelper = await deploy('v2-pool-utils/RecoveryModeHelper', { args: [vault.address] });
     const circuitBreakerLib = await deploy('CircuitBreakerLib');
+    const vaultReentrancyLib = await deploy('VaultReentrancyLib', { args: [vault.address] });
 
-    const factory = await deploy('ManagedPoolFactory', {
-      args: [vault.address, vault.getFeesProvider().address, 'factoryVersion', 'poolVersion', 0, 0],
-      libraries: {
-        CircuitBreakerLib: circuitBreakerLib.address,
-        ManagedPoolAddRemoveTokenLib: addRemoveTokenLib.address,
-      },
-    });
     const signer = (await ethers.getSigners())[0];
     // Can't use the factory one, since the pool is deployed manually
-    const ownerOnlyLib = await deploy('ManagedPoolOwnerOnlyLib', { args: [signer.address]});
-    
+    const ownerOnlyLib = await deploy('ManagedPoolOwnerOnlyLib', { args: [signer.address] });
+
     pool = await deploy('MockManagedPool', {
       args: [
         { name: '', symbol: '', assetManagers: new Array(2).fill(ZERO_ADDRESS) },
         {
           vault: vault.address,
           protocolFeeProvider: vault.getFeesProvider().address,
+          vaultReentrancyLib: vaultReentrancyLib.address,
           weightedMath: math.address,
           recoveryModeHelper: recoveryModeHelper.address,
           ownerOnlyLib: ownerOnlyLib.address,

--- a/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
+++ b/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
@@ -1,3 +1,4 @@
+import { ethers } from 'hardhat';
 import { expect } from 'chai';
 import { Contract } from 'ethers';
 import { Interface } from 'ethers/lib/utils';
@@ -10,9 +11,15 @@ import { fp } from '@balancer-labs/v2-helpers/src/numbers';
 import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { ProtocolFee } from '@balancer-labs/v2-helpers/src/models/vault/types';
 import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 describe('ManagedPool owner only actions', () => {
+  let deployer: SignerWithAddress;
   let pool: Contract;
+
+  before('setup signers', async () => {
+    [deployer] = await ethers.getSigners();
+  });
 
   sharedBeforeEach('deploy pool', async () => {
     const vault = await Vault.create();
@@ -23,9 +30,8 @@ describe('ManagedPool owner only actions', () => {
     const circuitBreakerLib = await deploy('CircuitBreakerLib');
     const vaultReentrancyLib = await deploy('VaultReentrancyLib', { args: [vault.address] });
 
-    const signer = (await ethers.getSigners())[0];
-    // Can't use the factory one, since the pool is deployed manually
-    const ownerOnlyLib = await deploy('ManagedPoolOwnerOnlyLib', { args: [signer.address] });
+    // Has to be initialized with the same account that will deploy the pool, so it will use the same disambiguator
+    const ownerOnlyLib = await deploy('ManagedPoolOwnerOnlyLib', { args: [deployer.address] });
 
     pool = await deploy('MockManagedPool', {
       args: [

--- a/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
+++ b/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
@@ -23,20 +23,13 @@ describe('ManagedPool owner only actions', () => {
     const circuitBreakerLib = await deploy('CircuitBreakerLib');
 
     const factory = await deploy('ManagedPoolFactory', {
-      args: [
-        vault.address,
-        vault.getFeesProvider().address,
-        'factoryVersion',
-        'poolVersion',
-        0,
-        0,
-      ],
+      args: [vault.address, vault.getFeesProvider().address, 'factoryVersion', 'poolVersion', 0, 0],
       libraries: {
         CircuitBreakerLib: circuitBreakerLib.address,
         ManagedPoolAddRemoveTokenLib: addRemoveTokenLib.address,
       },
     });
-    const ownerOnlyLib = await deploy('ManagedPoolOwnerOnlyLib', { args: [factory.address]});
+    const ownerOnlyLib = await deploy('ManagedPoolOwnerOnlyLib', { args: [factory.address] });
     pool = await deploy('MockManagedPool', {
       args: [
         { name: '', symbol: '', assetManagers: new Array(2).fill(ZERO_ADDRESS) },

--- a/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
+++ b/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
@@ -29,6 +29,10 @@ describe('ManagedPool owner only actions', () => {
         ManagedPoolAddRemoveTokenLib: addRemoveTokenLib.address,
       },
     });
+    const signer = (await ethers.getSigners())[0];
+    // Can't use the factory one, since the pool is deployed manually
+    const ownerOnlyLib = await deploy('ManagedPoolOwnerOnlyLib', { args: [signer.address]});
+    
     pool = await deploy('MockManagedPool', {
       args: [
         { name: '', symbol: '', assetManagers: new Array(2).fill(ZERO_ADDRESS) },
@@ -37,7 +41,7 @@ describe('ManagedPool owner only actions', () => {
           protocolFeeProvider: vault.getFeesProvider().address,
           weightedMath: math.address,
           recoveryModeHelper: recoveryModeHelper.address,
-          ownerOnlyLib: await factory.getOwnerOnlyLib(),
+          ownerOnlyLib: ownerOnlyLib.address,
           pauseWindowDuration: 0,
           bufferPeriodDuration: 0,
           version: '',

--- a/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
+++ b/pkg/pool-weighted/test/managed/ownerOnlyActions.test.ts
@@ -21,6 +21,22 @@ describe('ManagedPool owner only actions', () => {
     const math = await deploy('ExternalWeightedMath');
     const recoveryModeHelper = await deploy('v2-pool-utils/RecoveryModeHelper', { args: [vault.address] });
     const circuitBreakerLib = await deploy('CircuitBreakerLib');
+
+    const factory = await deploy('ManagedPoolFactory', {
+      args: [
+        vault.address,
+        vault.getFeesProvider().address,
+        'factoryVersion',
+        'poolVersion',
+        0,
+        0,
+      ],
+      libraries: {
+        CircuitBreakerLib: circuitBreakerLib.address,
+        ManagedPoolAddRemoveTokenLib: addRemoveTokenLib.address,
+      },
+    });
+    const ownerOnlyLib = await deploy('ManagedPoolOwnerOnlyLib', { args: [factory.address]});
     pool = await deploy('MockManagedPool', {
       args: [
         { name: '', symbol: '', assetManagers: new Array(2).fill(ZERO_ADDRESS) },
@@ -29,6 +45,7 @@ describe('ManagedPool owner only actions', () => {
           protocolFeeProvider: vault.getFeesProvider().address,
           weightedMath: math.address,
           recoveryModeHelper: recoveryModeHelper.address,
+          ownerOnlyLib: ownerOnlyLib.address,
           pauseWindowDuration: 0,
           bufferPeriodDuration: 0,
           version: '',

--- a/pkg/standalone-utils/contracts/test/MockRecoveryRateProviderPool.sol
+++ b/pkg/standalone-utils/contracts/test/MockRecoveryRateProviderPool.sol
@@ -28,7 +28,6 @@ contract MockRecoveryRateProviderPool is IRateProviderPool, BasePoolAuthorizatio
     constructor(IVault vault, IRateProvider[] memory rateProviders)
         Authentication(bytes32(uint256(address(this))))
         BasePoolAuthorization(_DELEGATE_OWNER)
-        RecoveryMode(vault)
     {
         _vault = vault;
         _rateProviders = rateProviders;

--- a/pvt/benchmarks/misc.ts
+++ b/pvt/benchmarks/misc.ts
@@ -11,7 +11,10 @@ import { MAX_UINT256, ZERO_ADDRESS, MAX_WEIGHTED_TOKENS, ZERO_BYTES32 } from '@b
 import { bn } from '@balancer-labs/v2-helpers/src/numbers';
 import { advanceTime, MONTH } from '@balancer-labs/v2-helpers/src/time';
 import { range } from 'lodash';
-import { ManagedPoolConfigParams, ManagedPoolParams, ManagedPoolSettingsParams } from '@balancer-labs/v2-helpers/src/models/pools/weighted/types';
+import {
+  ManagedPoolParams,
+  ManagedPoolSettingsParams,
+} from '@balancer-labs/v2-helpers/src/models/pools/weighted/types';
 import { poolConfigs } from './config';
 import { ProtocolFee } from '@balancer-labs/v2-helpers/src/models/vault/types';
 
@@ -77,7 +80,7 @@ export async function deployPool(vault: Vault, tokens: TokenList, poolName: Pool
     const WEIGHTS = range(10000, 10000 + tokens.length);
     const weights = toNormalizedWeights(WEIGHTS.map(bn)); // Equal weights for all tokens
     let params;
-    
+
     switch (poolName) {
       case 'ManagedPool': {
         const managedPoolParams: ManagedPoolParams = {

--- a/pvt/benchmarks/misc.ts
+++ b/pvt/benchmarks/misc.ts
@@ -11,7 +11,7 @@ import { MAX_UINT256, ZERO_ADDRESS, MAX_WEIGHTED_TOKENS, ZERO_BYTES32 } from '@b
 import { bn } from '@balancer-labs/v2-helpers/src/numbers';
 import { advanceTime, MONTH } from '@balancer-labs/v2-helpers/src/time';
 import { range } from 'lodash';
-import { ManagedPoolParams } from '@balancer-labs/v2-helpers/src/models/pools/weighted/types';
+import { ManagedPoolConfigParams, ManagedPoolParams, ManagedPoolSettingsParams } from '@balancer-labs/v2-helpers/src/models/pools/weighted/types';
 import { poolConfigs } from './config';
 import { ProtocolFee } from '@balancer-labs/v2-helpers/src/models/vault/types';
 
@@ -77,16 +77,16 @@ export async function deployPool(vault: Vault, tokens: TokenList, poolName: Pool
     const WEIGHTS = range(10000, 10000 + tokens.length);
     const weights = toNormalizedWeights(WEIGHTS.map(bn)); // Equal weights for all tokens
     let params;
-
+    
     switch (poolName) {
       case 'ManagedPool': {
-        const userInputs = {
+        const managedPoolParams: ManagedPoolParams = {
           name: name,
           symbol: symbol,
           assetManagers: Array(tokens.length).fill(ZERO_ADDRESS),
         };
 
-        const managedPoolSettings: ManagedPoolParams = {
+        const managedPoolSettings: ManagedPoolSettingsParams = {
           tokens: tokens.addresses,
           normalizedWeights: weights,
           swapFeePercentage: swapFeePercentage,
@@ -96,7 +96,7 @@ export async function deployPool(vault: Vault, tokens: TokenList, poolName: Pool
           aumFeeId: ProtocolFee.AUM,
         };
 
-        params = [userInputs, managedPoolSettings, creator.address];
+        params = [managedPoolParams, managedPoolSettings, creator.address];
         break;
       }
       default: {

--- a/pvt/common/hardhat-base-config.ts
+++ b/pvt/common/hardhat-base-config.ts
@@ -19,15 +19,15 @@ const contractSettings: ContractSettings = {
   },
   '@balancer-labs/v2-pool-weighted/contracts/managed/ManagedPoolFactory.sol': {
     version: '0.7.1',
-    runs: 200,
+    runs: 1,
   },
   '@balancer-labs/v2-pool-weighted/contracts/managed/ManagedPool.sol': {
     version: '0.7.1',
-    runs: 200,
+    runs: 1,
   },
   '@balancer-labs/v2-pool-weighted/contracts/test/MockManagedPool.sol': {
     version: '0.7.1',
-    runs: 200,
+    runs: 1,
   },
 };
 

--- a/pvt/helpers/src/models/pools/stable/StablePoolDeployer.ts
+++ b/pvt/helpers/src/models/pools/stable/StablePoolDeployer.ts
@@ -40,12 +40,14 @@ export default {
     } = params;
 
     const owner = TypesConverter.toAddress(params.owner);
+    const vaultReentrancyLib = await deploy('v2-pool-utils/VaultReentrancyLib', { args: [vault.address] });
 
     return deploy('v2-pool-stable/MockComposableStablePool', {
       args: [
         {
           vault: vault.address,
           protocolFeeProvider: vault.getFeesProvider().address,
+          vaultReentrancyLib: vaultReentrancyLib.address,
           name: NAME,
           symbol: SYMBOL,
           tokens: tokens.addresses,

--- a/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
@@ -28,6 +28,13 @@ export default {
     const pool = await (params.fromFactory ? this._deployFromFactory : this._deployStandalone)(deployment, vault);
     const poolId = await pool.getPoolId();
 
+    if (pool.initComposablePoolTokenLib) {
+      const composablePoolTokenLib = await deploy('v2-pool-weighted/ComposablePoolTokenLib', {
+        args: [pool.address, vault.address, poolId],
+      });
+      await pool.initComposablePoolTokenLib(composablePoolTokenLib.address);
+    }
+
     const {
       tokens,
       weights,

--- a/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
@@ -73,7 +73,6 @@ export default {
       swapEnabledOnStart,
       mustAllowlistLPs,
       managementAumFeePercentage,
-      aumProtocolFeesCollector,
       owner,
       from,
       aumFeeId,

--- a/pvt/helpers/src/models/pools/weighted/types.ts
+++ b/pvt/helpers/src/models/pools/weighted/types.ts
@@ -209,6 +209,12 @@ export type ManagedPoolRights = {
 };
 
 export type ManagedPoolParams = {
+  name: string;
+  symbol: string;
+  assetManagers: string[];
+};
+
+export type ManagedPoolSettingsParams = {
   tokens: string[];
   normalizedWeights: BigNumberish[];
   swapFeePercentage: BigNumberish;
@@ -216,6 +222,18 @@ export type ManagedPoolParams = {
   mustAllowlistLPs: boolean;
   managementAumFeePercentage: BigNumberish;
   aumFeeId: BigNumberish;
+};
+
+export type ManagedPoolConfigParams = {
+  vault: string;
+  protocolFeeProvider: string;
+  vaultReentrancyLib: string;
+  weightedMath: string;
+  recoveryModeHelper: string;
+  ownerOnlyLib: string;
+  pauseWindowDuration: BigNumber;
+  bufferPeriodDuration: BigNumber;
+  version: string;
 };
 
 export type CircuitBreakerState = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,6 +486,7 @@ __metadata:
     ethereum-waffle: ^3.4.4
     ethers: ^5.7.2
     hardhat: ^2.12.5
+    hardhat-contract-sizer: ^2.8.0
     hardhat-ignore-warnings: ^0.2.4
     lodash.frompairs: ^4.0.1
     lodash.pick: ^4.4.0
@@ -624,6 +625,13 @@ __metadata:
     typescript: ^4.0.2
   languageName: unknown
   linkType: soft
+
+"@colors/colors@npm:1.5.0":
+  version: 1.5.0
+  resolution: "@colors/colors@npm:1.5.0"
+  checksum: 152768b41b5f73c77552acb8e2921729674b83c835ba509b4b990fcb0eea6109fd14fd51ae5dd8531c6a1f93b01988d35083c1205a970906de704ee891300a7c
+  languageName: node
+  linkType: hard
 
 "@cspotcode/source-map-support@npm:^0.8.0":
   version: 0.8.1
@@ -4971,6 +4979,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-table3@npm:^0.6.0":
+  version: 0.6.3
+  resolution: "cli-table3@npm:0.6.3"
+  dependencies:
+    "@colors/colors": 1.5.0
+    string-width: ^4.2.0
+  dependenciesMeta:
+    "@colors/colors":
+      optional: true
+  checksum: d3996c75ef20d74bcb617743f8def66cf6679f8cba088e41cf74bf39cef00c3a45ad7c1386587ee30d3b1b4edc43a4d2e340c44578024c996347cb250247207a
+  languageName: node
+  linkType: hard
+
 "cli-width@npm:^2.0.0":
   version: 2.2.1
   resolution: "cli-width@npm:2.2.1"
@@ -7723,6 +7744,19 @@ __metadata:
     ajv: ^6.12.3
     har-schema: ^2.0.0
   checksum: 01b905cdaa7632c926a962c8127a77b98387935ef3aa0b44dae871eae2592ba6da948a3bdbb3eeceb90fa1599300f16716e50147965a7ea7c4e7c4e57ac69727
+  languageName: node
+  linkType: hard
+
+"hardhat-contract-sizer@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "hardhat-contract-sizer@npm:2.8.0"
+  dependencies:
+    chalk: ^4.0.0
+    cli-table3: ^0.6.0
+    strip-ansi: ^6.0.0
+  peerDependencies:
+    hardhat: ^2.0.0
+  checksum: cb550c3bac83c6a6c78f47399b0e88cb7471506232d66e1fe430956eebd98a1cc6340fc1fa2f5c1e63fc47b49b7bdcb1b5a8a95fd6800cdf5abeb3f045e0bb37
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

This version leaves joins/exits alone, and tries to make ManagedPool fit with 3 smaller, targeted interventions, presented here in order of increasing unpleasantness:

1) **VaultReentrancyLib**
    Made this external, and also borrowed code from Midas to make the check a view function, which also saves bytes.
    Previously, the `ensureNotInVaultContext` call needed a Vault argument, since it was used in ProtocolFeeCache ("above" the pool, where there is no Vault). Now that it's a contract, it can have data, so we can just give it the Vault on deployment. This also simplifies RecoveryMode, which no longer needs to receive and store the Vault.
     I'm deploying this library from the factory, and passing it into the pools. (So, one copy of this contract per factory, shared among all its pools.)

2) **isOwnerOnlyAction**
    This function (in ManagedPoolSettings) takes a surprising amount of bytes (~300). In ManagedPoolSettings, we can call `getActionId` on each "ManagedPoolSettings.function.selector". getActionId is from Authentication, which is initialized on pool deployment with the msg.sender (i.e., the deployer: normally the factory), so that all action ids use that as the disambiguator. I'm deploying this from the factory, using its own address as the disambiguator, so that it matches the pools.
    I get around having no access to ManagedPoolSettings by simply computing the selector from the signature of each function. This creates a maintenance issue, since any changes to those function signatures would need to be updated there as well, but they're unlikely to change.

3) **ComposablePoolTokenLib**
    There are two functions (`getPoolTokens` and `getVirtualSupply`) that again take a surprising amount of bytes. They call functions on the Vault, and ERC20 functions on the pool, and need to fetch the Vault and PoolId. I'm creating a separate external library that is deployed with the pool address, Vault, and PoolId.
    The especially icky thing about this one is it can't be done on pool deployment, since the PoolId is immutable, and not available during construction. So the factory deploys the pool, then calls an initialization function on the pool that deploys this helper contract. So it is one external lib per pool (which it has to be anyway, since part of it is the pool address).
    It means anybody deploying this outside the factory (or from a different factory), would have to call this function first before it's usable.

Draft because the tests aren't done.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

