### PR TITLE
Stakeless gauge checkpointer: generic cost gauges

### DIFF
--- a/pkg/interfaces/contracts/liquidity-mining/IStakelessGaugeCheckpointer.sol
+++ b/pkg/interfaces/contracts/liquidity-mining/IStakelessGaugeCheckpointer.sol
@@ -162,7 +162,7 @@ interface IStakelessGaugeCheckpointer {
      * @notice Returns the ETH cost to checkpoint all gauges from the given types.
      * @dev A lower minimum relative weight might return higher costs, since more gauges could potentially be included
      * in the checkpoint. Reverts for invalid gauge types.
-     * @param gaugeTypes Type of the gauges.
+     * @param gaugeTypes Types of the gauges.
      * @param minRelativeWeight Minimum relative weight filter: gauges below this value do not add to the bridge cost.
      */
     function getGaugeTypesBridgeCost(string[] memory gaugeTypes, uint256 minRelativeWeight)

--- a/pkg/interfaces/contracts/liquidity-mining/IStakelessGaugeCheckpointer.sol
+++ b/pkg/interfaces/contracts/liquidity-mining/IStakelessGaugeCheckpointer.sol
@@ -112,54 +112,71 @@ interface IStakelessGaugeCheckpointer {
 
     /**
      * @notice Performs a checkpoint for all added gauges above the given relative weight threshold.
-     * @dev Reverts if the ETH sent in the call is not enough to cover bridge costs.
+     * @dev Reverts if the ETH sent in the call is not enough to cover bridge costs. Use `getTotalBridgeCost` to
+     * determine the required amount of ETH for the execution to succeed.
      * @param minRelativeWeight Threshold to filter out gauges below it.
      */
-    function checkpointGaugesAboveRelativeWeight(uint256 minRelativeWeight) external payable;
+    function checkpointAllGaugesAboveRelativeWeight(uint256 minRelativeWeight) external payable;
 
     /**
-     * @notice Performs a checkpoint for all added gauges of a given type above the given relative weight threshold.
-     * @dev Reverts if the ETH sent in the call is not enough to cover bridge costs.
-     * @param gaugeType Type of the gauge.
+     * @notice Performs a checkpoint for all added gauges above the given relative weight threshold for the given types.
+     * @dev Reverts if the ETH sent in the call is not enough to cover bridge costs. Use `getGaugeTypesBridgeCost` to
+     * determine the required amount of ETH for the execution to succeed.
+     * Reverts if invalid gauge types are given.
+     * @param gaugeTypes Types of the gauges to checkpoint.
      * @param minRelativeWeight Threshold to filter out gauges below it.
      */
-    function checkpointGaugesOfTypeAboveRelativeWeight(string memory gaugeType, uint256 minRelativeWeight)
+    function checkpointGaugesOfTypesAboveRelativeWeight(string[] memory gaugeTypes, uint256 minRelativeWeight)
         external
         payable;
 
     /**
      * @notice Performs a checkpoint for a single added gauge of a given type.
-     * Reverts if the ETH sent in the call is not enough to cover bridge costs.
+     * @dev Reverts if the ETH sent in the call is not enough to cover bridge costs. Use `getSingleBridgeCost` to
+     * determine the required amount of ETH for the execution to succeed.
      * Reverts if the gauge was not added to the checkpointer beforehand.
      * @param gaugeType Type of the gauge.
      * @param gauge Address of the gauge to checkpoint.
      */
-    function checkpointSingleGauge(string memory gaugeType, address gauge) external payable;
+    function checkpointSingleGauge(string memory gaugeType, IStakelessGauge gauge) external payable;
 
     /**
      * @notice Performs a checkpoint for a multiple added gauges of the given types.
      * Reverts if the ETH sent in the call is not enough to cover bridge costs.
-     * Reverts if the gauges were not added to the checkpointer beforehand.
+     * Reverts if the gauges were not added to the checkpointer beforehand, or if invalid gauge types are given.
      * @param gaugeTypes Types of the gauges to be checkpointed. If a single type is provided, it is applied to all of
      * the gauges, otherwise the gauge types array should be equal in length to the gauges.
      * @param gauges Addresses of the gauges to checkpoint.
      */
-    function checkpointMultipleGauges(string[] memory gaugeTypes, address[] memory gauges) external payable;
-
-    /**
-     * @notice Returns the ETH cost to checkpoint a single given gauge.
-     * @dev Reverts if the gauge was not added to the checkpointer beforehand.
-     * @param gaugeType Type of the gauge.
-     * @param gauge Address of the gauge to check the bridge costs.
-     */
-    function getSingleBridgeCost(string memory gaugeType, address gauge) external view returns (uint256);
+    function checkpointMultipleGauges(string[] memory gaugeTypes, IStakelessGauge[] memory gauges) external payable;
 
     /**
      * @notice Returns the ETH cost to checkpoint all gauges for a given minimum relative weight.
      * @dev A lower minimum relative weight might return higher costs, since more gauges could potentially be included
      * in the checkpoint.
+     * @param minRelativeWeight Minimum relative weight filter: gauges below this value do not add to the bridge cost.
      */
     function getTotalBridgeCost(uint256 minRelativeWeight) external view returns (uint256);
+
+    /**
+     * @notice Returns the ETH cost to checkpoint all gauges from the given types.
+     * @dev A lower minimum relative weight might return higher costs, since more gauges could potentially be included
+     * in the checkpoint. Reverts for invalid gauge types.
+     * @param gaugeTypes Type of the gauges.
+     * @param minRelativeWeight Minimum relative weight filter: gauges below this value do not add to the bridge cost.
+     */
+    function getGaugeTypesBridgeCost(string[] memory gaugeTypes, uint256 minRelativeWeight)
+        external
+        view
+        returns (uint256 totalCost);
+
+    /**
+     * @notice Returns the ETH cost to checkpoint a single given gauge.
+     * @dev Reverts if the gauge was not added to the checkpointer beforehand, or if the gauge type is invalid.
+     * @param gaugeType Type of the gauge.
+     * @param gauge Address of the gauge to check the bridge costs.
+     */
+    function getSingleBridgeCost(string memory gaugeType, IStakelessGauge gauge) external view returns (uint256);
 
     /**
      * @notice Returns true if gauge type is valid; false otherwise.

--- a/pkg/interfaces/contracts/liquidity-mining/IStakelessGaugeCheckpointer.sol
+++ b/pkg/interfaces/contracts/liquidity-mining/IStakelessGaugeCheckpointer.sol
@@ -142,10 +142,21 @@ interface IStakelessGaugeCheckpointer {
 
     /**
      * @notice Performs a checkpoint for a multiple added gauges of the given types.
-     * Reverts if the ETH sent in the call is not enough to cover bridge costs.
+     * @dev Reverts if the ETH sent in the call is not enough to cover bridge costs.
+     * Reverts if the gauges were not added to the checkpointer beforehand, or if an invalid gauge type is given.
+     * @param gaugeType Type of the gauges to be checkpointed.
+     * @param gauges Addresses of the gauges to checkpoint.
+     */
+    function checkpointMultipleGaugesOfMatchingType(string memory gaugeType, IStakelessGauge[] memory gauges)
+        external
+        payable;
+
+    /**
+     * @notice Performs a checkpoint for a multiple added gauges of the given types.
+     * @dev Reverts if the ETH sent in the call is not enough to cover bridge costs.
      * Reverts if the gauges were not added to the checkpointer beforehand, or if invalid gauge types are given.
-     * @param gaugeTypes Types of the gauges to be checkpointed. If a single type is provided, it is applied to all of
-     * the gauges, otherwise the gauge types array should be equal in length to the gauges.
+     * Reverts if the types array does not have the same length as the gauges array.
+     * @param gaugeTypes Types of the gauges to be checkpointed, in the same order as the gauges to be checkpointed.
      * @param gauges Addresses of the gauges to checkpoint.
      */
     function checkpointMultipleGauges(string[] memory gaugeTypes, IStakelessGauge[] memory gauges) external payable;

--- a/pkg/liquidity-mining/contracts/gauges/StakelessGaugeCheckpointer.sol
+++ b/pkg/liquidity-mining/contracts/gauges/StakelessGaugeCheckpointer.sol
@@ -323,7 +323,7 @@ contract StakelessGaugeCheckpointer is IStakelessGaugeCheckpointer, ReentrancyGu
             // It might be the case that after the checkpoint the gauge is below the weight threshold, but given
             // that we cannot perform the checkpoint in this view function we consider it within the threshold in that
             // case. It is better to overestimate the gas required for the call given that it is returned at the end
-            // anyways.
+            // anyway.
             bool isGaugeUpdated = _gaugeController.time_weight(gauge) >= currentPeriod;
             if (isGaugeUpdated && _gaugeController.gauge_relative_weight(gauge, currentPeriod) < minRelativeWeight) {
                 continue;

--- a/pkg/liquidity-mining/contracts/gauges/StakelessGaugeCheckpointer.sol
+++ b/pkg/liquidity-mining/contracts/gauges/StakelessGaugeCheckpointer.sol
@@ -352,7 +352,7 @@ contract StakelessGaugeCheckpointer is IStakelessGaugeCheckpointer, ReentrancyGu
             return;
         }
 
-        // Most bridges are costless, and we can know about it by querying the cost of a single gauge.
+        // Most bridges are costless, and we can determine this by querying the cost of a single gauge.
         // If the cost of the first gauge in the list is 0, then it's 0 for the rest of them.
         // In that case, there's no need to query the bridge cost for every other gauge.
         // At this point we know there is at least one gauge in the set.
@@ -383,7 +383,7 @@ contract StakelessGaugeCheckpointer is IStakelessGaugeCheckpointer, ReentrancyGu
     }
 
     /**
-     * @dev Performs checkpoint for paid gauge, forwarding ETH to cover bridge costs.
+     * @dev Calls `checkpoint` on a paid gauge, forwarding ETH to cover bridge costs.
      */
     function _checkpointPaidBridgeGauge(IStakelessGauge gauge) private {
         uint256 checkpointCost = gauge.getTotalBridgeCost();
@@ -395,7 +395,7 @@ contract StakelessGaugeCheckpointer is IStakelessGaugeCheckpointer, ReentrancyGu
     }
 
     /**
-     * @dev Performs checkpoint for costless gauge; does not forward any ETH.
+     * @dev Calls `checkpoint` on a costless gauge; does not forward any ETH.
      */
     function _checkpointCostlessBridgeGauge(IStakelessGauge gauge) private {
         _authorizerAdaptorEntrypoint.performAction(

--- a/pkg/liquidity-mining/contracts/gauges/StakelessGaugeCheckpointer.sol
+++ b/pkg/liquidity-mining/contracts/gauges/StakelessGaugeCheckpointer.sol
@@ -218,7 +218,7 @@ contract StakelessGaugeCheckpointer is IStakelessGaugeCheckpointer, ReentrancyGu
         withValidGauge(gaugeType, gauge)
         returns (uint256)
     {
-        _getSingleBridgeCost(gauge);
+        return _getSingleBridgeCost(gauge);
     }
 
     /// @inheritdoc IStakelessGaugeCheckpointer
@@ -229,13 +229,13 @@ contract StakelessGaugeCheckpointer is IStakelessGaugeCheckpointer, ReentrancyGu
         withValidGaugeTypes(gaugeTypes)
         returns (uint256)
     {
-        _getGaugeTypesTotalBridgeCost(gaugeTypes, minRelativeWeight);
+        return _getGaugeTypesTotalBridgeCost(gaugeTypes, minRelativeWeight);
     }
 
     /// @inheritdoc IStakelessGaugeCheckpointer
     function getTotalBridgeCost(uint256 minRelativeWeight) external view override returns (uint256) {
         string[] memory gaugeTypes = getGaugeTypes();
-        _getGaugeTypesTotalBridgeCost(gaugeTypes, minRelativeWeight);
+        return _getGaugeTypesTotalBridgeCost(gaugeTypes, minRelativeWeight);
     }
 
     /// @inheritdoc IStakelessGaugeCheckpointer
@@ -320,8 +320,6 @@ contract StakelessGaugeCheckpointer is IStakelessGaugeCheckpointer, ReentrancyGu
             string memory gaugeType = gaugeTypes[i];
             totalCost += _getGaugeTypeTotalBridgeCost(gaugeType, minRelativeWeight);
         }
-
-        return totalCost;
     }
 
     function _checkpointGaugesAboveRelativeWeight(string[] memory gaugeTypes, uint256 minRelativeWeight) internal {

--- a/pkg/liquidity-mining/contracts/gauges/StakelessGaugeCheckpointer.sol
+++ b/pkg/liquidity-mining/contracts/gauges/StakelessGaugeCheckpointer.sol
@@ -55,13 +55,25 @@ contract StakelessGaugeCheckpointer is IStakelessGaugeCheckpointer, ReentrancyGu
         _;
     }
 
+    modifier withValidGaugeTypes(string[] memory gaugeTypes) {
+        for (uint256 i = 0; i < gaugeTypes.length; ++i) {
+            require(_gaugeAdder.isValidGaugeType(gaugeTypes[i]), "Invalid gauge type");
+        }
+        _;
+    }
+
+    modifier withValidGauge(string memory gaugeType, IStakelessGauge gauge) {
+        require(hasGauge(gaugeType, gauge), "Gauge not added");
+        _;
+    }
+
     /// @inheritdoc IStakelessGaugeCheckpointer
     function getGaugeAdder() external view override returns (IGaugeAdder) {
         return _gaugeAdder;
     }
 
     /// @inheritdoc IStakelessGaugeCheckpointer
-    function getGaugeTypes() external view override returns (string[] memory) {
+    function getGaugeTypes() public view override returns (string[] memory) {
         return _gaugeAdder.getGaugeTypes();
     }
 
@@ -108,7 +120,7 @@ contract StakelessGaugeCheckpointer is IStakelessGaugeCheckpointer, ReentrancyGu
 
     /// @inheritdoc IStakelessGaugeCheckpointer
     function hasGauge(string memory gaugeType, IStakelessGauge gauge)
-        external
+        public
         view
         override
         withValidGaugeType(gaugeType)
@@ -145,42 +157,37 @@ contract StakelessGaugeCheckpointer is IStakelessGaugeCheckpointer, ReentrancyGu
     }
 
     /// @inheritdoc IStakelessGaugeCheckpointer
-    function checkpointGaugesAboveRelativeWeight(uint256 minRelativeWeight) external payable override nonReentrant {
-        uint256 currentPeriod = _roundDownBlockTimestamp();
-
+    function checkpointAllGaugesAboveRelativeWeight(uint256 minRelativeWeight) external payable override nonReentrant {
         string[] memory gaugeTypes = _gaugeAdder.getGaugeTypes();
-        for (uint256 i = 0; i < gaugeTypes.length; ++i) {
-            _checkpointGauges(gaugeTypes[i], minRelativeWeight, currentPeriod);
-        }
-
-        // Send back any leftover ETH to the caller.
-        Address.sendValue(msg.sender, address(this).balance);
+        _checkpointGaugesAboveRelativeWeight(gaugeTypes, minRelativeWeight);
     }
 
     /// @inheritdoc IStakelessGaugeCheckpointer
-    function checkpointGaugesOfTypeAboveRelativeWeight(string memory gaugeType, uint256 minRelativeWeight)
+    function checkpointGaugesOfTypesAboveRelativeWeight(string[] memory gaugeTypes, uint256 minRelativeWeight)
         external
         payable
         override
         nonReentrant
-        withValidGaugeType(gaugeType)
+        withValidGaugeTypes(gaugeTypes)
     {
-        uint256 currentPeriod = _roundDownBlockTimestamp();
+        _checkpointGaugesAboveRelativeWeight(gaugeTypes, minRelativeWeight);
+    }
 
-        _checkpointGauges(gaugeType, minRelativeWeight, currentPeriod);
+    /// @inheritdoc IStakelessGaugeCheckpointer
+    function checkpointSingleGauge(string memory gaugeType, IStakelessGauge gauge)
+        external
+        payable
+        override
+        nonReentrant
+        withValidGauge(gaugeType, gauge)
+    {
+        _checkpointSingleGauge(gauge);
 
         _returnLeftoverEthIfAny();
     }
 
     /// @inheritdoc IStakelessGaugeCheckpointer
-    function checkpointSingleGauge(string memory gaugeType, address gauge) external payable override nonReentrant {
-        _checkpointSingleGauge(gaugeType, gauge);
-
-        _returnLeftoverEthIfAny();
-    }
-
-    /// @inheritdoc IStakelessGaugeCheckpointer
-    function checkpointMultipleGauges(string[] memory gaugeTypes, address[] memory gauges)
+    function checkpointMultipleGauges(string[] memory gaugeTypes, IStakelessGauge[] memory gauges)
         external
         payable
         override
@@ -192,42 +199,43 @@ contract StakelessGaugeCheckpointer is IStakelessGaugeCheckpointer, ReentrancyGu
 
         uint256 length = gauges.length;
         for (uint256 i = 0; i < length; ++i) {
-            _checkpointSingleGauge(singleType ? gaugeTypes[0] : gaugeTypes[i], gauges[i]);
+            string memory gaugeType = singleType ? gaugeTypes[0] : gaugeTypes[i];
+            IStakelessGauge gauge = gauges[i];
+
+            require(hasGauge(gaugeType, gauge), "Gauge not added");
+
+            _checkpointSingleGauge(gauges[i]);
         }
 
         _returnLeftoverEthIfAny();
     }
 
     /// @inheritdoc IStakelessGaugeCheckpointer
-    function getSingleBridgeCost(string memory gaugeType, address gauge) public view override returns (uint256) {
-        require(_gauges[gaugeType].contains(gauge), "Gauge was not added to the checkpointer");
+    function getSingleBridgeCost(string memory gaugeType, IStakelessGauge gauge)
+        external
+        view
+        override
+        withValidGauge(gaugeType, gauge)
+        returns (uint256)
+    {
+        _getSingleBridgeCost(gauge);
+    }
 
-        if (keccak256(abi.encodePacked(gaugeType)) == _arbitrum) {
-            return ArbitrumRootGauge(gauge).getTotalBridgeCost();
-        } else {
-            return 0;
-        }
+    /// @inheritdoc IStakelessGaugeCheckpointer
+    function getGaugeTypesBridgeCost(string[] memory gaugeTypes, uint256 minRelativeWeight)
+        external
+        view
+        override
+        withValidGaugeTypes(gaugeTypes)
+        returns (uint256)
+    {
+        _getGaugeTypesTotalBridgeCost(gaugeTypes, minRelativeWeight);
     }
 
     /// @inheritdoc IStakelessGaugeCheckpointer
     function getTotalBridgeCost(uint256 minRelativeWeight) external view override returns (uint256) {
-        uint256 currentPeriod = _roundDownBlockTimestamp();
-        uint256 totalArbitrumGauges = _gauges["Arbitrum"].length();
-        EnumerableSet.AddressSet storage arbitrumGauges = _gauges["Arbitrum"];
-        uint256 totalCost;
-
-        for (uint256 i = 0; i < totalArbitrumGauges; ++i) {
-            address gauge = arbitrumGauges.unchecked_at(i);
-            // Skip gauges that are below the threshold.
-            if (_gaugeController.gauge_relative_weight(gauge, currentPeriod) < minRelativeWeight) {
-                continue;
-            }
-
-            // Cost per gauge might not be the same if gauges come from different factories, so we add each
-            // gauge's bridge cost individually.
-            totalCost += ArbitrumRootGauge(gauge).getTotalBridgeCost();
-        }
-        return totalCost;
+        string[] memory gaugeTypes = getGaugeTypes();
+        _getGaugeTypesTotalBridgeCost(gaugeTypes, minRelativeWeight);
     }
 
     /// @inheritdoc IStakelessGaugeCheckpointer
@@ -263,6 +271,69 @@ contract StakelessGaugeCheckpointer is IStakelessGaugeCheckpointer, ReentrancyGu
         }
     }
 
+    function _getSingleBridgeCost(IStakelessGauge gauge) internal view returns (uint256) {
+        // Some versions of the stakeless gauges did not implement this interface, so we need to try / catch the call.
+        // In case the interface is not present, the cost is 0.
+        // Malicious contracts are ruled out at this stage: gauges shall be validated in external functions before
+        // reaching this point.
+        try gauge.getTotalBridgeCost() returns (uint256 cost) {
+            return cost;
+        } catch {
+            return 0;
+        }
+    }
+
+    function _getGaugeTypeTotalBridgeCost(string memory gaugeType, uint256 minRelativeWeight)
+        internal
+        view
+        returns (uint256 totalCost)
+    {
+        uint256 currentPeriod = _roundDownBlockTimestamp();
+        uint256 gaugesAmount = _gauges[gaugeType].length();
+        EnumerableSet.AddressSet storage gauges = _gauges[gaugeType];
+
+        for (uint256 i = 0; i < gaugesAmount; ++i) {
+            IStakelessGauge gauge = IStakelessGauge(gauges.unchecked_at(i));
+
+            if (_gaugeController.gauge_relative_weight(address(gauge), currentPeriod) < minRelativeWeight) {
+                continue;
+            }
+
+            uint256 gaugeBridgeCost = _getSingleBridgeCost(gauge);
+            // If one gauge is costless, the same should apply for all the gauges of the same type.
+            if (gaugeBridgeCost == 0) {
+                break;
+            }
+
+            // Cost per gauge might not be the same if gauges come from different factories, so we add each
+            // gauge's bridge cost individually.
+            totalCost += gaugeBridgeCost;
+        }
+    }
+
+    function _getGaugeTypesTotalBridgeCost(string[] memory gaugeTypes, uint256 minRelativeWeight)
+        internal
+        view
+        returns (uint256 totalCost)
+    {
+        for (uint256 i = 0; i < gaugeTypes.length; ++i) {
+            string memory gaugeType = gaugeTypes[i];
+            totalCost += _getGaugeTypeTotalBridgeCost(gaugeType, minRelativeWeight);
+        }
+
+        return totalCost;
+    }
+
+    function _checkpointGaugesAboveRelativeWeight(string[] memory gaugeTypes, uint256 minRelativeWeight) internal {
+        uint256 currentPeriod = _roundDownBlockTimestamp();
+
+        for (uint256 i = 0; i < gaugeTypes.length; ++i) {
+            _checkpointGauges(gaugeTypes[i], minRelativeWeight, currentPeriod);
+        }
+
+        _returnLeftoverEthIfAny();
+    }
+
     /**
      * @dev Performs checkpoints for all gauges of the given type whose relative weight is at least the specified one.
      * @param gaugeType Type of the gauges to checkpoint.
@@ -283,10 +354,16 @@ contract StakelessGaugeCheckpointer is IStakelessGaugeCheckpointer, ReentrancyGu
             return;
         }
 
+        // Most bridges are costless, and we can know about it by querying the cost of a single gauge.
+        // If the cost of the first gauge in the list is 0, then it's 0 for the rest of them.
+        // In that case, there's no need to query the bridge cost for every other gauge.
+        // At this point we know there is at least one gauge in the set.
+        bool isGaugeTypeCostless = (_getSingleBridgeCost(IStakelessGauge(typeGauges.unchecked_at(0))) == 0);
+
         // Arbitrum gauges need to send ETH when performing the checkpoint to pay for bridge costs. Furthermore,
         // if gauges come from different factories, the cost per gauge might not be the same for all gauges.
-        function(address) internal performCheckpoint = (keccak256(abi.encodePacked(gaugeType)) == _arbitrum)
-            ? _checkpointArbitrumGauge
+        function(IStakelessGauge) internal performCheckpoint = isGaugeTypeCostless
+            ? _checkpointPaidBridgeGauge
             : _checkpointCostlessBridgeGauge;
 
         for (uint256 i = 0; i < totalTypeGauges; ++i) {
@@ -302,33 +379,41 @@ contract StakelessGaugeCheckpointer is IStakelessGaugeCheckpointer, ReentrancyGu
             if (_gaugeController.gauge_relative_weight(gauge, currentPeriod) < minRelativeWeight) {
                 continue;
             }
-            performCheckpoint(gauge);
+
+            performCheckpoint(IStakelessGauge(gauge));
         }
     }
 
     /**
-     * @dev Performs checkpoint for Arbitrum gauge, forwarding ETH to pay bridge costs.
+     * @dev Performs checkpoint for paid gauge, forwarding ETH to cover bridge costs.
      */
-    function _checkpointArbitrumGauge(address gauge) private {
-        uint256 checkpointCost = ArbitrumRootGauge(gauge).getTotalBridgeCost();
+    function _checkpointPaidBridgeGauge(IStakelessGauge gauge) private {
+        uint256 checkpointCost = gauge.getTotalBridgeCost();
+
         _authorizerAdaptorEntrypoint.performAction{ value: checkpointCost }(
-            gauge,
+            address(gauge),
             abi.encodeWithSelector(IStakelessGauge.checkpoint.selector)
         );
     }
 
     /**
-     * @dev Performs checkpoint for non-Arbitrum gauge; does not forward any ETH.
+     * @dev Performs checkpoint for costless gauge; does not forward any ETH.
      */
-    function _checkpointCostlessBridgeGauge(address gauge) private {
-        _authorizerAdaptorEntrypoint.performAction(gauge, abi.encodeWithSelector(IStakelessGauge.checkpoint.selector));
+    function _checkpointCostlessBridgeGauge(IStakelessGauge gauge) private {
+        _authorizerAdaptorEntrypoint.performAction(
+            address(gauge),
+            abi.encodeWithSelector(IStakelessGauge.checkpoint.selector)
+        );
     }
 
-    function _checkpointSingleGauge(string memory gaugeType, address gauge) internal {
-        uint256 checkpointCost = getSingleBridgeCost(gaugeType, gauge);
+    /**
+     * @dev Performs checkpoint for any gauge, attempting to get the cost beforehand.
+     */
+    function _checkpointSingleGauge(IStakelessGauge gauge) internal {
+        uint256 checkpointCost = _getSingleBridgeCost(gauge);
 
         _authorizerAdaptorEntrypoint.performAction{ value: checkpointCost }(
-            gauge,
+            address(gauge),
             abi.encodeWithSelector(IStakelessGauge.checkpoint.selector)
         );
     }

--- a/pkg/liquidity-mining/contracts/gauges/StakelessGaugeCheckpointer.sol
+++ b/pkg/liquidity-mining/contracts/gauges/StakelessGaugeCheckpointer.sol
@@ -382,8 +382,8 @@ contract StakelessGaugeCheckpointer is IStakelessGaugeCheckpointer, ReentrancyGu
         // Arbitrum gauges need to send ETH when performing the checkpoint to pay for bridge costs. Furthermore,
         // if gauges come from different factories, the cost per gauge might not be the same for all gauges.
         function(IStakelessGauge) internal performCheckpoint = isGaugeTypeCostless
-            ? _checkpointPaidBridgeGauge
-            : _checkpointCostlessBridgeGauge;
+            ? _checkpointCostlessBridgeGauge
+            : _checkpointPaidBridgeGauge;
 
         for (uint256 i = 0; i < totalTypeGauges; ++i) {
             address gauge = typeGauges.unchecked_at(i);

--- a/pkg/liquidity-mining/contracts/test/MockGaugeController.sol
+++ b/pkg/liquidity-mining/contracts/test/MockGaugeController.sol
@@ -25,6 +25,7 @@ contract MockGaugeController is IGaugeController {
     mapping(address => bool) private _validGauge;
     mapping(address => int128) private _gaugeType;
     mapping(address => uint256) private _weights;
+    uint256 private _gaugeWeightBias;
 
     IAuthorizerAdaptor public override admin;
     // solhint-disable-next-line var-name-mixedcase
@@ -67,7 +68,7 @@ contract MockGaugeController is IGaugeController {
     }
 
     function gauge_relative_weight(address gauge, uint256) external view override returns (uint256) {
-        return _weights[gauge];
+        return _weights[gauge] + _gaugeWeightBias;
     }
 
     function change_type_weight(int128, uint256) external override {
@@ -81,6 +82,11 @@ contract MockGaugeController is IGaugeController {
     function setGaugeWeight(address gauge, uint256 weight) external {
         require(_validGauge[gauge], "Gauge does not exist on controller");
         _weights[gauge] = weight;
+    }
+
+    function setGaugeWeightBias(uint256 bias) external {
+        require(bias <= 1e18, "Bias too high");
+        _gaugeWeightBias = bias;
     }
 
     function time_weight(address) external pure override returns (uint256) {

--- a/pkg/liquidity-mining/test/StakelessGaugeCheckpointer.test.ts
+++ b/pkg/liquidity-mining/test/StakelessGaugeCheckpointer.test.ts
@@ -452,10 +452,9 @@ describe('StakelessGaugeCheckpointer', () => {
       });
 
       context('invalid inputs', () => {
-        it('multi gauge checkpoint reverts with no gauges to checkpoint', async () => {
-          await expect(stakelessGaugeCheckpointer.checkpointMultipleGauges([testGaugeType], [])).to.be.revertedWith(
-            'No gauges to checkpoint'
-          );
+        it('multi gauge checkpoint with no gauges to checkpoint does nothing', async () => {
+          const tx = await stakelessGaugeCheckpointer.checkpointMultipleGauges([], []);
+          expectEvent.notEmitted(await tx.wait(), 'Checkpoint');
         });
 
         it('multi gauge checkpoint reverts with mismatching input lengths', async () => {
@@ -492,7 +491,9 @@ describe('StakelessGaugeCheckpointer', () => {
         it('checkpoints many gauges at once specifying the type only once', async () => {
           const value = (await stakelessGaugeCheckpointer.getGaugeTypesBridgeCost([testGaugeType], 0)).add(extraEth);
           const receipt = await (
-            await stakelessGaugeCheckpointer.checkpointMultipleGauges([testGaugeType], testGauges, { value })
+            await stakelessGaugeCheckpointer.checkpointMultipleGaugesOfMatchingType(testGaugeType, testGauges, {
+              value,
+            })
           ).wait();
 
           for (const gauge of testGauges) {


### PR DESCRIPTION
# Description

This PR makes the stakeless gauge checkpointer more future proof and flexible, while making it compatible with the new avax gauges.

Summary of the changes:
- Introduce the notion of gauge costs for any gauge type (not only Arbitrum). The checkpointer is prepared in case legacy (mostly all existing non-arbitrum gauges) not implementing the interface to retrieve the cost, and defaulting to 0 in that case.
- Add more methods to checkpoint in a flexible manner: by a given list of types (which supersedes the function to checkpoint a single type).
- Moved the argument checks to the external / public functions. Before this change some checks were implicit (mostly for single gauge checkpoints); now all the functions are protected at the entry level, and internal functions just work with validated inputs.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [x] New feature <!-- (non-breaking change which adds functionality) -->
- [x] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A