### PR TITLE
Adjust gauge adder coordinator with current authorizer wrapper compat…

### DIFF
--- a/pkg/governance-scripts/contracts/20230518-gauge-adder-migration-v3-to-v4/GaugeAdderMigrationCoordinator.sol
+++ b/pkg/governance-scripts/contracts/20230518-gauge-adder-migration-v3-to-v4/GaugeAdderMigrationCoordinator.sol
@@ -80,7 +80,7 @@ contract GaugeAdderMigrationCoordinator is BaseCoordinator {
     }
 
     function _afterLastStage() internal virtual override {
-        ICurrentAuthorizer authorizer = ICurrentAuthorizer(address(getAuthorizer()));
+        ICurrentActualAuthorizer authorizer = _getActualAuthorizer();
 
         authorizer.renounceRole(authorizer.DEFAULT_ADMIN_ROLE(), address(this));
     }
@@ -88,7 +88,7 @@ contract GaugeAdderMigrationCoordinator is BaseCoordinator {
     // Internal functions
 
     function _setupNewGaugeAdder() private {
-        ICurrentAuthorizer authorizer = ICurrentAuthorizer(address(getAuthorizer()));
+        ICurrentActualAuthorizer authorizer = _getActualAuthorizer();
 
         {
             bytes32 addTypeRole = IAuthentication(address(newGaugeAdder)).getActionId(
@@ -137,7 +137,7 @@ contract GaugeAdderMigrationCoordinator is BaseCoordinator {
     }
 
     function _deprecateOldGaugeAdder() private {
-        ICurrentAuthorizer authorizer = ICurrentAuthorizer(address(getAuthorizer()));
+        ICurrentActualAuthorizer authorizer = _getActualAuthorizer();
 
         // Revoke the powers to add gauges to the GaugeController from the old GaugeAdder.
         bytes32 addGaugeRole = getAuthorizerAdaptor().getActionId(IGaugeController.add_gauge.selector);
@@ -146,5 +146,9 @@ contract GaugeAdderMigrationCoordinator is BaseCoordinator {
         // `liquidityMiningCommitteeMultisig` retains the permissions to call functions on `oldGaugeAdder`.
         // This is acceptable as any interactions with `oldGaugeAdder` will fail as it can no longer interact
         // with the `GaugeController`.
+    }
+
+    function _getActualAuthorizer() private view returns (ICurrentActualAuthorizer) {
+        return ICurrentAuthorizerWrapper(address(getAuthorizer())).getActualAuthorizer();
     }
 }

--- a/pkg/governance-scripts/contracts/BaseCoordinator.sol
+++ b/pkg/governance-scripts/contracts/BaseCoordinator.sol
@@ -22,10 +22,20 @@ import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/ReentrancyGuard.
 // solhint-disable not-rely-on-time
 
 /**
- * @dev The currently deployed Authorizer has a different interface relative to the Authorizer in the monorepo
- * for granting/revoking roles(referred to as permissions in the new Authorizer) and so we require a one-off interface
+ * @dev The currently deployed authorizer is a thin wrapper that is compatible with the `AuthorizerAdaptorEntrypoint`.
+ * It cannot grant, revoke or renounce roles directly, but it can provide the address of the base authorizer that can
+ * do so.
  */
-interface ICurrentAuthorizer is IAuthorizer {
+interface ICurrentAuthorizerWrapper is IAuthorizer {
+    function getActualAuthorizer() external view returns (ICurrentActualAuthorizer);
+}
+
+/**
+ * @dev The underlying actual authorizer that holds the permissions and can manage them has a different interface
+ * relative to the Authorizer in the monorepo for granting/revoking roles (referred to as permissions in the new
+ * Authorizer) and so we require a one-off interface.
+ */
+interface ICurrentActualAuthorizer is IAuthorizer {
     // solhint-disable-next-line func-name-mixedcase
     function DEFAULT_ADMIN_ROLE() external view returns (bytes32);
 


### PR DESCRIPTION
# Description

The adder coordinator relies in a reference to the actual authorizer to grant / renounce permissions, and it can't get it directly from the vault since it now points to the authorizer wrapper.

This PR fixes it (fork test works with these changes).

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A