### PR TITLE
Ensure CodeDeployer pseudo-contracts are not executable

### DIFF
--- a/pkg/solidity-utils/contracts/test/CodeDeployerFactory.sol
+++ b/pkg/solidity-utils/contracts/test/CodeDeployerFactory.sol
@@ -19,8 +19,8 @@ import "../helpers/CodeDeployer.sol";
 contract CodeDeployerFactory {
     event CodeDeployed(address destination);
 
-    function deploy(bytes memory data) external {
-        address destination = CodeDeployer.deploy(data);
+    function deploy(bytes memory data, bool preventExecution) external {
+        address destination = CodeDeployer.deploy(data, preventExecution);
         emit CodeDeployed(destination);
     }
 }

--- a/pkg/solidity-utils/test/CodeDeployer.test.ts
+++ b/pkg/solidity-utils/test/CodeDeployer.test.ts
@@ -5,9 +5,15 @@ import { ethers } from 'hardhat';
 import { deploy } from '@balancer-labs/v2-helpers/src/contract';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 describe('CodeDeployer', function () {
   let factory: Contract;
+  let admin: SignerWithAddress;
+
+  before('setup signers', async () => {
+    [, admin] = await ethers.getSigners();
+  });
 
   sharedBeforeEach(async () => {
     factory = await deploy('CodeDeployerFactory', { args: [] });
@@ -28,16 +34,79 @@ describe('CodeDeployer', function () {
   context('with code over 24kB long', () => {
     it('reverts', async () => {
       const data = `0x${'00'.repeat(24 * 1024 + 1)}`;
-      await expect(factory.deploy(data)).to.be.revertedWith('CODE_DEPLOYMENT_FAILED');
+      await expect(factory.deploy(data, false)).to.be.revertedWith('CODE_DEPLOYMENT_FAILED');
     });
   });
 
   function itStoresArgumentAsCode(data: string) {
     it('stores its constructor argument as its code', async () => {
-      const receipt = await (await factory.deploy(data)).wait();
+      const receipt = await (await factory.deploy(data, false)).wait();
       const event = expectEvent.inReceipt(receipt, 'CodeDeployed');
 
       expect(await ethers.provider.getCode(event.args.destination)).to.equal(data);
     });
   }
+
+  describe('CodeDeployer protection', () => {
+    let deployedContract: string;
+
+    context('raw selfdestruct', () => {
+      // PUSH0
+      // SELFDESTRUCT
+      // STOP (optional - works without this)
+      const code = '0x5fff00';
+
+      sharedBeforeEach('deploy contract', async () => {
+        const receipt = await (await factory.deploy(code, false)).wait();
+        const event = expectEvent.inReceipt(receipt, 'CodeDeployed');
+
+        deployedContract = event.args.destination;
+      });
+
+      itStoresArgumentAsCode(code);
+
+      it('self destructs', async () => {
+        const tx = {
+          to: deployedContract,
+          value: ethers.utils.parseEther('0.001'),
+        };
+
+        await admin.sendTransaction(tx);
+
+        expect(await ethers.provider.getCode(deployedContract)).to.equal('0x');
+      });
+    });
+
+    context('protected selfdestruct', () => {
+      // INVALID
+      // PUSH0
+      // SELFDESTRUCT
+      // STOP (optional - works without this)
+      const code = '0x5fff00';
+      const safeCode = '0xfe5fff00';
+
+      sharedBeforeEach('deploy contract', async () => {
+        // Pass it the unmodified code
+        const receipt = await (await factory.deploy(code, true)).wait();
+        const event = expectEvent.inReceipt(receipt, 'CodeDeployed');
+
+        deployedContract = event.args.destination;
+      });
+
+      // It should actually store the safecode
+      itStoresArgumentAsCode(safeCode);
+
+      it('does not self destruct', async () => {
+        const tx = {
+          to: deployedContract,
+          value: ethers.utils.parseEther('0.001'),
+        };
+
+        await expect(admin.sendTransaction(tx)).to.be.reverted;
+
+        // Should still have the safeCode
+        expect(await ethers.provider.getCode(deployedContract)).to.equal(safeCode);
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Description

We received an interesting report from [Czar102](https://github.com/Czar102) about the CodeDeployer library. Since it only happens on factory deployment, it's not a vulnerability, and the likelihood of this actually happening is low. Nevertheless, it is a valid issue with a non-zero probability of happening, so we will fix it.

CodeDeployer is a library which "deploys" arbitrary code to an address; it need not be a valid contract. We use this in the BaseSplitCodeFactory, which underlies all our pool factories, so that we are able to deploy contracts with very large creationCode: up to 48k, twice the contract size limit. This is needed for some contracts with very tight bytecode constraints, and also a large amount of initialization code (e.g., filling in immutables).

Essentially, it splits the bytecode in half, uses CodeDeployer to deploy each "contract half" separately, then rejoins them for the actual deployment. Every time a new pool is deployed, it reassembles the bytecode from these two contracts, then appends the constructor arguments for the specific pool.

Since the BaseSplitCodeFactory logic splits the bytecode exactly in half, the second half could have any random sequence of bytes. Depending on the layout (which could theoretically change in the future), it might be in the middle of a string or data section.

So here's the problem: what if that random sequence of bytes accidentally (or maliciously) happens to start with valid opcodes? Sending a transaction would try to execute it, and it wouldn't necessarily revert. If it happened to contain a "selfdestruct" opcode, it would destroy itself, effectively deleting the second half of the pool's bytecode, and bricking the factory.

To ensure that the second "half" can never be executed, "protect" it by prepending an invalid opcode. Rather than have the option, it could just always do it, but there might be use cases where exact fidelity is important.

In BaseSplitCodeFactory, we apply the protection to the second "half" of the bytecode, and then skip that extra byte during reassembly.

## Type of change

- [X] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

