### PR TITLE
Stakeless gauge checkpointer: multi gauge checkpoint

### DIFF
--- a/pkg/interfaces/contracts/liquidity-mining/IStakelessGaugeCheckpointer.sol
+++ b/pkg/interfaces/contracts/liquidity-mining/IStakelessGaugeCheckpointer.sol
@@ -132,6 +132,16 @@ interface IStakelessGaugeCheckpointer {
     function checkpointSingleGauge(string memory gaugeType, address gauge) external payable;
 
     /**
+     * @notice Performs a checkpoint for a multiple added gauges of the given types.
+     * Reverts if the ETH sent in the call is not enough to cover bridge costs.
+     * Reverts if the gauges were not added to the checkpointer beforehand.
+     * @param gaugeTypes Types of the gauges to be checkpointed. If a single type is provided, it is applied to all of
+     * the gauges, otherwise the gauge types array should be equal in length to the gauges.
+     * @param gauges Addresses of the gauges to checkpoint.
+     */
+    function checkpointMultipleGauges(string[] memory gaugeTypes, address[] memory gauges) external payable;
+
+    /**
      * @notice Returns the ETH cost to checkpoint a single given gauge.
      * @dev Reverts if the gauge was not added to the checkpointer beforehand.
      * @param gaugeType Type of the gauge.

--- a/pkg/liquidity-mining/contracts/test/MockStakelessGauge.sol
+++ b/pkg/liquidity-mining/contracts/test/MockStakelessGauge.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+/**
+ * @dev Simple mock for stakeless gauges, to verify single and multi checkpoint functionality.
+ * This shouldn't be used to test gauge checkpoints by type, since the mock has no connection with the gauge controller
+ * and hence the concept of gauge weights is not considered.
+ */
+contract MockStakelessGauge {
+    event Checkpoint();
+
+    address private immutable _authorizerAdaptor;
+
+    uint256 private _totalBridgeCost;
+    bool private _isKilled;
+
+    constructor(address authorizerAdaptor) {
+        _authorizerAdaptor = authorizerAdaptor;
+    }
+
+    function initialize(address, uint256) external {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    function checkpoint() external payable returns (bool) {
+        require(msg.sender == address(_authorizerAdaptor), "SENDER_NOT_ALLOWED");
+        require(msg.value >= _totalBridgeCost, "Insufficient ETH to checkpoint");
+        emit Checkpoint();
+    }
+
+    function setTotalBridgeCost(uint256 totalBridgeCost) external {
+        _totalBridgeCost = totalBridgeCost;
+    }
+
+    function getTotalBridgeCost() external view returns (uint256) {
+        return _totalBridgeCost;
+    }
+
+    // solhint-disable-next-line func-name-mixedcase
+    function is_killed() external view returns (bool) {
+        return _isKilled;
+    }
+
+    // These functions are permissioned in an actual gauge, but this mock should not be used to test that.
+    function killGauge() external {
+        _isKilled = true;
+    }
+
+    function unkillGauge() external {
+        _isKilled = false;
+    }
+}

--- a/pkg/liquidity-mining/test/StakelessGaugeCheckpointer.test.ts
+++ b/pkg/liquidity-mining/test/StakelessGaugeCheckpointer.test.ts
@@ -404,6 +404,23 @@ describe('StakelessGaugeCheckpointer', () => {
         });
       });
 
+      context('invalid inputs', () => {
+        it('reverts with no gauges to checkpoint', async () => {
+          await expect(stakelessGaugeCheckpointer.checkpointMultipleGauges([testGaugeType], [])).to.be.revertedWith(
+            'No gauges to checkpoint'
+          );
+        });
+
+        it('reverts with mismatching input lengths', async () => {
+          await expect(
+            stakelessGaugeCheckpointer.checkpointMultipleGauges(
+              Array(testGauges.length + 1).fill(testGaugeType),
+              testGauges
+            )
+          ).to.be.revertedWith('Mismatch between gauge types and addresses');
+        });
+      });
+
       function itCheckpointsGauges() {
         it('checkpoints single gauges one by one', async () => {
           for (const gauge of testGauges) {


### PR DESCRIPTION
# Description

This PR adds the capability to checkpoint multiple specific gauges in the same call.
The effect would be the same as calling `checkpointSingleGauge` multiple times, but it should be much cheaper to do so in one call because the storage reads are cheaper after the first time they are performed in the same tx.

Built on top of #2533; merge that one first.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A