### PR TITLE
Relayer: support recovery mode exit

### DIFF
--- a/pkg/standalone-utils/contracts/relayer/VaultActions.sol
+++ b/pkg/standalone-utils/contracts/relayer/VaultActions.sol
@@ -319,7 +319,7 @@ abstract contract VaultActions is IBaseRelayerLibrary {
         returns (bytes memory)
     {
         // Must check for the recovery mode ExitKind first, which is common to all pool types.
-        // If it is just a regular exit, pass it to the appropriate PoolKind handler for interpretation.  
+        // If it is just a regular exit, pass it to the appropriate PoolKind handler for interpretation.
         if (BasePoolUserData.isRecoveryModeExitKind(userData)) {
             return _doRecoveryExitReplacements(userData);
         } else if (kind == PoolKind.WEIGHTED) {

--- a/pkg/standalone-utils/contracts/relayer/VaultActions.sol
+++ b/pkg/standalone-utils/contracts/relayer/VaultActions.sol
@@ -18,6 +18,7 @@ pragma experimental ABIEncoderV2;
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-weighted/WeightedPoolUserData.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-stable/StablePoolUserData.sol";
+import "@balancer-labs/v2-interfaces/contracts/pool-utils/BasePoolUserData.sol";
 
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/InputHelpers.sol";
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/VaultHelpers.sol";
@@ -317,7 +318,9 @@ abstract contract VaultActions is IBaseRelayerLibrary {
         private
         returns (bytes memory)
     {
-        if (kind == PoolKind.WEIGHTED) {
+        if (BasePoolUserData.isRecoveryModeExitKind(userData)) {
+            return _doRecoveryExitReplacements(userData);
+        } else if (kind == PoolKind.WEIGHTED) {
             return _doWeightedExitChainedReferenceReplacements(userData);
         } else {
             if (kind == PoolKind.LEGACY_STABLE) {
@@ -364,6 +367,18 @@ abstract contract VaultActions is IBaseRelayerLibrary {
         if (_isChainedReference(bptAmountIn)) {
             bptAmountIn = _getChainedReferenceValue(bptAmountIn);
             return abi.encode(WeightedPoolUserData.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT, bptAmountIn);
+        } else {
+            // Save gas by only re-encoding the data if we actually performed a replacement
+            return userData;
+        }
+    }
+
+    function _doRecoveryExitReplacements(bytes memory userData) private returns (bytes memory) {
+        uint256 bptAmountIn = BasePoolUserData.recoveryModeExit(userData);
+
+        if (_isChainedReference(bptAmountIn)) {
+            bptAmountIn = _getChainedReferenceValue(bptAmountIn);
+            return abi.encode(BasePoolUserData.RECOVERY_MODE_EXIT_KIND, bptAmountIn);
         } else {
             // Save gas by only re-encoding the data if we actually performed a replacement
             return userData;

--- a/pkg/standalone-utils/contracts/relayer/VaultActions.sol
+++ b/pkg/standalone-utils/contracts/relayer/VaultActions.sol
@@ -318,6 +318,8 @@ abstract contract VaultActions is IBaseRelayerLibrary {
         private
         returns (bytes memory)
     {
+        // Must check for the recovery mode ExitKind first, which is common to all pool types.
+        // If it is just a regular exit, pass it to the appropriate PoolKind handler for interpretation.  
         if (BasePoolUserData.isRecoveryModeExitKind(userData)) {
             return _doRecoveryExitReplacements(userData);
         } else if (kind == PoolKind.WEIGHTED) {

--- a/pkg/standalone-utils/test/VaultActions.test.ts
+++ b/pkg/standalone-utils/test/VaultActions.test.ts
@@ -1212,7 +1212,9 @@ describe('VaultActions', function () {
         await expect(
           relayer.connect(other).multicall([
             await encodeExitPool(vault, relayerLibrary, tokens, {
-              poolKind: PoolKind.WEIGHTED,
+              // We need to give it a pool kind, but it doesn't matter which one. The logic checks for the special
+              // exit kind first, and only checks the pool kind when it is NOT a recovery exit.
+              poolKind: PoolKind.LEGACY_STABLE,
               poolId: poolIdA,
               userData: BasePoolEncoder.recoveryModeExit(amountInBPT),
               toInternalBalance: true,

--- a/pkg/standalone-utils/test/VaultActionsRelayer.setup.ts
+++ b/pkg/standalone-utils/test/VaultActionsRelayer.setup.ts
@@ -27,6 +27,7 @@ export type OutputReference = {
 
 export async function setupRelayerEnvironment(): Promise<{
   user: SignerWithAddress;
+  admin: SignerWithAddress;
   other: SignerWithAddress;
   vault: Vault;
   relayer: Contract;
@@ -55,7 +56,7 @@ export async function setupRelayerEnvironment(): Promise<{
   // Approve relayer by sender
   await vault.setRelayerApproval(user, relayer, true);
 
-  return { user, other, vault, relayer, relayerLibrary };
+  return { user, admin, other, vault, relayer, relayerLibrary };
 }
 
 export async function encodeJoinPool(


### PR DESCRIPTION
# Description

Recovery mode exits currently revert on both Weighted and Stable pools. This adds support for them.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

Closes #2458 
