### PR TITLE
Shorten Managed Pool initialization code

### DIFF
--- a/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
+++ b/pkg/pool-weighted/contracts/managed/ManagedPoolFactory.sol
@@ -16,14 +16,14 @@ pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/IFactoryCreatedPoolVersion.sol";
+import "@balancer-labs/v2-interfaces/contracts/pool-utils/IRecoveryModeHelper.sol";
+import "@balancer-labs/v2-interfaces/contracts/pool-weighted/IExternalWeightedMath.sol";
 import "@balancer-labs/v2-interfaces/contracts/standalone-utils/IProtocolFeePercentagesProvider.sol";
 
 import "@balancer-labs/v2-pool-utils/contracts/factories/BasePoolFactory.sol";
-import "@balancer-labs/v2-pool-utils/contracts/RecoveryModeHelper.sol";
 import "@balancer-labs/v2-pool-utils/contracts/Version.sol";
 
 import "./ManagedPool.sol";
-import "../ExternalWeightedMath.sol";
 
 /**
  * @dev This is a base factory designed to be called from other factories to deploy a ManagedPool
@@ -45,6 +45,8 @@ contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFact
     constructor(
         IVault vault,
         IProtocolFeePercentagesProvider protocolFeeProvider,
+        IExternalWeightedMath externalWeightedMath,
+        IRecoveryModeHelper recoveryModeHelper,
         string memory factoryVersion,
         string memory poolVersion,
         uint256 initialPauseWindowDuration,
@@ -59,8 +61,8 @@ contract ManagedPoolFactory is IFactoryCreatedPoolVersion, Version, BasePoolFact
         )
         Version(factoryVersion)
     {
-        _weightedMath = new ExternalWeightedMath();
-        _recoveryModeHelper = new RecoveryModeHelper(vault);
+        _weightedMath = externalWeightedMath;
+        _recoveryModeHelper = recoveryModeHelper;
         _poolVersion = poolVersion;
     }
 

--- a/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
+++ b/pkg/pool-weighted/test/ManagedPoolFactory.test.ts
@@ -61,10 +61,15 @@ describe('ManagedPoolFactory', function () {
         CircuitBreakerLib: circuitBreakerLib.address,
       },
     });
+    const math = await deploy('ExternalWeightedMath');
+    const recoveryModeHelper = await deploy('v2-pool-utils/RecoveryModeHelper', { args: [vault.address] });
+
     factory = await deploy('ManagedPoolFactory', {
       args: [
         vault.address,
         vault.getFeesProvider().address,
+        math.address,
+        recoveryModeHelper.address,
         factoryVersion,
         poolVersion,
         BASE_PAUSE_WINDOW_DURATION,

--- a/pvt/benchmarks/misc.ts
+++ b/pvt/benchmarks/misc.ts
@@ -201,10 +201,15 @@ async function deployPoolFromFactory(
         CircuitBreakerLib: circuitBreakerLib.address,
       },
     });
+    const math = await deploy('ExternalWeightedMath');
+    const recoveryModeHelper = await deploy('v2-pool-utils/RecoveryModeHelper', { args: [vault.address] });
+
     factory = await deploy('v2-pool-weighted/ManagedPoolFactory', {
       args: [
         vault.address,
         vault.getFeesProvider().address,
+        math.address,
+        recoveryModeHelper.address,
         'factoryVersion',
         'poolVersion',
         MANAGED_PAUSE_WINDOW_DURATION,

--- a/pvt/benchmarks/misc.ts
+++ b/pvt/benchmarks/misc.ts
@@ -201,7 +201,7 @@ async function deployPoolFromFactory(
         CircuitBreakerLib: circuitBreakerLib.address,
       },
     });
-    const math = await deploy('ExternalWeightedMath');
+    const math = await deploy('v2-pool-weighted/ExternalWeightedMath');
     const recoveryModeHelper = await deploy('v2-pool-utils/RecoveryModeHelper', { args: [vault.address] });
 
     factory = await deploy('v2-pool-weighted/ManagedPoolFactory', {

--- a/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
@@ -300,10 +300,15 @@ export default {
 
         const addRemoveTokenLib = await deploy('v2-pool-weighted/ManagedPoolAddRemoveTokenLib');
         const circuitBreakerLib = await deploy('v2-pool-weighted/CircuitBreakerLib');
+        const math = await deploy('ExternalWeightedMath');
+        const recoveryModeHelper = await deploy('v2-pool-utils/RecoveryModeHelper', { args: [vault.address]});
+
         const factory = await deploy('v2-pool-weighted/ManagedPoolFactory', {
           args: [
             vault.address,
             vault.getFeesProvider().address,
+            math.address,
+            recoveryModeHelper.address,
             factoryVersion,
             poolVersion,
             MANAGED_PAUSE_WINDOW_DURATION,

--- a/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
+++ b/pvt/helpers/src/models/pools/weighted/WeightedPoolDeployer.ts
@@ -301,7 +301,7 @@ export default {
         const addRemoveTokenLib = await deploy('v2-pool-weighted/ManagedPoolAddRemoveTokenLib');
         const circuitBreakerLib = await deploy('v2-pool-weighted/CircuitBreakerLib');
         const math = await deploy('ExternalWeightedMath');
-        const recoveryModeHelper = await deploy('v2-pool-utils/RecoveryModeHelper', { args: [vault.address]});
+        const recoveryModeHelper = await deploy('v2-pool-utils/RecoveryModeHelper', { args: [vault.address] });
 
         const factory = await deploy('v2-pool-weighted/ManagedPoolFactory', {
           args: [


### PR DESCRIPTION
# Description

Thwarted by [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860) after the Shapella hard fork, making it undeployable on mainnet, goerli, and polygon (despite squeezing under the bytecode limit by 6 bytes).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

