### PR TITLE
Support "recovery" exits from stable phantom pools

### DIFF
--- a/pkg/interfaces/contracts/pool-stable/PhantomStablePoolUserData.sol
+++ b/pkg/interfaces/contracts/pool-stable/PhantomStablePoolUserData.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.7.0 <0.9.0;
+
+library PhantomStablePoolUserData {
+    enum JoinKind { INIT, COLLECT_PROTOCOL_FEES }
+    enum ExitKind { EXACT_BPT_IN_FOR_TOKENS_OUT }
+
+    function joinKind(bytes memory self) internal pure returns (JoinKind) {
+        return abi.decode(self, (JoinKind));
+    }
+
+    function exitKind(bytes memory self) internal pure returns (ExitKind) {
+        return abi.decode(self, (ExitKind));
+    }
+
+    // Joins
+
+    function initialAmountsIn(bytes memory self) internal pure returns (uint256[] memory amountsIn) {
+        (, amountsIn) = abi.decode(self, (JoinKind, uint256[]));
+    }
+
+    // Exits
+
+    function exactBptInForTokensOut(bytes memory self) internal pure returns (uint256 bptAmountIn) {
+        (, bptAmountIn) = abi.decode(self, (ExitKind, uint256));
+    }
+}

--- a/pkg/interfaces/contracts/pool-stable/StablePhantomPoolUserData.sol
+++ b/pkg/interfaces/contracts/pool-stable/StablePhantomPoolUserData.sol
@@ -14,7 +14,7 @@
 
 pragma solidity >=0.7.0 <0.9.0;
 
-library PhantomStablePoolUserData {
+library StablePhantomPoolUserData {
     enum JoinKind { INIT, COLLECT_PROTOCOL_FEES }
     enum ExitKind { EXACT_BPT_IN_FOR_TOKENS_OUT }
 

--- a/pkg/standalone-utils/contracts/relayer/VaultActions.sol
+++ b/pkg/standalone-utils/contracts/relayer/VaultActions.sol
@@ -17,7 +17,7 @@ pragma experimental ABIEncoderV2;
 
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-weighted/WeightedPoolUserData.sol";
-import "@balancer-labs/v2-interfaces/contracts/pool-stable/PhantomStablePoolUserData.sol";
+import "@balancer-labs/v2-interfaces/contracts/pool-stable/StablePhantomPoolUserData.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-stable/StablePoolUserData.sol";
 import "@balancer-labs/v2-interfaces/contracts/pool-utils/BasePoolUserData.sol";
 
@@ -139,7 +139,7 @@ abstract contract VaultActions is IBaseRelayerLibrary {
         }
     }
 
-    enum PoolKind { WEIGHTED, LEGACY_STABLE, COMPOSABLE_STABLE, COMPOSABLE_STABLE_V2, PHANTOM_STABLE }
+    enum PoolKind { WEIGHTED, LEGACY_STABLE, COMPOSABLE_STABLE, COMPOSABLE_STABLE_V2, STABLE_PHANTOM }
 
     function joinPool(
         bytes32 poolId,
@@ -335,7 +335,7 @@ abstract contract VaultActions is IBaseRelayerLibrary {
                 return _doComposableStableExitChainedReferenceReplacements(userData);
             } else if (kind == PoolKind.COMPOSABLE_STABLE_V2) {
                 return _doComposableStableV2ExitChainedReferenceReplacements(userData);
-            } else if (kind == PoolKind.PHANTOM_STABLE) {
+            } else if (kind == PoolKind.STABLE_PHANTOM) {
                 return _doStablePhantomExitChainedReferenceReplacements(userData);
             } else {
                 revert("UNHANDLED_POOL_KIND");
@@ -402,11 +402,11 @@ abstract contract VaultActions is IBaseRelayerLibrary {
      * value.
      *
      * For instance, BPT_IN_FOR_EXACT_TOKENS_OUT is 2 in legacy Stable Pools, but 1 in Composable Stable Pools.
-     * (See the reference comment and libraries below.) PhantomStable only has a "recovery" exit (it predates
+     * (See the reference comment and libraries below.) StablePhantom only has a "recovery" exit (it predates
      * the standard recovery mode).
      *
      * Accordingly, the four do[PoolKind]ExitChainedReferenceReplacements functions below (for LegacyStable,
-     * ComposableStable, ComposableStableV2, and PhantomStable) extract the exitKind and pass it through to the
+     * ComposableStable, ComposableStableV2, and StablePhantom) extract the exitKind and pass it through to the
      * shared recoding functions.
      */
     function _doLegacyStableExitChainedReferenceReplacements(bytes memory userData) private returns (bytes memory) {
@@ -454,11 +454,11 @@ abstract contract VaultActions is IBaseRelayerLibrary {
         }
     }
 
-    // For PhantomStablePool
+    // For StablePhantomPool
     function _doStablePhantomExitChainedReferenceReplacements(bytes memory userData) private returns (bytes memory) {
         uint8 exitKind = uint8(StablePoolUserData.exitKind(userData));
 
-        if (exitKind == uint8(PhantomStablePoolUserData.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT)) {
+        if (exitKind == uint8(StablePhantomPoolUserData.ExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT)) {
             return _doStableExactBptInForTokensOutReplacements(userData, exitKind);
         } else {
             return userData;

--- a/pkg/standalone-utils/test/VaultActionsRelayer.setup.ts
+++ b/pkg/standalone-utils/test/VaultActionsRelayer.setup.ts
@@ -18,6 +18,7 @@ export enum PoolKind {
   LEGACY_STABLE,
   COMPOSABLE_STABLE,
   COMPOSABLE_STABLE_V2,
+  PHANTOM_STABLE,
 }
 
 export type OutputReference = {

--- a/pkg/standalone-utils/test/VaultActionsRelayer.setup.ts
+++ b/pkg/standalone-utils/test/VaultActionsRelayer.setup.ts
@@ -18,7 +18,7 @@ export enum PoolKind {
   LEGACY_STABLE,
   COMPOSABLE_STABLE,
   COMPOSABLE_STABLE_V2,
-  PHANTOM_STABLE,
+  STABLE_PHANTOM,
 }
 
 export type OutputReference = {

--- a/pkg/standalone-utils/test/VaultActionsStableJoinExit.test.ts
+++ b/pkg/standalone-utils/test/VaultActionsStableJoinExit.test.ts
@@ -956,7 +956,7 @@ describe('Vault Actions - Stable Pools', () => {
     });
   });
   describe('unhandled pool types', () => {
-    const INVALID_POOL_KIND = PoolKind.PHANTOM_STABLE + 1;
+    const INVALID_POOL_KIND = PoolKind.STABLE_PHANTOM + 1;
     const sender = randomAddress();
 
     context('on joins', () => {

--- a/pkg/standalone-utils/test/VaultActionsStableJoinExit.test.ts
+++ b/pkg/standalone-utils/test/VaultActionsStableJoinExit.test.ts
@@ -956,7 +956,7 @@ describe('Vault Actions - Stable Pools', () => {
     });
   });
   describe('unhandled pool types', () => {
-    const INVALID_POOL_KIND = PoolKind.COMPOSABLE_STABLE_V2 + 1;
+    const INVALID_POOL_KIND = PoolKind.PHANTOM_STABLE + 1;
     const sender = randomAddress();
 
     context('on joins', () => {


### PR DESCRIPTION
# Description

We noted that the relayer doesn't support "recovery" exits from StablePhantom pools. I believe this was omitted because such exits are only supported when the pools are paused, and the original StablePhantom pools are past their pause window. So this would really only be needed if someone redeployed the factory (e.g., on a new L2). (Or, I suppose, if someone were fork testing something in an old block within the pause window.)

Mostly a dotting i's, crossing t's thing, since V5 was supposed to support *all* stable pool types but (understandably / deliberately) left out StablePhantoms: and included a test for them that didn't actually test the relayer.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths (there is a working fork test in deployments, based off this build)
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

