### PR TITLE
Missing function Batch Relayer V6

### DIFF
--- a/pkg/interfaces/contracts/standalone-utils/IBalancerRelayer.sol
+++ b/pkg/interfaces/contracts/standalone-utils/IBalancerRelayer.sol
@@ -24,6 +24,8 @@ import "../vault/IVault.sol";
 interface IBalancerRelayer {
     function getLibrary() external view returns (address);
 
+    function getQueryLibrary() external view returns (address);
+
     function getVault() external view returns (IVault);
 
     function multicall(bytes[] calldata data) external payable returns (bytes[] memory results);

--- a/pkg/standalone-utils/contracts/relayer/BalancerRelayer.sol
+++ b/pkg/standalone-utils/contracts/relayer/BalancerRelayer.sol
@@ -82,6 +82,10 @@ contract BalancerRelayer is IBalancerRelayer, Version, ReentrancyGuard {
         return _library;
     }
 
+    function getQueryLibrary() external view override returns (address) {
+        return _queryLibrary;
+    }
+
     function multicall(bytes[] calldata data) external payable override nonReentrant returns (bytes[] memory results) {
         uint256 numData = data.length;
 

--- a/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
+++ b/pkg/standalone-utils/test/BaseRelayerLibrary.test.ts
@@ -9,7 +9,7 @@ import { deploy, deployedAt } from '@balancer-labs/v2-helpers/src/contract';
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
 
-import { ANY_ADDRESS, MAX_UINT256 } from '@balancer-labs/v2-helpers/src/constants';
+import { ANY_ADDRESS, MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
 import { BigNumberish, bn, fp } from '@balancer-labs/v2-helpers/src/numbers';
 import { toChainedReference } from './helpers/chainedReferences';
@@ -46,6 +46,10 @@ describe('BaseRelayerLibrary', function () {
   describe('relayer getters', () => {
     it('returns the library address', async () => {
       expect(await relayer.getLibrary()).to.equal(relayerLibrary.address);
+    });
+
+    it('returns the query library address', async () => {
+      expect(await relayer.getQueryLibrary()).not.to.equal(ZERO_ADDRESS);
     });
 
     it('returns the vault address', async () => {


### PR DESCRIPTION
# Description

Discovered during deployment preparation that the relayer now deploys *two* contracts: BalancerRelayer, and the new query library contract. In order to verify the query library (and the BalancerRelayer, which takes it as an argument), we need to expose the address of the query library.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [X] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

