### PR TITLE
Increase CSP factory pause window to 4 years, buffer period to 180 days.

### DIFF
--- a/pkg/pool-utils/contracts/factories/FactoryWidePauseWindow.sol
+++ b/pkg/pool-utils/contracts/factories/FactoryWidePauseWindow.sol
@@ -25,8 +25,8 @@ contract FactoryWidePauseWindow {
     // This contract relies on timestamps in a similar way as `TemporarilyPausable` does - the same caveats apply.
     // solhint-disable not-rely-on-time
 
-    uint256 private constant _INITIAL_PAUSE_WINDOW_DURATION = 90 days;
-    uint256 private constant _BUFFER_PERIOD_DURATION = 30 days;
+    uint256 private constant _INITIAL_PAUSE_WINDOW_DURATION = 4 * 365 days;
+    uint256 private constant _BUFFER_PERIOD_DURATION = 180 days;
 
     // Time when the pause window for all created Pools expires, and the pause window duration of new Pools becomes
     // zero.


### PR DESCRIPTION
# Description

Patch for CSP V6: same as V5, with longer pause and buffer periods.
Merge into patched branch `composable-stable-pool`, where the build infos come from.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [x] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A