### PR TITLE
Make `peekChainedReferenceValue` payable, non-view.

### DIFF
--- a/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/relayer/BaseRelayerLibrary.sol
@@ -89,8 +89,11 @@ contract BaseRelayerLibrary is IBaseRelayerLibrary {
     /**
      * @notice Returns the amount referenced by chained reference `ref`.
      * @dev It does not alter the reference (even if it's marked as temporary).
+     *
+     * This function does not alter the state in any way. It is not marked as view because it has to be `payable`
+     * in order to be used in a batch transaction.
      */
-    function peekChainedReferenceValue(uint256 ref) public view override returns (uint256 value) {
+    function peekChainedReferenceValue(uint256 ref) public payable override returns (uint256 value) {
         (, value) = _peekChainedReferenceValue(ref);
     }
 

--- a/pkg/standalone-utils/contracts/relayer/IBaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/relayer/IBaseRelayerLibrary.sol
@@ -34,7 +34,7 @@ abstract contract IBaseRelayerLibrary is AssetHelpers {
 
     function approveVault(IERC20 token, uint256 amount) public payable virtual;
 
-    function peekChainedReferenceValue(uint256 ref) public view virtual returns (uint256);
+    function peekChainedReferenceValue(uint256 ref) public payable virtual returns (uint256);
 
     function _pullToken(
         address sender,

--- a/pkg/standalone-utils/contracts/test/MockBaseRelayerLibrary.sol
+++ b/pkg/standalone-utils/contracts/test/MockBaseRelayerLibrary.sol
@@ -30,7 +30,7 @@ contract MockBaseRelayerLibrary is BaseRelayerLibrary {
         return _isChainedReference(amount);
     }
 
-    function setChainedReferenceValue(uint256 ref, uint256 value) public {
+    function setChainedReferenceValue(uint256 ref, uint256 value) public payable {
         _setChainedReferenceValue(ref, value);
     }
 

--- a/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
+++ b/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
@@ -144,36 +144,36 @@ describe('BaseRelayerLibrary', function () {
         });
 
         it('peeks uninitialized references as zero', async () => {
-          expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(0);
+          expect(await relayerLibrary.callStatic.peekChainedReferenceValue(reference)).to.be.eq(0);
         });
 
         it('peeks stored references', async () => {
           await relayerLibrary.setChainedReferenceValue(reference, 23);
-          expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(23);
+          expect(await relayerLibrary.callStatic.peekChainedReferenceValue(reference)).to.be.eq(23);
         });
 
         it('peeks overwritten data', async () => {
           await relayerLibrary.setChainedReferenceValue(reference, 42);
           await relayerLibrary.setChainedReferenceValue(reference, 17);
-          expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(17);
+          expect(await relayerLibrary.callStatic.peekChainedReferenceValue(reference)).to.be.eq(17);
         });
 
         it('peeks stored data in independent slots', async () => {
           await relayerLibrary.setChainedReferenceValue(reference, 5);
-          expect(await relayerLibrary.peekChainedReferenceValue(reference.add(1))).to.be.eq(0);
+          expect(await relayerLibrary.callStatic.peekChainedReferenceValue(reference.add(1))).to.be.eq(0);
         });
 
         it('peeks same slot multiple times', async () => {
           await relayerLibrary.setChainedReferenceValue(reference, 19);
-          expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(19);
-          expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(19);
-          expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(19);
+          expect(await relayerLibrary.callStatic.peekChainedReferenceValue(reference)).to.be.eq(19);
+          expect(await relayerLibrary.callStatic.peekChainedReferenceValue(reference)).to.be.eq(19);
+          expect(await relayerLibrary.callStatic.peekChainedReferenceValue(reference)).to.be.eq(19);
         });
 
         it('peeks and reads same slot', async () => {
           await relayerLibrary.setChainedReferenceValue(reference, 31);
 
-          expect(await relayerLibrary.peekChainedReferenceValue(reference)).to.be.eq(31);
+          expect(await relayerLibrary.callStatic.peekChainedReferenceValue(reference)).to.be.eq(31);
           await expectChainedReferenceContents(reference, 31);
         });
       }
@@ -316,6 +316,10 @@ describe('BaseRelayerLibrary', function () {
             });
           });
         });
+
+        it('is payable', async () => {
+          await expect(relayer.connect(signer).multicall([approvalData], { value: fp(1) })).to.not.be.reverted;
+        });
       });
 
       context('when relayer is not authorised by governance', () => {
@@ -335,6 +339,11 @@ describe('BaseRelayerLibrary', function () {
           relayerLibrary.interface.encodeFunctionData('peekChainedReferenceValue', [reference]),
         ]);
         expect(result).to.be.deep.eq(['0x', ethers.utils.hexZeroPad(value.toHexString(), 32)]);
+      });
+
+      it('is payable', async () => {
+        const reference = toChainedReference(174);
+        await expect(relayerLibrary.peekChainedReferenceValue(reference, { value: fp(1) })).to.not.be.reverted;
       });
     });
   });


### PR DESCRIPTION
# Description

`peek` fails to be used inside `multicall` whenever there's a value transfer because view functions are not payable.
This PR fixes it, and adjusts the tests accordingly.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A