### PR TITLE
Remove misleading comment

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -322,8 +322,6 @@ contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
         uint256 delay = _delaysPerActionId[actionId];
         require(delay > 0, "DELAY_IS_NOT_SET");
 
-        // We do not check if `where` is a contract because it might not be upon
-        // scheduling but it may be deployed later.
         uint256 scheduledExecutionId = _scheduleWithDelay(where, data, delay, executors);
 
         emit ExecutionScheduled(actionId, scheduledExecutionId);


### PR DESCRIPTION
# Description

This removes an incorrect comment. We _do_ indirectly check that `where` is a contract because we call `getActionId` on it.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [x] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

