### PR TITLE
Broken documentation links

### DIFF
--- a/pkg/pool-linear/README.md
+++ b/pkg/pool-linear/README.md
@@ -3,11 +3,11 @@
 # Balancer V2 Linear Pools
 
 [![NPM Package](https://img.shields.io/npm/v/@balancer-labs/v2-pool-linear.svg)](https://www.npmjs.org/package/@balancer-labs/v2-pool-linear)
-[![Docs](https://img.shields.io/badge/docs-%F0%9F%93%84-blue)](https://docs.balancer.fi/products/balancer-pools/boosted-pools)
+[![Docs](https://img.shields.io/badge/docs-%F0%9F%93%84-blue)](https://docs.balancer.fi/concepts/pools/boosted.html#boosted-pools)
 
 This package contains the source code of Balancer V2 Linear Pools. These are three-token pools which contain "Main" and "Wrapped" tokens, where the wrapped token is typically yield-bearing: e.g., USDC and aUSDC. The third token is the BPT itself, enabling "joins" and "exits" to be performed as part of a batch swap.
 
-Linear Pools are not designed to be accessed directly by end users. Rather, they are typically components of other pools, mainly as constituents of a `ComposableStablePool`, which enables the ["Boosted Pool"](https://docs.balancer.fi/products/balancer-pools/boosted-pools) behavior.
+Linear Pools are not designed to be accessed directly by end users. Rather, they are typically components of other pools, mainly as constituents of a `ComposableStablePool`, which enables the ["Boosted Pool"](https://docs.balancer.fi/concepts/pools/boosted.html#boosted-pools) behavior.
 
 ## Overview
 

--- a/pkg/pool-utils/README.md
+++ b/pkg/pool-utils/README.md
@@ -3,7 +3,7 @@
 # Balancer V2 Pool Utilities
 
 [![NPM Package](https://img.shields.io/npm/v/@balancer-labs/v2-pool-utils.svg)](https://www.npmjs.org/package/@balancer-labs/v2-pool-utils)
-[![Docs](https://img.shields.io/badge/docs-%F0%9F%93%84-blue)](https://docs.balancer.fi/products/balancer-pools)
+[![Docs](https://img.shields.io/badge/docs-%F0%9F%93%84-blue)](https://docs.balancer.fi/concepts/pools/#pools)
 
 This package contains Solidity utilities for developing Balancer V2 Pools, implementing common patterns such as token decimal scaling, caller checks on hooks, etc.
 

--- a/pkg/vault/README.md
+++ b/pkg/vault/README.md
@@ -3,7 +3,7 @@
 # Balancer V2 Vault
 
 [![NPM Package](https://img.shields.io/npm/v/@balancer-labs/v2-vault.svg)](https://www.npmjs.org/package/@balancer-labs/v2-vault)
-[![Docs](https://img.shields.io/badge/docs-%F0%9F%93%84-blue)](https://docs.balancer.fi/products/the-vault)
+[![Docs](https://img.shields.io/badge/docs-%F0%9F%93%84-blue)](https://docs.balancer.fi/concepts/vault#vault)
 
 This package contains the source code of Balancer V2's main contract, the [`Vault`](./contracts/Vault.sol).
 


### PR DESCRIPTION
# Description

The docs have changed, breaking a few links and causing the markdown link checks to fail (legitimately this time).

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [X] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

