### PR TITLE
Consider only directories for task IDs

### DIFF
--- a/pkg/deployments/src/task.ts
+++ b/pkg/deployments/src/task.ts
@@ -414,6 +414,7 @@ export default class Task {
     return [TASKS_DIRECTORY, DEPRECATED_DIRECTORY, SCRIPTS_DIRECTORY]
       .map((dir) => fs.readdirSync(dir))
       .flat()
+      .filter((dir) => fs.lstatSync(dir).isDirectory()) // MacOS saves .DS_Store files; we only care about directories.
       .sort();
   }
 }


### PR DESCRIPTION
# Description

Apparently `.DS_Store` files cause some issues in MacOS for some hardhat tasks when the ID is not set.
This should filter them out everywhere.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- N/A The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

See https://github.com/balancer/balancer-v2-monorepo/pull/2476#pullrequestreview-1421659436