### PR TITLE
Make Timelock grant and revoke consistent

### DIFF
--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -315,7 +315,7 @@ contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
             require(msg.sender == getTimelockExecutionHelper(), "GRANT_MUST_BE_SCHEDULED");
         }
 
-        require(!_isPermissionGranted[actionId][account][where], "PERMISSION_ALREADY_GRANTED");
+        require(!hasPermission(actionId, account, where), "PERMISSION_ALREADY_GRANTED");
 
         _isPermissionGranted[actionId][account][where] = true;
         emit PermissionGranted(actionId, account, where);

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -412,6 +412,8 @@ contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
         address account,
         address where
     ) private {
+        require(hasPermission(actionId, account, where), "PERMISSION_NOT_GRANTED");
+
         if (_isPermissionGranted[actionId][account][EVERYWHERE()]) {
             // If an account has global permission, then it must explicitly lose this global privilege. This prevents
             // scenarios where an account has their permission revoked over a specific contract, but they can still
@@ -420,9 +422,6 @@ contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
             // permission over some contracts after losing global privilege. This is considered an unlikely scenario,
             // and would require manual removal of the specific permissions even after removal of the global one.
             require(where == EVERYWHERE(), "ACCOUNT_HAS_GLOBAL_PERMISSION");
-        } else {
-            // Alternatively, they must currently have the permission in order to have it revoked.
-            require(_isPermissionGranted[actionId][account][where], "PERMISSION_NOT_GRANTED");
         }
 
         _isPermissionGranted[actionId][account][where] = false;

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizer.sol
@@ -316,6 +316,11 @@ contract TimelockAuthorizer is IAuthorizer, TimelockAuthorizerManagement {
         }
 
         require(!hasPermission(actionId, account, where), "PERMISSION_ALREADY_GRANTED");
+        // Note that it is possible for `account` to have permission for an `actionId` in some specific `where`, and
+        // then be granted permission over `EVERYWHERE`, resulting in 'duplicate' permissions. This is not an issue per
+        // se, but removing these permissions status will require undoing these actions in inverse order.
+        // To avoid these issues, it is recommended to revoke any prior prermissions over specific contracts before
+        // granting an account a global permissions.
 
         _isPermissionGranted[actionId][account][where] = true;
         emit PermissionGranted(actionId, account, where);

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
@@ -374,6 +374,8 @@ abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer {
         // The root account is always a canceler, and this cannot be revoked.
         require(!isRoot(account), "CANNOT_REMOVE_ROOT_CANCELER");
 
+        require(isCanceler(scheduledExecutionId, account), "ACCOUNT_IS_NOT_CANCELER");
+
         if (_isCanceler[GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID()][account]) {
             // If an account is a global canceler, then it must explicitly lose this global privilege. This prevents
             // scenarios where an account has their canceler status revoked over a specific scheduled execution id, but
@@ -383,9 +385,6 @@ abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer {
             // scenario, and would require manual removal of the specific canceler privileges even after removal
             // of the global one.
             require(scheduledExecutionId == GLOBAL_CANCELER_SCHEDULED_EXECUTION_ID(), "ACCOUNT_IS_GLOBAL_CANCELER");
-        } else {
-            // Alternatively, they must currently be a canceler in order to be revoked.
-            require(_isCanceler[scheduledExecutionId][account], "ACCOUNT_IS_NOT_CANCELER");
         }
 
         _isCanceler[scheduledExecutionId][account] = false;

--- a/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
+++ b/pkg/vault/contracts/authorizer/TimelockAuthorizerManagement.sol
@@ -402,7 +402,7 @@ abstract contract TimelockAuthorizerManagement is ITimelockAuthorizer {
         require(isRoot(msg.sender), "SENDER_IS_NOT_ROOT");
 
         require(!isGranter(actionId, account, where), "ACCOUNT_IS_ALREADY_GRANTER");
-        // Note that it is possible for `account` to be a granter for the same `actionId` in some specific `where`, and
+        // Note that it is possible for `account` to be a granter for an `actionId` in some specific `where`, and
         // then be granted permission over `EVERYWHERE`, resulting in 'duplicate' permissions. This is not an issue per
         // se, but removing this granter status will require undoing these actions in inverse order.
         // To avoid these issues, it is recommended to revoke any prior granter status over specific contracts before

--- a/pkg/vault/test/authorizer/TimelockAuthorizerPermissions.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerPermissions.test.ts
@@ -545,15 +545,6 @@ describe('TimelockAuthorizer permissions', () => {
                 authorizer.revokePermissionGlobally(ACTION_1, user, { from: getSender() })
               ).to.be.revertedWith('PERMISSION_NOT_GRANTED');
             });
-
-            it('cannot perform the requested action everywhere', async () => {
-              expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.false;
-              expect(await authorizer.canPerform(ACTION_2, user, EVERYWHERE)).to.be.false;
-            });
-
-            it('can perform the requested action for the previously granted permissions', async () => {
-              expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
-            });
           });
         });
 
@@ -566,7 +557,7 @@ describe('TimelockAuthorizer permissions', () => {
             it('cannot revoke the permission', async () => {
               await expect(
                 authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: getSender() })
-              ).to.be.revertedWith('PERMISSION_NOT_GRANTED');
+              ).to.be.revertedWith('ACCOUNT_HAS_GLOBAL_PERMISSION');
             });
 
             it('can perform the requested action for the requested contract', async () => {
@@ -679,21 +670,10 @@ describe('TimelockAuthorizer permissions', () => {
           });
 
           context('when revoking the permission for a contract', () => {
-            it('still can perform the requested action for the requested contract', async () => {
+            it('cannot revoke the permission', async () => {
               await expect(authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: revoker })).to.be.revertedWith(
-                'PERMISSION_NOT_GRANTED'
+                'ACCOUNT_HAS_GLOBAL_PERMISSION'
               );
-
-              expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
-              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
-            });
-
-            it('still can perform the requested action everywhere', async () => {
-              await expect(authorizer.revokePermission(ACTION_1, user, WHERE_1, { from: revoker })).to.be.revertedWith(
-                'PERMISSION_NOT_GRANTED'
-              );
-
-              expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.true;
             });
           });
         });
@@ -964,7 +944,7 @@ describe('TimelockAuthorizer permissions', () => {
       context('when renouncing the permission for a specific contract', () => {
         it('cannot renounce the permission if it was not granted', async () => {
           await expect(authorizer.renouncePermission(ACTION_1, WHERE_1, { from: user })).to.be.revertedWith(
-            'PERMISSION_NOT_GRANTED'
+            'ACCOUNT_HAS_GLOBAL_PERMISSION'
           );
         });
 

--- a/pkg/vault/test/authorizer/TimelockAuthorizerPermissions.test.ts
+++ b/pkg/vault/test/authorizer/TimelockAuthorizerPermissions.test.ts
@@ -138,6 +138,7 @@ describe('TimelockAuthorizer permissions', () => {
           sharedBeforeEach('grant a permission', async () => {
             await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() });
           });
+
           it('cannot grant the permission twice', async () => {
             await expect(authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() })).to.be.revertedWith(
               'PERMISSION_ALREADY_GRANTED'
@@ -149,14 +150,7 @@ describe('TimelockAuthorizer permissions', () => {
               await authorizer.grantPermissionGlobally(ACTION_1, user, { from: getSender() });
 
               expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.true;
-            });
-
-            it('still can perform the requested action for the previously granted contracts', async () => {
-              await authorizer.grantPermissionGlobally(ACTION_2, user, { from: getSender() });
-
-              expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
-              expect(await authorizer.canPerform(ACTION_2, user, WHERE_1)).to.be.true;
-              expect(await authorizer.canPerform(ACTION_2, user, WHERE_2)).to.be.true;
+              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
             });
 
             it('emits an event', async () => {
@@ -179,36 +173,10 @@ describe('TimelockAuthorizer permissions', () => {
           });
 
           context('when granting the permission for a contract', () => {
-            it('grants the permission to perform the requested action for the requested contract', async () => {
-              await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() });
-
-              expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
-              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
-            });
-
-            it('still can perform the requested actions everywhere', async () => {
-              await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() });
-
-              expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.true;
-              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
-            });
-
-            it('still can perform the requested actions for other contracts', async () => {
-              await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() });
-
-              expect(await authorizer.canPerform(ACTION_1, user, NOT_WHERE)).to.be.true;
-              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
-            });
-
-            it('emits an event', async () => {
-              const receipt = await (
-                await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() })
-              ).wait();
-              expectEvent.inReceipt(receipt, 'PermissionGranted', {
-                actionId: ACTION_1,
-                account: user.address,
-                where: WHERE_1,
-              });
+            it('cannot grant the permission twice', async () => {
+              await expect(
+                authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: getSender() })
+              ).to.be.revertedWith('PERMISSION_ALREADY_GRANTED');
             });
           });
 
@@ -310,36 +278,10 @@ describe('TimelockAuthorizer permissions', () => {
           });
 
           context('when granting the permission for a contract', () => {
-            it('grants the permission to perform the requested action for the requested contract', async () => {
-              await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter });
-
-              expect(await authorizer.canPerform(ACTION_1, user, WHERE_1)).to.be.true;
-              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
-            });
-
-            it('still can perform the requested actions everywhere', async () => {
-              await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter });
-
-              expect(await authorizer.canPerform(ACTION_1, user, EVERYWHERE)).to.be.true;
-              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
-            });
-
-            it('still can perform the requested actions for other contracts', async () => {
-              await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter });
-
-              expect(await authorizer.canPerform(ACTION_1, user, NOT_WHERE)).to.be.true;
-              expect(await authorizer.canPerform(ACTION_1, user, WHERE_2)).to.be.true;
-            });
-
-            it('emits an event', async () => {
-              const receipt = await (
-                await authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter })
-              ).wait();
-              expectEvent.inReceipt(receipt, 'PermissionGranted', {
-                actionId: ACTION_1,
-                account: user.address,
-                where: WHERE_1,
-              });
+            it('cannot grant the permission twice', async () => {
+              await expect(authorizer.grantPermission(ACTION_1, user, WHERE_1, { from: granter })).to.be.revertedWith(
+                'PERMISSION_ALREADY_GRANTED'
+              );
             });
           });
         });


### PR DESCRIPTION
# Description

Grant and revoke can be made globally by passing the EVERYWHERE sentinel value. This is the same as granters and cancelers. However, we were not considering the special case when mixing specific and global permissions. In particular, we shouldn't allow specific granting if the user is already global, and we should disawllow specific revoking for global users.

This PR brings the behavior of grant and revoke in line with that of granters, revokers and cancelers, fixes existing tests, and adds a couple new ones. The test style of grant and revoke is not ideal (and inferior to that of granter/revoker/canceler), but I followed it nonetheless to avoid causing too much disruption.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [x] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

