### PR TITLE
Improve expect event

### DIFF
--- a/pkg/standalone-utils/test/VaultActions.test.ts
+++ b/pkg/standalone-utils/test/VaultActions.test.ts
@@ -549,6 +549,11 @@ describe('VaultActions', function () {
           });
 
           expect(amountOutBAT).to.equal(amountInBAT);
+          const events = expectEvent.inIndirectReceipt(receipt, vault.instance.interface, 'Swap', {}, vault.address, 4);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          expect(events.map((e: any) => e.signature)).to.deep.equal(
+            Array(4).fill('Swap(bytes32,address,address,uint256,uint256)')
+          );
         });
       }
     });

--- a/pvt/helpers/src/test/expectEvent.ts
+++ b/pvt/helpers/src/test/expectEvent.ts
@@ -61,7 +61,7 @@ export function inIndirectReceipt(
   }
 
   const exceptions: Array<string> = [];
-  const event = expectedEvents.find(function (e) {
+  const events = expectedEvents.filter(function (e) {
     for (const [k, v] of Object.entries(eventArgs)) {
       try {
         if (e.args == undefined) {
@@ -77,13 +77,33 @@ export function inIndirectReceipt(
     return true;
   });
 
-  if (event === undefined) {
-    // Each event entry may have failed to match for different reasons,
-    // throw the first one
-    throw exceptions[0];
+  if (amount !== undefined) {
+    if (events.length !== expectedEvents.length) {
+      if (exceptions.length > 0) {
+        // Each event entry may have failed to match for different reasons,
+        // throw the first one
+        throw exceptions[0];
+      } else {
+        throw Error(
+          `${expectedEvents.length} '${eventName}' events found, but only ${events.length} match the given arguments`
+        );
+      }
+    }
+    return events;
+  } else {
+    if (events.length === 0) {
+      if (exceptions.length > 0) {
+        // Each event entry may have failed to match for different reasons,
+        // throw the first one
+        throw exceptions[0];
+      } else {
+        throw Error(`No events match the given arguments`);
+      }
+    }
+    return events[0];
   }
 
-  return event;
+  return events.length == 1 ? events[1] : events;
 }
 
 export function notEmitted(receipt: ContractReceipt, eventName: string): void {

--- a/pvt/helpers/src/test/expectEvent.ts
+++ b/pvt/helpers/src/test/expectEvent.ts
@@ -51,9 +51,9 @@ export function inReceipt(receipt: ContractReceipt, eventName: string, eventArgs
  * @param eventArgs Arguments of the event(s). This does not need to be a complete list; as long as the event contains
  *  the specified ones, the function will not throw.
  * @param address Contract address that emits the event(s). If undefined, the logs will not be filtered by address.
- * @param amount Amount of expected events that match all the specified conditions. If not specified, at least one is
+ * @param amount Number of expected events that match all the specified conditions. If not specified, at least one is
  *  expected.
- * @returns First matching event if the amount is not specified, all matching events otherwise.
+ * @returns First matching event if the amount is not specified; all matching events otherwise.
  */
 export function inIndirectReceipt(
   receipt: ContractReceipt,
@@ -92,7 +92,7 @@ export function inIndirectReceipt(
 
   // Each event entry may have failed to match for different reasons; in case of failure we throw the first one.
   if (amount === undefined) {
-    // If amount is undefined, we don't care about the amount of events. If no events were found, we throw.
+    // If amount is undefined, we don't care about the number of events. If no events were found, we throw.
     if (filteredEvents.length === 0) {
       throw exceptions[0];
     }

--- a/pvt/helpers/src/test/expectEvent.ts
+++ b/pvt/helpers/src/test/expectEvent.ts
@@ -42,6 +42,19 @@ export function inReceipt(receipt: ContractReceipt, eventName: string, eventArgs
   return event;
 }
 
+/**
+ * Throws error if the given receipt does not contain a set of events with specific arguments.
+ * Expecting a specific amount of events from a particular address is optional.
+ * @param receipt Receipt to analyze.
+ * @param emitter Interface of the contract emitting the event(s).
+ * @param eventName Name of the event(s).
+ * @param eventArgs Arguments of the event(s). This does not need to be a complete list; as long as the event contains
+ *  the specified ones, the function will not throw.
+ * @param address Contract address that emits the event(s). If undefined, the logs will not be filtered by address.
+ * @param amount Amount of expected events that match all the specified conditions. If not specified, at least one is
+ *  expected.
+ * @returns First matching event if the amount is not specified, all matching events otherwise.
+ */
 export function inIndirectReceipt(
   receipt: ContractReceipt,
   emitter: Interface,


### PR DESCRIPTION
# Description

Improve `expectEvent.inIndirectReceipt` when the amount of events are specified.

Without this change, as long as one event matched the given arguments it would pass, even if the expected amount was larger than one. With this change, if the amount is specified we expect all the matches to contain the given arguments.

The return type also changes: it returns a single event for the regular use-case (i.e. when no amount is specified), but returns all of the matches when the amount is specified.

This should be backwards compatible, equally intuitive to use in general when (at least) one event is expected, but more flexible and powerful when analyzing multiple logs in a single receipt.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A