### PR TITLE
Restore Root Gauge Mocks

### DIFF
--- a/pkg/liquidity-mining/contracts/test/MockAvalancheRootGauge.sol
+++ b/pkg/liquidity-mining/contracts/test/MockAvalancheRootGauge.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "../gauges/avalanche/AvalancheRootGauge.sol";
+
+/**
+ * @dev This is used by the Avalanche Root Gauge deployment task in the deployments-repo, and is referenced there.
+ * Do not delete.
+ */
+contract MockAvalancheRootGauge is AvalancheRootGauge {
+    constructor(IMainnetBalancerMinter minter, ILayerZeroBALProxy lzBALProxy) AvalancheRootGauge(minter, lzBALProxy) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    /**
+     * @dev It would be very difficult to contrive a fork test that set the mintAmount to a precise value,
+     * so the bridge limits are best tested with a mock and unit tests.
+     * It must be payable to send ETH to pay for gas in the child chain.
+     * @param mintAmount Amount to be bridged
+     */
+    function bridge(uint256 mintAmount) external payable {
+        _postMintAction(mintAmount);
+    }
+}

--- a/pkg/liquidity-mining/contracts/test/MockAvalancheRootGauge.sol
+++ b/pkg/liquidity-mining/contracts/test/MockAvalancheRootGauge.sol
@@ -18,7 +18,7 @@ pragma experimental ABIEncoderV2;
 import "../gauges/avalanche/AvalancheRootGauge.sol";
 
 /**
- * @dev This is used by the Avalanche Root Gauge deployment task in the deployments-repo, and is referenced there.
+ * @dev This is used by the Avalanche Root Gauge deployment task in the deployments repo, and is referenced there.
  * Do not delete.
  */
 contract MockAvalancheRootGauge is AvalancheRootGauge {

--- a/pkg/liquidity-mining/contracts/test/MockBaseRootGauge.sol
+++ b/pkg/liquidity-mining/contracts/test/MockBaseRootGauge.sol
@@ -18,7 +18,7 @@ pragma experimental ABIEncoderV2;
 import "../gauges/base/BaseRootGauge.sol";
 
 /**
- * @dev This is used by the Base Root Gauge deployment task in the deployments-repo, and is referenced there.
+ * @dev This is used by the Base Root Gauge deployment task in the deployments repo, and is referenced there.
  * Do not delete.
  */
 contract MockBaseRootGauge is BaseRootGauge {

--- a/pkg/liquidity-mining/contracts/test/MockBaseRootGauge.sol
+++ b/pkg/liquidity-mining/contracts/test/MockBaseRootGauge.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "../gauges/base/BaseRootGauge.sol";
+
+/**
+ * @dev This is used by the Base Root Gauge deployment task in the deployments-repo, and is referenced there.
+ * Do not delete.
+ */
+contract MockBaseRootGauge is BaseRootGauge {
+    constructor(
+        IMainnetBalancerMinter minter,
+        IL1StandardBridge baseBridge,
+        address baseBAL
+    ) BaseRootGauge(minter, baseBridge, baseBAL) {
+        // solhint-disable-previous-line no-empty-blocks
+    }
+
+    /**
+     * @dev It would be very difficult to contrive a fork test that set the mintAmount to a precise value,
+     * so the bridge limits are best tested with a mock and unit tests.
+     * It must be payable to send ETH to pay for gas in the child chain.
+     * @param mintAmount Amount to be bridged
+     */
+    function bridge(uint256 mintAmount) external payable {
+        _postMintAction(mintAmount);
+    }
+}


### PR DESCRIPTION
# Description

Root Gauge Mocks are required for the fork tests of *some* root gauges (e.g., Avalanche). They are not used in the monorepo, but need to be in the build-info for the deployment fork tests to work.

There is a way to import them into the deployments repo (e.g., src/contracts/helpers), but this is undesirable, as the mock contracts are directly dependent on the root gauges themselves, and we do not want to introduce a dependency on liquidity-mining in the deployments repo.

So, the compromise is to leave them in the monorepo, and document in both places where the files are coming from.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

