### PR TITLE
Timelock spelling and naming improvements

### DIFF
--- a/pkg/governance-scripts/test/TimelockAuthorizerMigrator.test.ts
+++ b/pkg/governance-scripts/test/TimelockAuthorizerMigrator.test.ts
@@ -163,7 +163,7 @@ describe('TimelockAuthorizerMigrator', () => {
   context('executeDelays', () => {
     context("when MINIMUM_CHANGE_DELAY_EXECUTION_DELAY hasn't passed", () => {
       it('reverts', async () => {
-        await expect(migrator.executeDelays()).to.be.revertedWith('ACTION_NOT_YET_EXECUTABLE');
+        await expect(migrator.executeDelays()).to.be.revertedWith('EXECUTION_NOT_YET_EXECUTABLE');
       });
     });
 

--- a/pkg/interfaces/contracts/vault/ITimelockAuthorizer.sol
+++ b/pkg/interfaces/contracts/vault/ITimelockAuthorizer.sol
@@ -22,17 +22,17 @@ pragma experimental ABIEncoderV2;
  *
  * Users are allowed to perform actions if they have the permission to do so.
  *
- * This Authorizer implementation allows defining a delay per action identifier. If a delay is set for an action, users
- * are instead allowed to schedule an execution that will be run in the future by the Authorizer instead of executing it
- * directly themselves.
+ * This Authorizer implementation allows defining delays per action identifier. If a delay is set for an action, users
+ * are not allowed to execute it directly themselves. Instead, they schedule an execution that the Authorizer will
+ * run in the future.
  *
  * Glossary:
- * - Action: Operation that can be performed to a target contract. These are identified by a unique bytes32 `actionId`
+ * - Action: Operation that can be performed on a target contract. These are identified by a unique bytes32 `actionId`
  *   defined by each target contract following `IAuthentication.getActionId`.
- * - Scheduled execution: The Authorizer can define different delays per `actionId` in order to determine that a
- *   specific time window must pass before these can be executed. When a delay is set for an `actionId`, executions
- *   must be scheduled. These executions are identified with an unsigned integer called `scheduledExecutionId`.
- * - Permission: Unique identifier to refer to a user (who) that is allowed to perform an action (what) in a specific
+ * - Scheduled execution: The Authorizer can define a delay for an `actionId` to require that a specific
+ *   time window must pass before it can be executed. When a delay is set for an `actionId`, executions
+ *   must be scheduled. These executions are identified by an unsigned integer called `scheduledExecutionId`.
+ * - Permission: Unique identifier to refer to a user (who) that is allowed to perform an action (what) on a specific
  *   target contract (where). This identifier is called `permissionId` and is computed as
  *   `keccak256(actionId, account, where)`.
  *

--- a/pkg/interfaces/contracts/vault/ITimelockAuthorizer.sol
+++ b/pkg/interfaces/contracts/vault/ITimelockAuthorizer.sol
@@ -197,7 +197,7 @@ interface ITimelockAuthorizer {
 
     /**
      * @notice A constant value for `scheduledExecutionId` that will match any execution Id.
-     * Cancelers assigned to this Id will be able to cancel *any* scheduled action,
+     * Cancelers assigned to this Id will be able to cancel *any* scheduled execution,
      * which is very useful for e.g. emergency response dedicated teams that analyze these.
      */
     // solhint-disable-next-line func-name-mixedcase
@@ -393,7 +393,7 @@ interface ITimelockAuthorizer {
     function claimRoot() external;
 
     /**
-     * @notice Executes a scheduled action `scheduledExecutionId`. This is used to execute all scheduled executions,
+     * @notice Executes a scheduled execution `scheduledExecutionId`. This is used to execute all scheduled executions,
      * not only those that originate from `schedule`, but also internal TimelockAuthorizer functions such as
      * `scheduleRootChange` or `scheduleDelayChange`.
      *
@@ -404,8 +404,8 @@ interface ITimelockAuthorizer {
      *
      * We mark this function as `nonReentrant` out of an abundance of caution, as in theory this and the Authorizer
      * should be resilient to reentrant executions. The non-reentrancy check means that it is not possible to execute a
-     * scheduled action during the execution of another scheduled action - an unlikely and convoluted scenario that we
-     * explicitly forbid.
+     * scheduled execution during the execution of another scheduled execution - an unlikely and convoluted scenario
+     * that we explicitly forbid.
      *
      * Note that while `execute` is nonReentrant, other functions are not - indeed, we rely on reentrancy to e.g. call
      * `setPendingRoot` or `setDelay`.
@@ -413,8 +413,8 @@ interface ITimelockAuthorizer {
     function execute(uint256 scheduledExecutionId) external returns (bytes memory result);
 
     /**
-     * @notice Cancels a scheduled action `scheduledExecutionId`, which prevents execution via `execute`. Canceling is
-     * irreversible. Scheduled executions that have already been executed cannot be canceled. This is the only way to
+     * @notice Cancels a scheduled execution `scheduledExecutionId`, which prevents execution via `execute`. Canceling
+     * is irreversible. Scheduled executions that have already been executed cannot be canceled. This is the only way to
      * prevent a scheduled execution from being executed (assuming there are willing executors).
      *
      * The caller must be a canceler, a permission which is managed by the `addCanceler` and `removeCanceler` functions.
@@ -423,7 +423,7 @@ interface ITimelockAuthorizer {
     function cancel(uint256 scheduledExecutionId) external;
 
     /**
-     * @notice Grants canceler status to `account` for scheduled action `scheduledExecutionId`.
+     * @notice Grants canceler status to `account` for scheduled execution `scheduledExecutionId`.
      * @dev Only the root can add a canceler.
      *
      * Note that there are no delays associated with adding or removing cancelers. This is based on the assumption that
@@ -433,7 +433,7 @@ interface ITimelockAuthorizer {
     function addCanceler(uint256 scheduledExecutionId, address account) external;
 
     /**
-     * @notice Remove canceler status from `account` for scheduled action `scheduledExecutionId`.
+     * @notice Remove canceler status from `account` for scheduled execution `scheduledExecutionId`.
      * @dev Only the root can remove a canceler.
      */
     function removeCanceler(uint256 scheduledExecutionId, address account) external;
@@ -535,7 +535,7 @@ interface ITimelockAuthorizer {
      * 5 days, then the time difference between the delays must pass. Otherwise, the minimum delay change execution
      * delay of 5 days must pass instead.
      *
-     * Only `executors` will be able to execute the scheduled action, unless `executors` is an empty array, in which
+     * Only `executors` will be able to execute the scheduled execution, unless `executors` is an empty array, in which
      * case any account can execute it.
      *
      * Avoid scheduling multiple delay changes for the same action at the same time, as this makes it harder to reason
@@ -563,7 +563,7 @@ interface ITimelockAuthorizer {
      * than 5 days, then the time difference between the grant delays must pass. Otherwise, the minimum delay change
      * execution delay of 5 days must pass instead.
      *
-     * Only `executors` will be able to execute the scheduled action, unless `executors` is an empty array, in which
+     * Only `executors` will be able to execute the scheduled execution, unless `executors` is an empty array, in which
      * case any account can execute it.
      *
      * Avoid scheduling multiple grant delay changes for the same action at the same time, as this makes it harder to
@@ -592,7 +592,7 @@ interface ITimelockAuthorizer {
      * than 5 days, then the time difference between the revoke delays must pass. Otherwise, the minimum delay change
      * execution delay of 5 days must pass instead.
      *
-     * Only `executors` will be able to execute the scheduled action, unless `executors` is an empty array, in which
+     * Only `executors` will be able to execute the scheduled execution, unless `executors` is an empty array, in which
      * case any account can execute it.
      *
      * Avoid scheduling multiple revoke delay changes for the same action at the same time, as this makes it harder to

--- a/pkg/interfaces/contracts/vault/ITimelockAuthorizer.sol
+++ b/pkg/interfaces/contracts/vault/ITimelockAuthorizer.sol
@@ -16,7 +16,31 @@ pragma solidity >=0.7.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 /**
- * @dev We need this interface to avoid overriding functions at TimelockAuthorizer
+ * @title Timelock Authorizer
+ * @author Balancer Labs
+ * @dev Authorizer with timelocks (delays).
+ *
+ * Users are allowed to perform actions if they have the permission to do so.
+ *
+ * This Authorizer implementation allows defining a delay per action identifier. If a delay is set for an action, users
+ * are instead allowed to schedule an execution that will be run in the future by the Authorizer instead of executing it
+ * directly themselves.
+ *
+ * Glossary:
+ * - Action: Operation that can be performed to a target contract. These are identified by a unique bytes32 `actionId`
+ *   defined by each target contract following `IAuthentication.getActionId`.
+ * - Scheduled execution: The Authorizer can define different delays per `actionId` in order to determine that a
+ *   specific time window must pass before these can be executed. When a delay is set for an `actionId`, executions
+ *   must be scheduled. These executions are identified with an unsigned integer called `scheduledExecutionId`.
+ * - Permission: Unique identifier to refer to a user (who) that is allowed to perform an action (what) in a specific
+ *   target contract (where). This identifier is called `permissionId` and is computed as
+ *   `keccak256(actionId, account, where)`.
+ *
+ * Note that the TimelockAuthorizer doesn't use reentrancy guard on its external functions.
+ * The only function which makes an external non-view call (and so could initate a reentrancy attack) is `execute`
+ * which executes a scheduled execution, protected by the Checks-Effects-Interactions pattern.
+ * In fact a number of the TimelockAuthorizer's functions may only be called through a scheduled execution so reentrancy
+ * is necessary in order to be able to call these.
  */
 interface ITimelockAuthorizer {
     struct ScheduledExecution {

--- a/pkg/interfaces/contracts/vault/ITimelockAuthorizer.sol
+++ b/pkg/interfaces/contracts/vault/ITimelockAuthorizer.sol
@@ -47,15 +47,15 @@ interface ITimelockAuthorizer {
         address where;
         bytes data;
         bool executed;
-        bool cancelled;
+        bool canceled;
         bool protected;
         uint256 executableAt;
         address scheduledBy;
         uint256 scheduledAt;
         address executedBy;
         uint256 executedAt;
-        address cancelledBy;
-        uint256 cancelledAt;
+        address canceledBy;
+        uint256 canceledAt;
     }
 
     /**
@@ -104,9 +104,9 @@ interface ITimelockAuthorizer {
     event ExecutionExecuted(uint256 indexed scheduledExecutionId);
 
     /**
-     * @notice Emitted when an execution `scheduledExecutionId` is cancelled.
+     * @notice Emitted when an execution `scheduledExecutionId` is canceled.
      */
-    event ExecutionCancelled(uint256 indexed scheduledExecutionId);
+    event ExecutionCanceled(uint256 indexed scheduledExecutionId);
 
     /**
      * @notice Emitted when a new `root` is set.
@@ -314,7 +314,7 @@ interface ITimelockAuthorizer {
 
     /**
      * @notice Returns true if execution `scheduledExecutionId` can be executed.
-     * Only true if it is not already executed or cancelled, and if the execution delay has passed.
+     * Only true if it is not already executed or canceled, and if the execution delay has passed.
      */
     function canExecute(uint256 scheduledExecutionId) external view returns (bool);
 

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -26,31 +26,7 @@ import "./TimelockExecutionHelper.sol";
 import "./TimelockAuthorizerManagement.sol";
 
 /**
- * @title Timelock Authorizer
- * @author Balancer Labs
- * @dev Authorizer with timelocks (delays).
- *
- * Users are allowed to perform actions if they have the permission to do so.
- *
- * This Authorizer implementation allows defining a delay per action identifier. If a delay is set for an action, users
- * are instead allowed to schedule an execution that will be run in the future by the Authorizer instead of executing it
- * directly themselves.
- *
- * Glossary:
- * - Action: Operation that can be performed to a target contract. These are identified by a unique bytes32 `actionId`
- *   defined by each target contract following `IAuthentication.getActionId`.
- * - Scheduled execution: The Authorizer can define different delays per `actionId` in order to determine that a
- *   specific time window must pass before these can be executed. When a delay is set for an `actionId`, executions
- *   must be scheduled. These executions are identified with an unsigned integer called `scheduledExecutionId`.
- * - Permission: Unique identifier to refer to a user (who) that is allowed to perform an action (what) in a specific
- *   target contract (where). This identifier is called `permissionId` and is computed as
- *   `keccak256(actionId, account, where)`.
- *
- * Note that the TimelockAuthorizer doesn't use reentrancy guard on its external functions.
- * The only function which makes an external non-view call (and so could initate a reentrancy attack) is `execute`
- * which executes a scheduled execution, protected by the Checks-Effects-Interactions pattern.
- * In fact a number of the TimelockAuthorizer's functions may only be called through a scheduled execution so reentrancy
- * is necessary in order to be able to call these.
+ * See ITimelockAuthorizer.
  */
 contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
     // solhint-disable-next-line const-name-snakecase

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -302,8 +302,8 @@ contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
 
         emit ExecutionScheduled(actionId, scheduledExecutionId);
 
-        // Accounts that schedule actions are automatically made cancelers for them, so that they can manage their
-        // action. We check that they are not already a canceler since e.g. root may schedule actions (and root is
+        // Accounts that schedule exectutions are automatically made cancelers for them, so that they can manage their
+        // action. We check that they are not already a canceler since e.g. root may schedule exectutions (and root is
         // always a global canceler).
         if (!isCanceler(scheduledExecutionId, msg.sender)) {
             _addCanceler(scheduledExecutionId, msg.sender);
@@ -354,7 +354,7 @@ contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
 
         uint256 scheduledExecutionId = _scheduleWithDelay(address(this), data, delay, executors);
         emit GrantPermissionScheduled(actionId, account, where, scheduledExecutionId);
-        // Granters that schedule actions are automatically made cancelers for them, so that they can manage their
+        // Granters that schedule exectutions are automatically made cancelers for them, so that they can manage their
         // action. We check that they are not already a canceler since e.g. root may schedule grants (and root is
         // always a global canceler).
         if (!isCanceler(scheduledExecutionId, msg.sender)) {
@@ -400,7 +400,7 @@ contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
 
         uint256 scheduledExecutionId = _scheduleWithDelay(address(this), data, delay, executors);
         emit RevokePermissionScheduled(actionId, account, where, scheduledExecutionId);
-        // Revokers that schedule actions are automatically made cancelers for them, so that they can manage their
+        // Revokers that schedule exectutions are automatically made cancelers for them, so that they can manage their
         // action. We check that they are not already a canceler since e.g. root may schedule revokes (and root is
         // always a global canceler).
         if (!isCanceler(scheduledExecutionId, msg.sender)) {

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -302,8 +302,8 @@ contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
 
         emit ExecutionScheduled(actionId, scheduledExecutionId);
 
-        // Accounts that schedule exectutions are automatically made cancelers for them, so that they can manage their
-        // action. We check that they are not already a canceler since e.g. root may schedule exectutions (and root is
+        // Accounts that schedule executions are automatically made cancelers for them, so that they can manage their
+        // actions. We check that they are not already a canceler since e.g. root may schedule executions (and root is
         // always a global canceler).
         if (!isCanceler(scheduledExecutionId, msg.sender)) {
             _addCanceler(scheduledExecutionId, msg.sender);
@@ -354,7 +354,7 @@ contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
 
         uint256 scheduledExecutionId = _scheduleWithDelay(address(this), data, delay, executors);
         emit GrantPermissionScheduled(actionId, account, where, scheduledExecutionId);
-        // Granters that schedule exectutions are automatically made cancelers for them, so that they can manage their
+        // Granters that schedule executions are automatically made cancelers for them, so that they can manage their
         // action. We check that they are not already a canceler since e.g. root may schedule grants (and root is
         // always a global canceler).
         if (!isCanceler(scheduledExecutionId, msg.sender)) {
@@ -400,7 +400,7 @@ contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
 
         uint256 scheduledExecutionId = _scheduleWithDelay(address(this), data, delay, executors);
         emit RevokePermissionScheduled(actionId, account, where, scheduledExecutionId);
-        // Revokers that schedule exectutions are automatically made cancelers for them, so that they can manage their
+        // Revokers that schedule executions are automatically made cancelers for them, so that they can manage their
         // action. We check that they are not already a canceler since e.g. root may schedule revokes (and root is
         // always a global canceler).
         if (!isCanceler(scheduledExecutionId, msg.sender)) {

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
@@ -253,7 +253,7 @@ abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer {
      * @inheritdoc ITimelockAuthorizer
      */
     function canExecute(uint256 scheduledExecutionId) external view override returns (bool) {
-        require(scheduledExecutionId < _scheduledExecutions.length, "ACTION_DOES_NOT_EXIST");
+        require(scheduledExecutionId < _scheduledExecutions.length, "EXECUTION_DOES_NOT_EXIST");
 
         ITimelockAuthorizer.ScheduledExecution storage scheduledExecution = _scheduledExecutions[scheduledExecutionId];
         return
@@ -310,13 +310,13 @@ abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer {
      * @inheritdoc ITimelockAuthorizer
      */
     function execute(uint256 scheduledExecutionId) external override returns (bytes memory result) {
-        require(scheduledExecutionId < _scheduledExecutions.length, "ACTION_DOES_NOT_EXIST");
+        require(scheduledExecutionId < _scheduledExecutions.length, "EXECUTION_DOES_NOT_EXIST");
 
         ITimelockAuthorizer.ScheduledExecution storage scheduledExecution = _scheduledExecutions[scheduledExecutionId];
-        require(!scheduledExecution.executed, "ACTION_ALREADY_EXECUTED");
-        require(!scheduledExecution.canceled, "ACTION_ALREADY_CANCELED");
+        require(!scheduledExecution.executed, "EXECUTION_ALREADY_EXECUTED");
+        require(!scheduledExecution.canceled, "EXECUTION_ALREADY_CANCELED");
 
-        require(block.timestamp >= scheduledExecution.executableAt, "ACTION_NOT_YET_EXECUTABLE");
+        require(block.timestamp >= scheduledExecution.executableAt, "EXECUTION_NOT_YET_EXECUTABLE");
 
         if (scheduledExecution.protected) {
             // Protected scheduled executions can only be executed by a set of accounts designated by the original
@@ -341,12 +341,12 @@ abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer {
      * @inheritdoc ITimelockAuthorizer
      */
     function cancel(uint256 scheduledExecutionId) external override {
-        require(scheduledExecutionId < _scheduledExecutions.length, "ACTION_DOES_NOT_EXIST");
+        require(scheduledExecutionId < _scheduledExecutions.length, "EXECUTION_DOES_NOT_EXIST");
 
         ITimelockAuthorizer.ScheduledExecution storage scheduledExecution = _scheduledExecutions[scheduledExecutionId];
 
-        require(!scheduledExecution.executed, "ACTION_ALREADY_EXECUTED");
-        require(!scheduledExecution.canceled, "ACTION_ALREADY_CANCELED");
+        require(!scheduledExecution.executed, "EXECUTION_ALREADY_EXECUTED");
+        require(!scheduledExecution.canceled, "EXECUTION_ALREADY_CANCELED");
 
         require(isCanceler(scheduledExecutionId, msg.sender), "SENDER_IS_NOT_CANCELER");
 
@@ -539,12 +539,12 @@ abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer {
         if (scheduledExecutionId != GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID()) {
             // It is not possible to predict future execution ids (because they'll depend on the order of scheduled
             // actions), so it is never a good idea to add cancelers for executions that don't yet exist.
-            require(scheduledExecutionId < _scheduledExecutions.length, "ACTION_DOES_NOT_EXIST");
+            require(scheduledExecutionId < _scheduledExecutions.length, "EXECUTION_DOES_NOT_EXIST");
 
             // It is also pointless to add a canceler for a scheduled execution that has already been executed or
             // canceled, so we disallow this to provide more information to a caller that would attempt this.
             ScheduledExecution storage execution = _scheduledExecutions[scheduledExecutionId];
-            require(!execution.executed && !execution.canceled, "ACTION_IS_NOT_PENDING");
+            require(!execution.executed && !execution.canceled, "EXECUTION_IS_NOT_PENDING");
         }
 
         _isCanceler[scheduledExecutionId][account] = true;

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
@@ -24,7 +24,7 @@ import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
 import "./TimelockExecutionHelper.sol";
 
-// Scheduled actions are time based and are expected to be on the order of days, so any time changes or manipulation on
+// Scheduled executions are time based and are expected to be on the order of days, so any time changes or manipulation on
 // the order of seconds or minutes is irrelevant.
 // solhint-disable not-rely-on-time
 

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
@@ -36,7 +36,7 @@ import "./TimelockExecutionHelper.sol";
  * (`setPendingRoot` and 'claimRoot'), scheduling and executing actions (`_scheduleWithDelay`, `execute`, and
  * `cancel`), and managing roles (`addRevoker`, `addGranter`, `addCanceler`).
  *
- * See `TimelockAuthorizer`
+ * See `ITimelockAuthorizer`.
  */
 abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer {
     using Address for address;

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
@@ -258,7 +258,7 @@ abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer {
         ITimelockAuthorizer.ScheduledExecution storage scheduledExecution = _scheduledExecutions[scheduledExecutionId];
         return
             !scheduledExecution.executed &&
-            !scheduledExecution.cancelled &&
+            !scheduledExecution.canceled &&
             block.timestamp >= scheduledExecution.executableAt;
     }
 
@@ -314,7 +314,7 @@ abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer {
 
         ITimelockAuthorizer.ScheduledExecution storage scheduledExecution = _scheduledExecutions[scheduledExecutionId];
         require(!scheduledExecution.executed, "ACTION_ALREADY_EXECUTED");
-        require(!scheduledExecution.cancelled, "ACTION_ALREADY_CANCELLED");
+        require(!scheduledExecution.canceled, "ACTION_ALREADY_CANCELED");
 
         require(block.timestamp >= scheduledExecution.executableAt, "ACTION_NOT_YET_EXECUTABLE");
 
@@ -346,15 +346,15 @@ abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer {
         ITimelockAuthorizer.ScheduledExecution storage scheduledExecution = _scheduledExecutions[scheduledExecutionId];
 
         require(!scheduledExecution.executed, "ACTION_ALREADY_EXECUTED");
-        require(!scheduledExecution.cancelled, "ACTION_ALREADY_CANCELLED");
+        require(!scheduledExecution.canceled, "ACTION_ALREADY_CANCELED");
 
         require(isCanceler(scheduledExecutionId, msg.sender), "SENDER_IS_NOT_CANCELER");
 
-        scheduledExecution.cancelled = true;
-        scheduledExecution.cancelledBy = msg.sender;
-        scheduledExecution.cancelledAt = block.timestamp;
+        scheduledExecution.canceled = true;
+        scheduledExecution.canceledBy = msg.sender;
+        scheduledExecution.canceledAt = block.timestamp;
 
-        emit ExecutionCancelled(scheduledExecutionId);
+        emit ExecutionCanceled(scheduledExecutionId);
     }
 
     /**
@@ -501,15 +501,15 @@ abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer {
                 where: where,
                 data: data,
                 executed: false,
-                cancelled: false,
+                canceled: false,
                 protected: protected,
                 executableAt: executableAt,
                 scheduledBy: msg.sender,
                 scheduledAt: block.timestamp,
                 executedBy: address(0),
                 executedAt: 0,
-                cancelledBy: address(0),
-                cancelledAt: 0
+                canceledBy: address(0),
+                canceledAt: 0
             })
         );
 
@@ -542,9 +542,9 @@ abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer {
             require(scheduledExecutionId < _scheduledExecutions.length, "ACTION_DOES_NOT_EXIST");
 
             // It is also pointless to add a canceler for a scheduled execution that has already been executed or
-            // cancelled, so we disallow this to provide more information to a caller that would attempt this.
+            // canceled, so we disallow this to provide more information to a caller that would attempt this.
             ScheduledExecution storage execution = _scheduledExecutions[scheduledExecutionId];
-            require(!execution.executed && !execution.cancelled, "ACTION_IS_NOT_PENDING");
+            require(!execution.executed && !execution.canceled, "ACTION_IS_NOT_PENDING");
         }
 
         _isCanceler[scheduledExecutionId][account] = true;

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
@@ -24,8 +24,8 @@ import "@balancer-labs/v2-solidity-utils/contracts/math/Math.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/Address.sol";
 import "./TimelockExecutionHelper.sol";
 
-// Scheduled executions are time based and are expected to be on the order of days, so any time changes or manipulation on
-// the order of seconds or minutes is irrelevant.
+// Scheduled executions are time based and are expected to be on the order of days, so any time changes or manipulation
+// on the order of seconds or minutes is irrelevant.
 // solhint-disable not-rely-on-time
 
 /**

--- a/pkg/vault/contracts/authorizer/TimelockExecutionHelper.sol
+++ b/pkg/vault/contracts/authorizer/TimelockExecutionHelper.sol
@@ -22,11 +22,11 @@ import "@balancer-labs/v2-interfaces/contracts/vault/IAuthorizer.sol";
 import "./TimelockAuthorizer.sol";
 
 /**
- * @dev Helper contract that is used by the TimelockAuthorizer to execute scheduled actions.
+ * @dev Helper contract that is used by the TimelockAuthorizer to execute scheduled executions.
  *
  * This contract always has permission to call any permissioned function in any contract, as long as they have a delay.
- * That is, `canPerform` always returns true for the ExecutionHelper for delayed actions. Additionally, native Timelock
- * scheduled functions (such as setDelay or setPendingRoot) can also only be called by the ExecutionHelper.
+ * That is, `canPerform` always returns true for the ExecutionHelper for delayed executions. Additionally, native
+ * Timelock scheduled functions (such as setDelay or setPendingRoot) can also only be called by the ExecutionHelper.
  *
  * The ExecutionHelper features a single function, `execute`, which then performs an arbitrary function call on any
  * address. This is how functions that have delays associated are called. However, only the TimelockAuthorizer itself
@@ -52,12 +52,12 @@ contract TimelockExecutionHelper is ReentrancyGuard {
     /**
      * @dev Calls `target` with `data`. Because the ExecutionHelper is authorized to call any permission function that
      * has a delay, this is a very powerful call. However, only the TimelockAuthorizer can initiate it, and it should
-     * only do so after having validated that the conditions to perform a delayed action have been met.
+     * only do so after having validated that the conditions to perform a delayed execution have been met.
      *
      * We mark this function as `nonReentrant` out of an abundance of caution, as in theory this and the Authorizer
      * should be resilient to reentrant executions. The non-reentrancy check means that it is not possible to execute a
-     * scheduled action during the execution of another scheduled action - an unlikely and convoluted scenario that we
-     * knowingly forbid.
+     * scheduled execution during the execution of another scheduled execution - an unlikely and convoluted scenario
+     * that we knowingly forbid.
      */
     function execute(address target, bytes memory data) external nonReentrant returns (bytes memory) {
         require(msg.sender == address(_authorizer), "SENDER_IS_NOT_AUTHORIZER");

--- a/pkg/vault/test/authorizer/TimelockAuthorizerActors.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerActors.test.ts
@@ -570,7 +570,7 @@ describe('TimelockAuthorizer actors', () => {
 
         it('reverts if the scheduled execution does not exist', async () => {
           await expect(authorizer.addCanceler(42, canceler, { from: root })).to.be.revertedWith(
-            'ACTION_DOES_NOT_EXIST'
+            'EXECUTION_DOES_NOT_EXIST'
           );
         });
 
@@ -579,7 +579,7 @@ describe('TimelockAuthorizer actors', () => {
           await authorizer.execute(executionId);
 
           await expect(authorizer.addCanceler(executionId, canceler, { from: root })).to.be.revertedWith(
-            'ACTION_IS_NOT_PENDING'
+            'EXECUTION_IS_NOT_PENDING'
           );
         });
 
@@ -587,7 +587,7 @@ describe('TimelockAuthorizer actors', () => {
           await authorizer.cancel(executionId, { from: root });
 
           await expect(authorizer.addCanceler(executionId, canceler, { from: root })).to.be.revertedWith(
-            'ACTION_IS_NOT_PENDING'
+            'EXECUTION_IS_NOT_PENDING'
           );
         });
       });

--- a/pkg/vault/test/authorizer/TimelockAuthorizerDelays.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerDelays.test.ts
@@ -85,8 +85,8 @@ describe('TimelockAuthorizer delays', () => {
         const scheduledExecution = await authorizer.getScheduledExecution(id);
         expect(scheduledExecution.executedBy).to.equal(ZERO_ADDRESS);
         expect(scheduledExecution.executedAt).to.equal(0);
-        expect(scheduledExecution.cancelledBy).to.equal(ZERO_ADDRESS);
-        expect(scheduledExecution.cancelledAt).to.equal(0);
+        expect(scheduledExecution.canceledBy).to.equal(ZERO_ADDRESS);
+        expect(scheduledExecution.canceledAt).to.equal(0);
       });
 
       it('execution can be unprotected', async () => {
@@ -112,7 +112,7 @@ describe('TimelockAuthorizer delays', () => {
         expect(await authorizer.isCanceler(id, root)).to.be.true;
 
         const receipt = await authorizer.cancel(id, { from: root });
-        expectEvent.inReceipt(await receipt.wait(), 'ExecutionCancelled', { scheduledExecutionId: id });
+        expectEvent.inReceipt(await receipt.wait(), 'ExecutionCanceled', { scheduledExecutionId: id });
       });
 
       it('can be executed after the expected delay', async () => {
@@ -284,8 +284,8 @@ describe('TimelockAuthorizer delays', () => {
         const scheduledExecution = await authorizer.getScheduledExecution(id);
         expect(scheduledExecution.executedBy).to.equal(ZERO_ADDRESS);
         expect(scheduledExecution.executedAt).to.equal(0);
-        expect(scheduledExecution.cancelledBy).to.equal(ZERO_ADDRESS);
-        expect(scheduledExecution.cancelledAt).to.equal(0);
+        expect(scheduledExecution.canceledBy).to.equal(ZERO_ADDRESS);
+        expect(scheduledExecution.canceledAt).to.equal(0);
       });
 
       it('execution can be unprotected', async () => {
@@ -311,7 +311,7 @@ describe('TimelockAuthorizer delays', () => {
         expect(await authorizer.isCanceler(id, root)).to.be.true;
 
         const receipt = await authorizer.cancel(id, { from: root });
-        expectEvent.inReceipt(await receipt.wait(), 'ExecutionCancelled', { scheduledExecutionId: id });
+        expectEvent.inReceipt(await receipt.wait(), 'ExecutionCanceled', { scheduledExecutionId: id });
       });
 
       it('can be executed after the expected delay', async () => {
@@ -486,8 +486,8 @@ describe('TimelockAuthorizer delays', () => {
         const scheduledExecution = await authorizer.getScheduledExecution(id);
         expect(scheduledExecution.executedBy).to.equal(ZERO_ADDRESS);
         expect(scheduledExecution.executedAt).to.equal(0);
-        expect(scheduledExecution.cancelledBy).to.equal(ZERO_ADDRESS);
-        expect(scheduledExecution.cancelledAt).to.equal(0);
+        expect(scheduledExecution.canceledBy).to.equal(ZERO_ADDRESS);
+        expect(scheduledExecution.canceledAt).to.equal(0);
       });
 
       it('execution can be unprotected', async () => {
@@ -513,7 +513,7 @@ describe('TimelockAuthorizer delays', () => {
         expect(await authorizer.isCanceler(id, root)).to.be.true;
 
         const receipt = await authorizer.cancel(id, { from: root });
-        expectEvent.inReceipt(await receipt.wait(), 'ExecutionCancelled', { scheduledExecutionId: id });
+        expectEvent.inReceipt(await receipt.wait(), 'ExecutionCanceled', { scheduledExecutionId: id });
       });
 
       it('can be executed after the expected delay', async () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizerExecute.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerExecute.test.ts
@@ -372,23 +372,23 @@ describe('TimelockAuthorizer execute', () => {
       const id = await schedule();
       await advanceTime(delay);
       await authorizer.execute(id, { from: executor });
-      await expect(authorizer.execute(id, { from: executor })).to.be.revertedWith('ACTION_ALREADY_EXECUTED');
+      await expect(authorizer.execute(id, { from: executor })).to.be.revertedWith('EXECUTION_ALREADY_EXECUTED');
     });
 
     it('reverts if action was canceled', async () => {
       const id = await schedule();
       await advanceTime(delay);
       await authorizer.cancel(id, { from: user });
-      await expect(authorizer.execute(id, { from: executor })).to.be.revertedWith('ACTION_ALREADY_CANCELED');
+      await expect(authorizer.execute(id, { from: executor })).to.be.revertedWith('EXECUTION_ALREADY_CANCELED');
     });
 
     it('reverts if the delay has not passed', async () => {
       const id = await schedule();
-      await expect(authorizer.execute(id, { from: executor })).to.be.revertedWith('ACTION_NOT_YET_EXECUTABLE');
+      await expect(authorizer.execute(id, { from: executor })).to.be.revertedWith('EXECUTION_NOT_YET_EXECUTABLE');
     });
 
     it('reverts if the scheduled id is invalid', async () => {
-      await expect(authorizer.execute(100)).to.be.revertedWith('ACTION_DOES_NOT_EXIST');
+      await expect(authorizer.execute(100)).to.be.revertedWith('EXECUTION_DOES_NOT_EXIST');
     });
   });
 
@@ -474,11 +474,11 @@ describe('TimelockAuthorizer execute', () => {
       const id = await schedule();
       await authorizer.cancel(id, { from: canceler });
 
-      await expect(authorizer.cancel(id, { from: canceler })).to.be.revertedWith('ACTION_ALREADY_CANCELED');
+      await expect(authorizer.cancel(id, { from: canceler })).to.be.revertedWith('EXECUTION_ALREADY_CANCELED');
     });
 
     it('reverts if the scheduled id is invalid', async () => {
-      await expect(authorizer.cancel(100)).to.be.revertedWith('ACTION_DOES_NOT_EXIST');
+      await expect(authorizer.cancel(100)).to.be.revertedWith('EXECUTION_DOES_NOT_EXIST');
     });
 
     it('reverts if action was executed', async () => {
@@ -486,7 +486,7 @@ describe('TimelockAuthorizer execute', () => {
       await advanceTime(delay);
       await authorizer.execute(id);
 
-      await expect(authorizer.cancel(id, { from: canceler })).to.be.revertedWith('ACTION_ALREADY_EXECUTED');
+      await expect(authorizer.cancel(id, { from: canceler })).to.be.revertedWith('EXECUTION_ALREADY_EXECUTED');
     });
 
     it('reverts if sender is not canceler', async () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizerExecute.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerExecute.test.ts
@@ -101,8 +101,8 @@ describe('TimelockAuthorizer execute', () => {
       const scheduledExecution = await authorizer.getScheduledExecution(id);
       expect(scheduledExecution.executedBy).to.equal(ZERO_ADDRESS);
       expect(scheduledExecution.executedAt).to.equal(0);
-      expect(scheduledExecution.cancelledBy).to.equal(ZERO_ADDRESS);
-      expect(scheduledExecution.cancelledAt).to.equal(0);
+      expect(scheduledExecution.canceledBy).to.equal(ZERO_ADDRESS);
+      expect(scheduledExecution.canceledAt).to.equal(0);
     });
 
     it('schedules a non-protected execution', async () => {
@@ -139,7 +139,7 @@ describe('TimelockAuthorizer execute', () => {
       const id = await schedule(authenticatedContract);
       // should not revert
       const receipt = await authorizer.cancel(id, { from: user });
-      expectEvent.inReceipt(await receipt.wait(), 'ExecutionCancelled', { scheduledExecutionId: id });
+      expectEvent.inReceipt(await receipt.wait(), 'ExecutionCanceled', { scheduledExecutionId: id });
     });
 
     it('schedules the protected execution', async () => {
@@ -302,8 +302,8 @@ describe('TimelockAuthorizer execute', () => {
       await authorizer.execute(id, { from: executor });
 
       const scheduledExecution = await authorizer.getScheduledExecution(id);
-      expect(scheduledExecution.cancelledBy).to.equal(ZERO_ADDRESS);
-      expect(scheduledExecution.cancelledAt).to.equal(0);
+      expect(scheduledExecution.canceledBy).to.equal(ZERO_ADDRESS);
+      expect(scheduledExecution.canceledAt).to.equal(0);
     });
 
     it('execute returns a correct result', async () => {
@@ -375,11 +375,11 @@ describe('TimelockAuthorizer execute', () => {
       await expect(authorizer.execute(id, { from: executor })).to.be.revertedWith('ACTION_ALREADY_EXECUTED');
     });
 
-    it('reverts if action was cancelled', async () => {
+    it('reverts if action was canceled', async () => {
       const id = await schedule();
       await advanceTime(delay);
       await authorizer.cancel(id, { from: user });
-      await expect(authorizer.execute(id, { from: executor })).to.be.revertedWith('ACTION_ALREADY_CANCELLED');
+      await expect(authorizer.execute(id, { from: executor })).to.be.revertedWith('ACTION_ALREADY_CANCELED');
     });
 
     it('reverts if the delay has not passed', async () => {
@@ -419,8 +419,8 @@ describe('TimelockAuthorizer execute', () => {
       await authorizer.cancel(id, { from: canceler });
 
       const scheduledExecution = await authorizer.getScheduledExecution(id);
-      expect(scheduledExecution.cancelledBy).to.equal(canceler.address);
-      expect(scheduledExecution.cancelledAt).to.equal(await currentTimestamp());
+      expect(scheduledExecution.canceledBy).to.equal(canceler.address);
+      expect(scheduledExecution.canceledAt).to.equal(await currentTimestamp());
     });
 
     it('stores empty executor information', async () => {
@@ -438,7 +438,7 @@ describe('TimelockAuthorizer execute', () => {
       await authorizer.cancel(id, { from: canceler });
 
       const scheduledExecution = await authorizer.getScheduledExecution(id);
-      expect(scheduledExecution.cancelled).to.be.true;
+      expect(scheduledExecution.canceled).to.be.true;
     });
 
     it('global canceler can cancel the action', async () => {
@@ -452,7 +452,7 @@ describe('TimelockAuthorizer execute', () => {
       await authorizer.cancel(id, { from: canceler });
 
       const scheduledExecution = await authorizer.getScheduledExecution(id);
-      expect(scheduledExecution.cancelled).to.be.true;
+      expect(scheduledExecution.canceled).to.be.true;
     });
 
     it('root canceler can cancel the action', async () => {
@@ -460,21 +460,21 @@ describe('TimelockAuthorizer execute', () => {
       await authorizer.cancel(id, { from: root });
 
       const scheduledExecution = await authorizer.getScheduledExecution(id);
-      expect(scheduledExecution.cancelled).to.be.true;
+      expect(scheduledExecution.canceled).to.be.true;
     });
 
     it('emits an event', async () => {
       const id = await schedule();
       const receipt = await authorizer.cancel(id, { from: canceler });
 
-      expectEvent.inReceipt(await receipt.wait(), 'ExecutionCancelled', { scheduledExecutionId: id });
+      expectEvent.inReceipt(await receipt.wait(), 'ExecutionCanceled', { scheduledExecutionId: id });
     });
 
-    it('cannot be cancelled twice', async () => {
+    it('cannot be canceled twice', async () => {
       const id = await schedule();
       await authorizer.cancel(id, { from: canceler });
 
-      await expect(authorizer.cancel(id, { from: canceler })).to.be.revertedWith('ACTION_ALREADY_CANCELLED');
+      await expect(authorizer.cancel(id, { from: canceler })).to.be.revertedWith('ACTION_ALREADY_CANCELED');
     });
 
     it('reverts if the scheduled id is invalid', async () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizerPermissions.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerPermissions.test.ts
@@ -404,8 +404,8 @@ describe('TimelockAuthorizer permissions', () => {
         const scheduledExecution = await authorizer.getScheduledExecution(id);
         expect(scheduledExecution.executedBy).to.equal(ZERO_ADDRESS);
         expect(scheduledExecution.executedAt).to.equal(0);
-        expect(scheduledExecution.cancelledBy).to.equal(ZERO_ADDRESS);
-        expect(scheduledExecution.cancelledAt).to.equal(0);
+        expect(scheduledExecution.canceledBy).to.equal(ZERO_ADDRESS);
+        expect(scheduledExecution.canceledAt).to.equal(0);
       });
 
       it('execution can be unprotected', async () => {
@@ -431,7 +431,7 @@ describe('TimelockAuthorizer permissions', () => {
         expect(await authorizer.isCanceler(id, getSender())).to.be.true;
 
         const receipt = await authorizer.cancel(id, { from: getSender() });
-        expectEvent.inReceipt(await receipt.wait(), 'ExecutionCancelled', { scheduledExecutionId: id });
+        expectEvent.inReceipt(await receipt.wait(), 'ExecutionCanceled', { scheduledExecutionId: id });
       });
 
       it('can be executed after the expected delay', async () => {
@@ -816,8 +816,8 @@ describe('TimelockAuthorizer permissions', () => {
         const scheduledExecution = await authorizer.getScheduledExecution(id);
         expect(scheduledExecution.executedBy).to.equal(ZERO_ADDRESS);
         expect(scheduledExecution.executedAt).to.equal(0);
-        expect(scheduledExecution.cancelledBy).to.equal(ZERO_ADDRESS);
-        expect(scheduledExecution.cancelledAt).to.equal(0);
+        expect(scheduledExecution.canceledBy).to.equal(ZERO_ADDRESS);
+        expect(scheduledExecution.canceledAt).to.equal(0);
       });
 
       it('execution can be unprotected', async () => {
@@ -843,7 +843,7 @@ describe('TimelockAuthorizer permissions', () => {
         expect(await authorizer.isCanceler(id, getSender())).to.be.true;
 
         const receipt = await authorizer.cancel(id, { from: getSender() });
-        expectEvent.inReceipt(await receipt.wait(), 'ExecutionCancelled', { scheduledExecutionId: id });
+        expectEvent.inReceipt(await receipt.wait(), 'ExecutionCanceled', { scheduledExecutionId: id });
       });
 
       it('can be executed after the expected delay', async () => {

--- a/pkg/vault/test/authorizer/TimelockAuthorizerRoot.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerRoot.test.ts
@@ -63,7 +63,7 @@ describe('TimelockAuthorizer root', () => {
             const newPendingRoot: SignerWithAddress = getNewPendingRoot();
             const id = await authorizer.scheduleRootChange(newPendingRoot, [], { from: root });
 
-            await expect(authorizer.execute(id)).to.be.revertedWith('ACTION_NOT_YET_EXECUTABLE');
+            await expect(authorizer.execute(id)).to.be.revertedWith('EXECUTION_NOT_YET_EXECUTABLE');
 
             await advanceTime(ROOT_CHANGE_DELAY);
             await authorizer.execute(id);

--- a/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
+++ b/pvt/helpers/src/models/authorizer/TimelockAuthorizer.ts
@@ -72,7 +72,7 @@ export default class TimelockAuthorizer {
 
   async getScheduledExecution(id: BigNumberish): Promise<{
     executed: boolean;
-    cancelled: boolean;
+    canceled: boolean;
     protected: boolean;
     executableAt: BigNumber;
     data: string;
@@ -81,8 +81,8 @@ export default class TimelockAuthorizer {
     scheduledAt: BigNumber;
     executedBy: string;
     executedAt: BigNumber;
-    cancelledBy: string;
-    cancelledAt: BigNumber;
+    canceledBy: string;
+    canceledAt: BigNumber;
   }> {
     return this.instance.getScheduledExecution(id);
   }


### PR DESCRIPTION
# Description

This makes the spelling of 'canceling' consistent, as well as changes all instances of 'scheduled actions' to 'scheduled executions' (to avoid confusion between an execution and an action with an action id).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [x] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

