### PR TITLE
Update dependencies in GH actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,11 +4,11 @@ runs:
   using: composite
   steps:
     - name: Install node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 18.15
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache
       with:
         path: '**/node_modules'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,7 +11,7 @@ jobs:
   deployment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Compile
@@ -24,7 +24,7 @@ jobs:
   single-pair-swap:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Compile
@@ -37,7 +37,7 @@ jobs:
   multihop-swap:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Compile
@@ -50,7 +50,7 @@ jobs:
   join-exit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Compile
@@ -63,7 +63,7 @@ jobs:
   relayer:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Lint
@@ -24,7 +24,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Build
@@ -35,7 +35,7 @@ jobs:
   test-solidity-utils:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Set up environment
@@ -56,7 +56,7 @@ jobs:
   test-standalone-utils:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Set up environment
@@ -77,7 +77,7 @@ jobs:
   test-vault:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Set up environment
@@ -98,7 +98,7 @@ jobs:
   test-pool-utils:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Set up environment
@@ -119,7 +119,7 @@ jobs:
   test-pool-weighted:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Set up environment
@@ -140,7 +140,7 @@ jobs:
   test-pool-stable:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Set up environment
@@ -161,7 +161,7 @@ jobs:
   test-pool-linear:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Set up environment
@@ -182,7 +182,7 @@ jobs:
   test-liquidity-mining:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Set up environment
@@ -203,7 +203,7 @@ jobs:
   test-governance-scripts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Compile
@@ -216,13 +216,13 @@ jobs:
   test-fork:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 18.15
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: '**/node_modules'
@@ -246,7 +246,7 @@ jobs:
         #  - use a different key on every single run, causing for the cache to always be saved.
         #  - use a wildcard as a restore key, which will cause all stored keys to match and the most recent one to be
         #    selected.
-        uses: pat-s/always-upload-cache@v3.0.1
+        uses: pat-s/always-upload-cache@v3
         id: cache-forked-network
         with:
           path: 'pkg/deployments/cache/hardhat-network-fork/**'

--- a/.github/workflows/deployment-checks.yml
+++ b/.github/workflows/deployment-checks.yml
@@ -13,7 +13,7 @@ jobs:
   check-artifacts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Compile balancer-js
@@ -24,7 +24,7 @@ jobs:
   check-addresses:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Compile balancer-js
@@ -46,7 +46,7 @@ jobs:
   check-action-ids:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Compile balancer-js
@@ -68,7 +68,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'


### PR DESCRIPTION
# Description

We are having a few warnings in CI such as this one: 

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-node@v1, actions/cache@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.Show less
```

And also issues with `save-state` and `save-output` in fork tests (which are probably coming from our 'save always' cache dependency; see [here](https://github.com/pat-s/always-upload-cache/tags) for reference):

```
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```


## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [x] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A