### PR TITLE
Relayer: Chain internal balance operations

### DIFF
--- a/pkg/standalone-utils/test/VaultActions.test.ts
+++ b/pkg/standalone-utils/test/VaultActions.test.ts
@@ -1426,8 +1426,8 @@ describe('VaultActions', function () {
           const amountInBPT = fp(1);
 
           // Exit Pool A (DAI, MKR) to internal balance
-          // Pretend MKR is bricked
-          // Trade with Pool B MKR -> SNX (from and to internal balance)
+          // Pretend MKR is bricked (i.e., external transfers fail)
+          // Swap *internally* with Pool B MKR -> SNX
           // Withdraw DAI and SNX back out to wallet
           // So external token balances of DAI/MKR should be unchanged, and SNX should equal token out from swap
           const receipt = await (
@@ -1478,12 +1478,12 @@ describe('VaultActions', function () {
             }
           );
 
+          daiAmountOut = daiTransfer.args.delta;
+
           expectEvent.inIndirectReceipt(receipt, vault.instance.interface, 'InternalBalanceChanged', {
             user: TypesConverter.toAddress(relayer),
             token: tokens.MKR.address,
           });
-
-          daiAmountOut = daiTransfer.args.delta;
 
           const snxTransfer = expectEvent.inIndirectReceipt(
             receipt,
@@ -1494,6 +1494,7 @@ describe('VaultActions', function () {
               token: tokens.SNX.address,
             }
           );
+
           const snxAmountWithdrawn = snxTransfer.args.delta;
 
           const {

--- a/pkg/standalone-utils/test/VaultActions.test.ts
+++ b/pkg/standalone-utils/test/VaultActions.test.ts
@@ -28,6 +28,7 @@ import {
   getJoinExitAmounts,
   approveVaultForRelayer,
   PoolKind,
+  OutputReference,
 } from './VaultActionsRelayer.setup';
 import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
 
@@ -139,13 +140,8 @@ describe('VaultActions', function () {
       sender: Account;
       recipient?: Account;
     }>;
-    outputReferences?: Dictionary<BigNumberish>;
+    outputReferences?: OutputReference[];
   }): string {
-    const outputReferences = Object.entries(params.outputReferences ?? {}).map(([index, key]) => ({
-      index,
-      key,
-    }));
-
     return relayerLibrary.interface.encodeFunctionData('manageUserBalance', [
       params.ops.map((op) => ({
         kind: op.kind,
@@ -155,7 +151,7 @@ describe('VaultActions', function () {
         recipient: op.recipient ?? TypesConverter.toAddress(recipient),
       })),
       0,
-      outputReferences,
+      params.outputReferences ?? [],
     ]);
   }
 
@@ -1284,10 +1280,10 @@ describe('VaultActions', function () {
                   { kind: UserBalanceOpKind.DepositInternal, asset: tokens.DAI.address, amount: amountDAI, sender },
                   { kind: UserBalanceOpKind.DepositInternal, asset: tokens.SNX.address, amount: amountSNX, sender },
                 ],
-                outputReferences: {
-                  0: toChainedReference(0),
-                  1: toChainedReference(1),
-                },
+                outputReferences: [
+                  { index: 0, key: toChainedReference(0) },
+                  { index: 1, key: toChainedReference(1) },
+                ],
               }),
             ])
           ).wait();
@@ -1356,10 +1352,10 @@ describe('VaultActions', function () {
                         recipient: relayer.address,
                       },
                     ],
-                    outputReferences: {
-                      0: toChainedReference(0),
-                      1: toChainedReference(1),
-                    },
+                    outputReferences: [
+                      { index: 0, key: toChainedReference(0) },
+                      { index: 1, key: toChainedReference(1) },
+                    ],
                   }),
                   encodeManageUserBalance({
                     ops: [

--- a/pkg/standalone-utils/test/VaultActionsRelayer.setup.ts
+++ b/pkg/standalone-utils/test/VaultActionsRelayer.setup.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'hardhat';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
-import { Contract } from 'ethers';
+import { BigNumber, Contract } from 'ethers';
 import { MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
@@ -19,6 +19,11 @@ export enum PoolKind {
   COMPOSABLE_STABLE,
   COMPOSABLE_STABLE_V2,
 }
+
+export type OutputReference = {
+  index: number;
+  key: BigNumber;
+};
 
 export async function setupRelayerEnvironment(): Promise<{
   user: SignerWithAddress;


### PR DESCRIPTION
# Description

The Batch Relayer has always supported internal balance operations - but not with chained references. (And, somehow, there were no tests for it at all!)

Extending it to support chaining would allow more efficient operation; e.g., you could deposit a bunch of tokens into internal balance, then do a big batch swap, all in the same transaction.

It also facilitates certain kinds of "rescue" operations. For example, if a given token got "bricked," such that all transfers failed. This would defeat even a Recovery Mode exit (to an external wallet). Now you could exit to internal balance and, e.g., internal transfer to some sort of helper contract empowered to assist in mitigation, or swap into another token that could be withdrawn, etc.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [X] Breaking change <!-- It does change the manageUserBalance interface, adding output references -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

Closes #2351 
