### PR TITLE
Add ChildChainGaugeRegistry

### DIFF
--- a/pkg/interfaces/contracts/liquidity-mining/IL2LayerZeroDelegation.sol
+++ b/pkg/interfaces/contracts/liquidity-mining/IL2LayerZeroDelegation.sol
@@ -18,7 +18,14 @@ pragma solidity >=0.7.0 <0.9.0;
  * @notice Minimal hook interface to be called whenever the veBAL balance of a user is updated in a L2 chain.
  */
 interface IL2LayerZeroDelegation {
+    /**
+     * @notice Called whenever the veBAL balance of a user is updated in a L2 chain.
+     * @param user The user whose veBAL balance was updated.
+     */
     function onVeBalBridged(address user) external;
 
+    /**
+     * @notice Called whenever the total veBAL supply is updated in a L2 chain.
+     */
     function onVeBalSupplyUpdate() external;
 }

--- a/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeCheckpointer.sol
+++ b/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeCheckpointer.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IChildChainGauge.sol";
+import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/ILiquidityGaugeFactory.sol";
+
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthentication.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/EnumerableSet.sol";
+import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IL2LayerZeroDelegation.sol";
+
+import { ChildChainGaugeRegistry } from "./ChildChainGaugeRegistry.sol";
+
+contract ChildChainGaugeCheckpointer is IL2LayerZeroDelegation {
+    ChildChainGaugeRegistry private immutable _childChainGaugeRegistry;
+
+    constructor(ChildChainGaugeRegistry childChainGaugeRegistry) {
+        _childChainGaugeRegistry = childChainGaugeRegistry;
+    }
+
+    function onVeBalBridged(address user) external override {
+        uint256 totalGauges = _childChainGaugeRegistry.totalGauges();
+        IChildChainGauge[] memory gauges = _childChainGaugeRegistry.getGauges(0, totalGauges);
+        for (uint256 i = 0; i < totalGauges; i++) {
+            gauges[i].user_checkpoint(user);
+        }
+    }
+
+    function onVeBalSupplyUpdate() external override {}
+}

--- a/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeCheckpointer.sol
+++ b/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeCheckpointer.sol
@@ -23,6 +23,11 @@ import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IL2LayerZeroDele
 
 import { ChildChainGaugeRegistry } from "./ChildChainGaugeRegistry.sol";
 
+/**
+ * @title ChildChainGaugeCheckpointer
+ * @notice Checkpointer for all child chain gauges.
+ * This contract calls `user_checkpoint` function on every child chain gauge during onVeBalBridged callback.
+ */
 contract ChildChainGaugeCheckpointer is IL2LayerZeroDelegation {
     ChildChainGaugeRegistry private immutable _childChainGaugeRegistry;
 
@@ -30,6 +35,7 @@ contract ChildChainGaugeCheckpointer is IL2LayerZeroDelegation {
         _childChainGaugeRegistry = childChainGaugeRegistry;
     }
 
+    /// @inheritdoc IL2LayerZeroDelegation
     function onVeBalBridged(address user) external override {
         uint256 totalGauges = _childChainGaugeRegistry.totalGauges();
         IChildChainGauge[] memory gauges = _childChainGaugeRegistry.getGauges(0, totalGauges);
@@ -38,6 +44,7 @@ contract ChildChainGaugeCheckpointer is IL2LayerZeroDelegation {
         }
     }
 
+    /// @inheritdoc IL2LayerZeroDelegation
     function onVeBalSupplyUpdate() external override {
         // solhint-disable-previous-line no-empty-blocks
     }

--- a/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeCheckpointer.sol
+++ b/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeCheckpointer.sol
@@ -38,5 +38,7 @@ contract ChildChainGaugeCheckpointer is IL2LayerZeroDelegation {
         }
     }
 
-    function onVeBalSupplyUpdate() external override {}
+    function onVeBalSupplyUpdate() external override {
+        // solhint-disable-previous-line no-empty-blocks
+    }
 }

--- a/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeRegistry.sol
+++ b/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeRegistry.sol
@@ -54,7 +54,7 @@ contract ChildChainGaugeRegistry is SingletonAuthentication, ReentrancyGuard {
 
     /**
      * @notice Add a gauge to the registry after validating its legitimacy.
-     * This function checks that the gauge's factory is registered with the L2BalancerPseudoMinter,
+     * @dev This function checks that the gauge's factory is registered with the L2BalancerPseudoMinter,
      * and that the gauge has been deployed from the registered factory. If these conditions are met,
      * the gauge is added to the registry, and a GaugeAdded event is emitted.
      * @param gauge The gauge to add to the registry.

--- a/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeRegistry.sol
+++ b/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeRegistry.sol
@@ -74,7 +74,7 @@ contract ChildChainGaugeRegistry is SingletonAuthentication, ReentrancyGuard {
 
     /**
      * @notice Remove a registered gauge from the registry and emit a GaugeRemoved event.
-     * If the gauge is not registered, the function reverts with a "GAUGE_NOT_REGISTERED" error.
+     * @dev If the gauge is not registered, the function reverts with a "GAUGE_NOT_REGISTERED" error.
      * Remove a gauge might affect the order of the remaining gauges.
      * @param gauge The gauge to remove from the registry.
      */

--- a/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeRegistry.sol
+++ b/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeRegistry.sol
@@ -19,10 +19,17 @@ import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IChildChainGauge
 
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthentication.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/EnumerableSet.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.sol";
 
 import "../L2BalancerPseudoMinter.sol";
 
-contract ChildChainGaugeRegistry is SingletonAuthentication {
+/**
+ * @title ChildChainGaugeRegistry
+ * @notice Registry for all child chain gauges.
+ * This contract enables the addition and removal of child chain gauges to the registry.
+ * Duplication is not permitted. Gauges are verified to be valid.
+ */
+contract ChildChainGaugeRegistry is SingletonAuthentication, ReentrancyGuard {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     L2BalancerPseudoMinter private immutable _l2BalancerPseudoMinter;
@@ -33,38 +40,64 @@ contract ChildChainGaugeRegistry is SingletonAuthentication {
     event GaugeAdded(IChildChainGauge indexed gauge);
     event GaugeRemoved(IChildChainGauge indexed gauge);
 
-    constructor(
-        IVault vault,
-        L2BalancerPseudoMinter l2BalancerPseudoMinter,
-        ILiquidityGaugeFactory liquidityGaugeFactory
-    ) SingletonAuthentication(vault) {
+    /**
+     * @notice Constructor initializes the ChildChainGaugeRegistry contract.
+     * @param l2BalancerPseudoMinter The L2 Balancer pseudo minter.
+     * @param liquidityGaugeFactory The liquidity gauge factory.
+     */
+    constructor(L2BalancerPseudoMinter l2BalancerPseudoMinter, ILiquidityGaugeFactory liquidityGaugeFactory)
+        SingletonAuthentication(l2BalancerPseudoMinter.getVault())
+    {
         _l2BalancerPseudoMinter = l2BalancerPseudoMinter;
         _liquidityGaugeFactory = liquidityGaugeFactory;
     }
 
-    function addGauge(IChildChainGauge gauge) external authenticate {
+    /**
+     * @notice Add a gauge to the registry after validating its legitimacy.
+     * This function checks that the gauge's factory is registered with the L2BalancerPseudoMinter,
+     * and that the gauge has been deployed from the registered factory. If these conditions are met,
+     * the gauge is added to the registry, and a GaugeAdded event is emitted.
+     * @param gauge The gauge to add to the registry.
+     */
+    function addGauge(IChildChainGauge gauge) external authenticate nonReentrant {
         // Check that the gauge is valid
         // 1. The gauge's factory is registered with the L2BalancerPseudoMinter
         // 2. The gauge is deployed from the registered factory
         ILiquidityGaugeFactory factory = gauge.factory();
         require(_l2BalancerPseudoMinter.isValidGaugeFactory(factory), "INVALID_GAUGE_FACTORY");
-        require(factory.isGaugeFromFactory(address(gauge)), "GAUGE_NOT_FROM_FACTORY`");
+        require(factory.isGaugeFromFactory(address(gauge)), "GAUGE_NOT_FROM_FACTORY");
 
         require(_gauges.add(address(gauge)), "GAUGE_ALREADY_REGISTERED");
 
         emit GaugeAdded(gauge);
     }
 
+    /**
+     * @notice Remove a registered gauge from the registry and emit a GaugeRemoved event.
+     * If the gauge is not registered, the function reverts with a "GAUGE_NOT_REGISTERED" error.
+     * Remove a gauge might affect the order of the remaining gauges.
+     * @param gauge The gauge to remove from the registry.
+     */
     function removeGauge(IChildChainGauge gauge) external authenticate {
         require(_gauges.remove(address(gauge)), "GAUGE_NOT_REGISTERED");
 
         emit GaugeRemoved(gauge);
     }
 
+    /**
+     * @notice Retrieve the total number of gauges registered in the registry.
+     * @return The total number of registered gauges as a uint256.
+     */
     function totalGauges() external view returns (uint256) {
         return _gauges.length();
     }
 
+    /**
+     * @notice Retrieve a list of gauges within the specified index range from the registry.
+     * @param startIndex The starting index (inclusive) for retrieving gauges from the registry.
+     * @param endIndex The ending index (exclusive) for retrieving gauges from the registry.
+     * @return An array of IChildChainGauge containing the gauges within the specified index range.
+     */
     function getGauges(uint256 startIndex, uint256 endIndex) external view returns (IChildChainGauge[] memory) {
         require(startIndex < endIndex, "INVALID_INDICES");
         require(endIndex <= _gauges.length(), "END_INDEX_OUT_OF_BOUNDS");

--- a/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeRegistry.sol
+++ b/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeRegistry.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/ILiquidityGaugeFactory.sol";
+import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthentication.sol";
+
+import "../L2BalancerPseudoMinter.sol";
+
+contract ChildChainGaugeRegistry is SingletonAuthentication {
+    L2BalancerPseudoMinter private immutable _l2BalancerPseudoMinter;
+    ILiquidityGaugeFactory private immutable _liquidityGaugeFactory;
+
+    IChildChainGauge[] private _gauges;
+
+    event GaugeAdded(IChildChainGauge indexed gauge);
+
+    constructor(
+        IVault vault,
+        L2BalancerPseudoMinter l2BalancerPseudoMinter,
+        ILiquidityGaugeFactory liquidityGaugeFactory
+    ) SingletonAuthentication(vault) {
+        _l2BalancerPseudoMinter = l2BalancerPseudoMinter;
+        _liquidityGaugeFactory = liquidityGaugeFactory;
+    }
+
+    function addGauge(IChildChainGauge gauge) external authenticate {
+        // Check that the gauge is valid
+        // 1. The gauge's factory is registered with the L2BalancerPseudoMinter
+        // 2. The gauge is deployed from the registered factory
+        ILiquidityGaugeFactory factory = gauge.factory();
+        require(_l2BalancerPseudoMinter.isValidGaugeFactory(factory), "INVALID_GAUGE_FACTORY");
+        require(factory.isGaugeFromFactory(address(gauge)), "INVALID_GAUGE");
+
+        _gauges.push(gauge);
+
+        emit GaugeAdded(gauge);
+    }
+
+    function totalGauges() external view returns (uint256) {
+        return _gauges.length;
+    }
+
+    function getGauges(uint256 startIndex, uint256 endIndex) external view returns (IChildChainGauge[] memory) {
+        require(startIndex < endIndex, "Invalid indices");
+        require(endIndex <= _gauges.length, "End index out of bounds");
+
+        uint256 size = endIndex - startIndex;
+        IChildChainGauge[] memory slicedGauges = new IChildChainGauge[](size);
+
+        for (uint256 i = 0; i < size; i++) {
+            slicedGauges[i] = _gauges[startIndex + i];
+        }
+
+        return slicedGauges;
+    }
+}

--- a/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeRegistry.sol
+++ b/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeRegistry.sol
@@ -15,6 +15,8 @@
 pragma solidity ^0.7.0;
 
 import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/ILiquidityGaugeFactory.sol";
+import "@balancer-labs/v2-interfaces/contracts/liquidity-mining/IChildChainGauge.sol";
+
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthentication.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/EnumerableSet.sol";
 

--- a/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeRegistry.sol
+++ b/pkg/liquidity-mining/contracts/gauges/ChildChainGaugeRegistry.sol
@@ -48,7 +48,7 @@ contract ChildChainGaugeRegistry is SingletonAuthentication {
         // 2. The gauge is deployed from the registered factory
         ILiquidityGaugeFactory factory = gauge.factory();
         require(_l2BalancerPseudoMinter.isValidGaugeFactory(factory), "INVALID_GAUGE_FACTORY");
-        require(factory.isGaugeFromFactory(address(gauge)), "INVALID_GAUGE");
+        require(factory.isGaugeFromFactory(address(gauge)), "GAUGE_NOT_FROM_FACTORY`");
 
         require(_gauges.add(address(gauge)), "GAUGE_ALREADY_REGISTERED");
 

--- a/pkg/liquidity-mining/contracts/test/MockChildChainGaugeFactory.sol
+++ b/pkg/liquidity-mining/contracts/test/MockChildChainGaugeFactory.sol
@@ -24,7 +24,7 @@ contract MockChildChainGaugeFactory {
         return address(0);
     }
 
-    function isGaugeFromFactory(address ) external pure returns (bool) {
+    function isGaugeFromFactory(address) external pure returns (bool) {
         return true;
     }
 }

--- a/pkg/liquidity-mining/contracts/test/MockChildChainGaugeFactory.sol
+++ b/pkg/liquidity-mining/contracts/test/MockChildChainGaugeFactory.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+contract MockChildChainGaugeFactory {
+    function getProductVersion() public pure returns (string memory) {
+        return "";
+    }
+
+    function getGaugeImplementation() public pure returns (address) {
+        return address(0);
+    }
+
+    function isGaugeFromFactory(address ) external pure returns (bool) {
+        return true;
+    }
+}

--- a/pkg/liquidity-mining/test/ChildChainGaugeCheckpointer.test.ts
+++ b/pkg/liquidity-mining/test/ChildChainGaugeCheckpointer.test.ts
@@ -1,0 +1,67 @@
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+
+describe('ChildChainGaugeCheckpointer', () => {
+  let gaugeFactory: Contract;
+  let gauge1: Contract;
+  let gauge2: Contract;
+  let checkpointer: Contract;
+  let admin: SignerWithAddress, user1: SignerWithAddress, other: SignerWithAddress;
+  let registry: Contract;
+
+  before('setup signers', async () => {
+    [, admin, user1, other] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy gauge ChildChainGaugeCheckpointer', async () => {
+    const vault = await Vault.create();
+    const balToken = await deploy('TestBalancerToken', { args: [admin.address, 'Balancer', 'BAL'] });
+
+    const mockBPT = await deploy('v2-solidity-utils/TestToken', { args: ['Balancer Pool Test token', 'BPTST', 18] });
+
+    const pseudoMinter = await deploy('L2BalancerPseudoMinter', { args: [vault.address, balToken.address] });
+
+    gaugeFactory = await deploy('MockChildChainGaugeFactory', {});
+
+    registry = await deploy('ChildChainGaugeRegistry', {
+      args: [vault.address, pseudoMinter.address, gaugeFactory.address],
+    });
+
+    await vault.grantPermissionGlobally(await actionId(pseudoMinter, 'addGaugeFactory'), admin.address);
+    await vault.grantPermissionGlobally(await actionId(registry, 'addGauge'), admin.address);
+    await vault.grantPermissionGlobally(await actionId(registry, 'removeGauge'), admin.address);
+
+    await pseudoMinter.connect(admin).addGaugeFactory(gaugeFactory.address);
+
+    gauge1 = await deploy('MockChildChainGauge', { args: ['test'] });
+    await gauge1.setMockFactory(gaugeFactory.address);
+    gauge2 = await deploy('MockChildChainGauge', { args: ['test'] });
+    await gauge2.setMockFactory(gaugeFactory.address);
+
+    await registry.connect(admin).addGauge(gauge1.address);
+    await registry.connect(admin).addGauge(gauge2.address);
+
+    checkpointer = await deploy('ChildChainGaugeCheckpointer', {
+      args: [registry.address],
+    });
+  });
+
+  describe('onVeBalBridged', () => {
+    it('calls user_checkpoint on every gauge in the registry', async () => {
+      const tx = await checkpointer.connect(other).onVeBalBridged(user1.address);
+
+      for (const gauge of [gauge1, gauge2]) {
+        await expectEvent.inIndirectReceipt(await tx.wait(), gauge.interface, 'UserCheckpoint', {
+          user: user1.address,
+        });
+      }
+    });
+  });
+});

--- a/pkg/liquidity-mining/test/ChildChainGaugeCheckpointer.test.ts
+++ b/pkg/liquidity-mining/test/ChildChainGaugeCheckpointer.test.ts
@@ -24,8 +24,6 @@ describe('ChildChainGaugeCheckpointer', () => {
     const vault = await Vault.create();
     const balToken = await deploy('TestBalancerToken', { args: [admin.address, 'Balancer', 'BAL'] });
 
-    const mockBPT = await deploy('v2-solidity-utils/TestToken', { args: ['Balancer Pool Test token', 'BPTST', 18] });
-
     const pseudoMinter = await deploy('L2BalancerPseudoMinter', { args: [vault.address, balToken.address] });
 
     gaugeFactory = await deploy('MockChildChainGaugeFactory', {});

--- a/pkg/liquidity-mining/test/ChildChainGaugeCheckpointer.test.ts
+++ b/pkg/liquidity-mining/test/ChildChainGaugeCheckpointer.test.ts
@@ -1,6 +1,5 @@
 import { ethers } from 'hardhat';
 import { Contract } from 'ethers';
-import { expect } from 'chai';
 
 import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';

--- a/pkg/liquidity-mining/test/ChildChainGaugeCheckpointer.test.ts
+++ b/pkg/liquidity-mining/test/ChildChainGaugeCheckpointer.test.ts
@@ -86,7 +86,7 @@ describe('ChildChainGaugeCheckpointer', () => {
         gauge1.address
       );
 
-      expect(expectEvent.arrayFromIndirectReceipt(await tx.wait(), gauge1.interface, 'UserCheckpoint').length).to.eq(1);
+      await expectEvent.inIndirectReceipt(await tx.wait(), gauge1.interface, 'UserCheckpoint', undefined, undefined, 1);
     });
 
     it('does checkpoint new gagues', async () => {
@@ -106,7 +106,7 @@ describe('ChildChainGaugeCheckpointer', () => {
         gauge3.address
       );
 
-      expect(expectEvent.arrayFromIndirectReceipt(await tx.wait(), gauge1.interface, 'UserCheckpoint').length).to.eq(1);
+      await expectEvent.inIndirectReceipt(await tx.wait(), gauge1.interface, 'UserCheckpoint', undefined, undefined, 1);
     });
   });
 });

--- a/pkg/liquidity-mining/test/ChildChainGaugeRegistry.test.ts
+++ b/pkg/liquidity-mining/test/ChildChainGaugeRegistry.test.ts
@@ -1,0 +1,135 @@
+import { ethers } from 'hardhat';
+import { Contract } from 'ethers';
+
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
+import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
+import { expect } from 'chai';
+import { ANY_ADDRESS, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
+
+describe('ChildChainGaugeRegistry', () => {
+  let gaugeImplementation: Contract;
+  let gaugeFactory: Contract;
+  let otherGaugeFactory: Contract;
+  let gauge: Contract;
+  let otherGauge: Contract;
+  let admin: SignerWithAddress, other: SignerWithAddress;
+  let registry: Contract;
+
+  const factoryVersion = JSON.stringify({
+    name: 'ChildChainGaugeFactory',
+    version: '1',
+    deployment: 'test-deployment',
+  });
+  const productVersion = JSON.stringify({
+    name: 'ChildChainGauge',
+    version: '0',
+    deployment: 'test-deployment',
+  });
+
+  before('setup signers', async () => {
+    [, admin, other] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy gauge registry', async () => {
+    const vault = await Vault.create();
+    const balToken = await deploy('TestBalancerToken', { args: [admin.address, 'Balancer', 'BAL'] });
+
+    const mockVE = await deploy('v2-solidity-utils/TestToken', { args: ['Voting Escrow', 'veBAL', 18] });
+    const mockBPT = await deploy('v2-solidity-utils/TestToken', { args: ['Balancer Pool Test token', 'BPTST', 18] });
+
+    const veDelegationProxy = await deploy('VotingEscrowDelegationProxy', {
+      args: [vault.address, mockVE.address, ZERO_ADDRESS],
+    });
+
+    const pseudoMinter = await deploy('L2BalancerPseudoMinter', { args: [vault.address, balToken.address] });
+
+    gaugeImplementation = await deploy('ChildChainGauge', {
+      args: [veDelegationProxy.address, pseudoMinter.address, vault.authorizerAdaptor.address, productVersion],
+    });
+
+    gaugeFactory = await deploy('ChildChainGaugeFactory', {
+      args: [gaugeImplementation.address, factoryVersion, productVersion],
+    });
+
+    otherGaugeFactory = await deploy('ChildChainGaugeFactory', {
+      args: [gaugeImplementation.address, factoryVersion, productVersion],
+    });
+
+    registry = await deploy('ChildChainGaugeRegistry', {
+      args: [vault.address, pseudoMinter.address, gaugeFactory.address],
+    });
+
+    await vault.grantPermissionGlobally(await actionId(pseudoMinter, 'addGaugeFactory'), admin.address);
+    await vault.grantPermissionGlobally(await actionId(registry, 'addGauge'), admin.address);
+    await vault.grantPermissionGlobally(await actionId(registry, 'removeGauge'), admin.address);
+
+    await pseudoMinter.connect(admin).addGaugeFactory(gaugeFactory.address);
+
+    let tx = await gaugeFactory.create(mockBPT.address);
+    let event = expectEvent.inReceipt(await tx.wait(), 'GaugeCreated');
+    gauge = await deployedAt('ChildChainGauge', event.args.gauge);
+
+    tx = await otherGaugeFactory.create(mockBPT.address);
+    event = expectEvent.inReceipt(await tx.wait(), 'GaugeCreated');
+    otherGauge = await deployedAt('ChildChainGauge', event.args.gauge);
+  });
+
+  describe('addGauge', () => {
+    it('can add a valid gauge to the registry', async () => {
+      const tx = await registry.connect(admin).addGauge(gauge.address);
+
+      expectEvent.inReceipt(await tx.wait(), 'GaugeAdded', { gauge: gauge.address });
+      expect(await registry.totalGauges()).to.eq(1);
+      expect((await registry.getGauges(0, 1))[0]).to.eq(gauge.address);
+    });
+
+    it('only privileged account can add a gauge', async () => {
+      await expect(registry.connect(other).addGauge(gauge.address)).to.be.revertedWith('SENDER_NOT_ALLOWED');
+    });
+
+    it('cannot add the same gauge twice', async () => {
+      await registry.connect(admin).addGauge(gauge.address);
+      await expect(registry.connect(admin).addGauge(gauge.address)).to.be.revertedWith('GAUGE_ALREADY_REGISTERED');
+    });
+
+    it('reverts if gauge is not from the factory', async () => {
+      const maliciousGauge = await deploy('MockChildChainGauge', { args: ['test'] });
+      await maliciousGauge.setMockFactory(gaugeFactory.address);
+      await expect(registry.connect(admin).addGauge(maliciousGauge.address)).to.be.revertedWith(
+        'GAUGE_NOT_FROM_FACTORY'
+      );
+    });
+
+    it('reverts if gauge factory is invalid', async () => {
+      await expect(registry.connect(admin).addGauge(otherGauge.address)).to.be.revertedWith('INVALID_GAUGE_FACTORY');
+    });
+  });
+
+  describe('removeGauge', () => {
+    sharedBeforeEach('add gauge', async () => {
+      await registry.connect(admin).addGauge(gauge.address);
+    });
+
+    it('can remove a valid gauge from the registry', async () => {
+      const tx = await registry.connect(admin).removeGauge(gauge.address);
+
+      expectEvent.inReceipt(await tx.wait(), 'GaugeRemoved', { gauge: gauge.address });
+      expect(await registry.totalGauges()).to.eq(0);
+      await expect(registry.getGauges(0, 1)).to.be.revertedWith('END_INDEX_OUT_OF_BOUNDS');
+    });
+
+    it('reverts if gauge is not present', async () => {
+      await expect(registry.connect(admin).removeGauge(otherGaugeFactory.address)).to.be.revertedWith(
+        'GAUGE_NOT_REGISTERED'
+      );
+    });
+
+    it('only privileged account can remove a gauge', async () => {
+      await expect(registry.connect(other).removeGauge(gauge.address)).to.be.revertedWith('SENDER_NOT_ALLOWED');
+    });
+  });
+});

--- a/pkg/liquidity-mining/test/ChildChainGaugeRegistry.test.ts
+++ b/pkg/liquidity-mining/test/ChildChainGaugeRegistry.test.ts
@@ -5,7 +5,7 @@ import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
 import { expect } from 'chai';
-import { ANY_ADDRESS, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';

--- a/pvt/helpers/src/test/expectEvent.ts
+++ b/pvt/helpers/src/test/expectEvent.ts
@@ -93,7 +93,7 @@ export function notEmitted(receipt: ContractReceipt, eventName: string): void {
   }
 }
 
-export function arrayFromIndirectReceipt(
+function arrayFromIndirectReceipt(
   receipt: ContractReceipt,
   emitter: Interface,
   eventName: string,

--- a/pvt/helpers/src/test/expectEvent.ts
+++ b/pvt/helpers/src/test/expectEvent.ts
@@ -93,7 +93,7 @@ export function notEmitted(receipt: ContractReceipt, eventName: string): void {
   }
 }
 
-function arrayFromIndirectReceipt(
+export function arrayFromIndirectReceipt(
   receipt: ContractReceipt,
   emitter: Interface,
   eventName: string,


### PR DESCRIPTION
# Description

* We need to have an enumerable list of gauges on the L2s.
* Store this list and provide functionality for querying it (e.g., return the total number of elements and a function to return a slice of the array from element N to element M).
* Allow someone to update the list by adding new entries.
* The second function should be permissioned.
* Additionally, we want to check that the gauges are valid.
  * This validation is similar to the check from L2BalancerPseudoMinter:
  * require(isValidGaugeFactory(factory), "INVALID_GAUGE_FACTORY");
  * require(factory.isGaugeFromFactory(gauge), "INVALID_GAUGE");
   * (You'd want to call l2BalancerPseudoMiner.isValidGaugeFactory().)
* With the list of gauges, we can then mass-update them when the veBAL balance gets bridged.
* Duplication is not allowed
* Gagues can be removed by authorized actor

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
