### PR TITLE
Cleanup obsolete AUM parameter

### DIFF
--- a/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPool.ts
@@ -61,7 +61,6 @@ export default class WeightedPool extends BasePool {
   swapEnabledOnStart: boolean;
   mustAllowlistLPs: boolean;
   managementAumFeePercentage: BigNumberish;
-  aumProtocolFeesCollector: string;
   poolVersion: string;
 
   static async create(params: RawWeightedPoolDeployment = {}): Promise<WeightedPool> {
@@ -81,7 +80,6 @@ export default class WeightedPool extends BasePool {
     swapEnabledOnStart: boolean,
     mustAllowlistLPs: boolean,
     managementAumFeePercentage: BigNumberish,
-    aumProtocolFeesCollector: string,
     poolVersion: string,
     owner?: SignerWithAddress
   ) {
@@ -94,7 +92,6 @@ export default class WeightedPool extends BasePool {
     this.swapEnabledOnStart = swapEnabledOnStart;
     this.mustAllowlistLPs = mustAllowlistLPs;
     this.managementAumFeePercentage = managementAumFeePercentage;
-    this.aumProtocolFeesCollector = aumProtocolFeesCollector;
     this.poolVersion = poolVersion;
   }
 

--- a/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
@@ -33,7 +33,6 @@ export default {
       swapEnabledOnStart,
       mustAllowlistLPs,
       managementAumFeePercentage,
-      aumProtocolFeesCollector,
       poolVersion,
     } = deployment;
 
@@ -50,7 +49,6 @@ export default {
       swapEnabledOnStart,
       mustAllowlistLPs,
       managementAumFeePercentage,
-      aumProtocolFeesCollector,
       poolVersion
     );
   },
@@ -68,7 +66,6 @@ export default {
       swapEnabledOnStart,
       mustAllowlistLPs,
       managementAumFeePercentage,
-      aumProtocolFeesCollector,
       owner,
       from,
       aumFeeId,
@@ -124,7 +121,6 @@ export default {
               swapEnabledOnStart: swapEnabledOnStart,
               mustAllowlistLPs: mustAllowlistLPs,
               managementAumFeePercentage: managementAumFeePercentage,
-              aumProtocolFeesCollector: aumProtocolFeesCollector,
               aumFeeId: aumFeeId,
             },
             owner,
@@ -166,7 +162,6 @@ export default {
               swapEnabledOnStart: swapEnabledOnStart,
               mustAllowlistLPs: mustAllowlistLPs,
               managementAumFeePercentage: managementAumFeePercentage,
-              aumProtocolFeesCollector: aumProtocolFeesCollector,
               aumFeeId: aumFeeId,
             },
             owner,
@@ -194,7 +189,6 @@ export default {
               swapEnabledOnStart: swapEnabledOnStart,
               mustAllowlistLPs: mustAllowlistLPs,
               managementAumFeePercentage: managementAumFeePercentage,
-              aumProtocolFeesCollector: aumProtocolFeesCollector,
               aumFeeId: aumFeeId,
             },
             vault.address,

--- a/pvt/helpers/src/models/pools/weighted/types.ts
+++ b/pvt/helpers/src/models/pools/weighted/types.ts
@@ -27,7 +27,6 @@ export type RawWeightedPoolDeployment = {
   swapEnabledOnStart?: boolean;
   mustAllowlistLPs?: boolean;
   managementAumFeePercentage?: BigNumberish;
-  aumProtocolFeesCollector?: string;
   owner?: Account;
   admin?: SignerWithAddress;
   from?: SignerWithAddress;
@@ -52,7 +51,6 @@ export type WeightedPoolDeployment = {
   swapEnabledOnStart: boolean;
   mustAllowlistLPs: boolean;
   managementAumFeePercentage: BigNumberish;
-  aumProtocolFeesCollector: string;
   factoryVersion: string;
   poolVersion: string;
   aumFeeId?: BigNumberish;

--- a/pvt/helpers/src/models/types/TypesConverter.ts
+++ b/pvt/helpers/src/models/types/TypesConverter.ts
@@ -66,7 +66,6 @@ export default {
       swapEnabledOnStart,
       mustAllowlistLPs,
       managementAumFeePercentage,
-      aumProtocolFeesCollector,
       poolType,
       aumFeeId,
       factoryVersion,
@@ -82,7 +81,6 @@ export default {
     if (!rateProviders) rateProviders = Array(tokens.length).fill(ZERO_ADDRESS);
     if (!assetManagers) assetManagers = Array(tokens.length).fill(ZERO_ADDRESS);
     if (!poolType) poolType = WeightedPoolType.WEIGHTED_POOL;
-    if (!aumProtocolFeesCollector) aumProtocolFeesCollector = ZERO_ADDRESS;
     if (undefined == aumFeeId) aumFeeId = ProtocolFee.AUM;
     if (undefined == swapEnabledOnStart) swapEnabledOnStart = true;
     if (undefined == mustAllowlistLPs) mustAllowlistLPs = false;
@@ -100,7 +98,6 @@ export default {
       swapEnabledOnStart,
       mustAllowlistLPs,
       managementAumFeePercentage,
-      aumProtocolFeesCollector,
       owner: this.toAddress(params.owner),
       from: params.from,
       poolType,


### PR DESCRIPTION
# Description

Reviewing all the deployment parameters for the Managed Pool, I realized we still had the AUM Protocol Fee Collector, from a time before we unifed all the protocol fee handling, and still had a separate contract for AUM. Just removing that, for clarity.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution
