### PR TITLE
Fix `BalancerErrors` compiler range

### DIFF
--- a/pkg/interfaces/CHANGELOG.md
+++ b/pkg/interfaces/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Moved `GaugeType` from `IGaugeAdder` to `IL2GaugeCheckpointer`, and adjusted types to accept new networks.
 - Refactored `IL2GaugeCheckpointer`.
   - Removed `isSupportedGaugeType` from interface.
+- Bumped minimum compiler version from `0.7.0` to `0.7.1` in `BalancerErrors`.
 
 ## 0.4.0 (2023-03-15)
 

--- a/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
+++ b/pkg/interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity >=0.7.1 <0.9.0;
 
 // solhint-disable
 


### PR DESCRIPTION
# Description

`BalancerErrors` doesn't actually compile with 0.7.0.
We need the first feature listed in the [release notes for 0.7.1](https://blog.soliditylang.org/2020/09/02/solidity-0.7.1-release-announcement/).

Another option would be not using "free functions", but at this point I think it's just not worth it.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A - Complex code has been commented, including external interfaces
- N/A - Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A