### PR TITLE
Add support for ethereum gauges in `L2GaugeCheckpointer`.

### DIFF
--- a/pkg/liquidity-mining/contracts/gauges/L2GaugeCheckpointer.sol
+++ b/pkg/liquidity-mining/contracts/gauges/L2GaugeCheckpointer.sol
@@ -125,6 +125,7 @@ contract L2GaugeCheckpointer is IL2GaugeCheckpointer, ReentrancyGuard {
         // solhint-disable-next-line not-rely-on-time
         uint256 currentPeriod = _roundDownTimestamp(block.timestamp);
 
+        _checkpointGauges(IGaugeAdder.GaugeType.Ethereum, minRelativeWeight, currentPeriod);
         _checkpointGauges(IGaugeAdder.GaugeType.Polygon, minRelativeWeight, currentPeriod);
         _checkpointGauges(IGaugeAdder.GaugeType.Arbitrum, minRelativeWeight, currentPeriod);
         _checkpointGauges(IGaugeAdder.GaugeType.Optimism, minRelativeWeight, currentPeriod);

--- a/pkg/liquidity-mining/contracts/gauges/L2GaugeCheckpointer.sol
+++ b/pkg/liquidity-mining/contracts/gauges/L2GaugeCheckpointer.sol
@@ -247,6 +247,7 @@ contract L2GaugeCheckpointer is IL2GaugeCheckpointer, ReentrancyGuard {
 
     function _isSupportedGaugeType(IGaugeAdder.GaugeType gaugeType) private pure returns (bool) {
         return
+            gaugeType == IGaugeAdder.GaugeType.Ethereum ||
             gaugeType == IGaugeAdder.GaugeType.Polygon ||
             gaugeType == IGaugeAdder.GaugeType.Arbitrum ||
             gaugeType == IGaugeAdder.GaugeType.Optimism ||

--- a/pkg/liquidity-mining/test/L2GaugeCheckpointer.test.ts
+++ b/pkg/liquidity-mining/test/L2GaugeCheckpointer.test.ts
@@ -28,9 +28,9 @@ describe('L2GaugeCheckpointer', () => {
   let testGauges: string[], otherTypeGauges: string[];
 
   const GAUGES_PER_TYPE = 3;
-  const FIRST_VALID_GAUGE = GaugeType.Polygon;
+  const FIRST_VALID_GAUGE = GaugeType.Ethereum;
 
-  // Allowed gauges: Polygon, Arbitrum, Optimism, Gnosis, ZKSync.
+  // Allowed gauges: Ethereum, Polygon, Arbitrum, Optimism, Gnosis, ZKSync.
   const GAUGE_TYPES = Object.values(GaugeType)
     .filter((v) => !isNaN(Number(v)) && v >= FIRST_VALID_GAUGE)
     .map((t) => Number(t));


### PR DESCRIPTION
# Description

There are some `SingleRecipientGauge`s that are being manually checkpointed nowadays.

See checkpoints in [tx](https://etherscan.io/tx/0x86f1acf38dc80701fbafdb01bc6806bd40612773eb39b4fd92228ea2574ca8ab#eventlog):
- [0x56124eb16441A1eF12A4CCAeAbDD3421281b795A](https://etherscan.io/address/0x56124eb16441A1eF12A4CCAeAbDD3421281b795A)
- [0xe867ad0a48e8f815dc0cda2cdb275e0f163a480b](https://etherscan.io/address/0xe867ad0a48e8f815dc0cda2cdb275e0f163a480b)

Those are registered as type 2 in the [gauge controller](https://etherscan.io/address/0xC128468b7Ce63eA702C1f104D55A2566b13D3ABD#readContract#F5), so I see no reason not to support them in the checkpointer.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A