### PR TITLE
Refactor: Optimism --> Optimistic gauges, with public network tag.

### DIFF
--- a/pkg/liquidity-mining/contracts/gauges/optimistic/OptimisticRootGauge.sol
+++ b/pkg/liquidity-mining/contracts/gauges/optimistic/OptimisticRootGauge.sol
@@ -24,6 +24,7 @@ import "../StakelessGauge.sol";
 contract OptimisticRootGauge is StakelessGauge {
     using SafeERC20 for IERC20;
 
+    // solhint-disable-next-line var-name-mixedcase
     string public NETWORK;
 
     IL1StandardBridge private immutable _optimismL1StandardBridge;
@@ -43,7 +44,11 @@ contract OptimisticRootGauge is StakelessGauge {
         _factory = IOptimismGasLimitProvider(msg.sender);
     }
 
-    function initialize(address recipient, uint256 relativeWeightCap, string memory targetNetwork) external {
+    function initialize(
+        address recipient,
+        uint256 relativeWeightCap,
+        string memory targetNetwork
+    ) external {
         // This will revert in all calls except the first one
         __StakelessGauge_init(relativeWeightCap);
 

--- a/pkg/liquidity-mining/contracts/gauges/optimistic/OptimisticRootGauge.sol
+++ b/pkg/liquidity-mining/contracts/gauges/optimistic/OptimisticRootGauge.sol
@@ -21,8 +21,10 @@ import "@balancer-labs/v2-solidity-utils/contracts/openzeppelin/SafeERC20.sol";
 
 import "../StakelessGauge.sol";
 
-contract OptimismRootGauge is StakelessGauge {
+contract OptimisticRootGauge is StakelessGauge {
     using SafeERC20 for IERC20;
+
+    string public NETWORK;
 
     IL1StandardBridge private immutable _optimismL1StandardBridge;
     address private immutable _optimismBal;
@@ -41,11 +43,12 @@ contract OptimismRootGauge is StakelessGauge {
         _factory = IOptimismGasLimitProvider(msg.sender);
     }
 
-    function initialize(address recipient, uint256 relativeWeightCap) external {
+    function initialize(address recipient, uint256 relativeWeightCap, string memory targetNetwork) external {
         // This will revert in all calls except the first one
         __StakelessGauge_init(relativeWeightCap);
 
         _recipient = recipient;
+        NETWORK = targetNetwork;
     }
 
     function getRecipient() external view override returns (address) {

--- a/pkg/liquidity-mining/contracts/gauges/optimistic/OptimisticRootGaugeFactory.sol
+++ b/pkg/liquidity-mining/contracts/gauges/optimistic/OptimisticRootGaugeFactory.sol
@@ -21,6 +21,7 @@ import "../BaseGaugeFactory.sol";
 import "./OptimisticRootGauge.sol";
 
 contract OptimisticRootGaugeFactory is IOptimismGasLimitProvider, BaseGaugeFactory, SingletonAuthentication {
+    // solhint-disable-next-line var-name-mixedcase
     string public NETWORK;
 
     uint32 private _gasLimit;

--- a/pkg/liquidity-mining/contracts/gauges/optimistic/OptimisticRootGaugeFactory.sol
+++ b/pkg/liquidity-mining/contracts/gauges/optimistic/OptimisticRootGaugeFactory.sol
@@ -18,9 +18,11 @@ pragma experimental ABIEncoderV2;
 import "@balancer-labs/v2-solidity-utils/contracts/helpers/SingletonAuthentication.sol";
 
 import "../BaseGaugeFactory.sol";
-import "./OptimismRootGauge.sol";
+import "./OptimisticRootGauge.sol";
 
-contract OptimismRootGaugeFactory is IOptimismGasLimitProvider, BaseGaugeFactory, SingletonAuthentication {
+contract OptimisticRootGaugeFactory is IOptimismGasLimitProvider, BaseGaugeFactory, SingletonAuthentication {
+    string public NETWORK;
+
     uint32 private _gasLimit;
 
     event OptimismGasLimitModified(uint256 gasLimit);
@@ -30,12 +32,14 @@ contract OptimismRootGaugeFactory is IOptimismGasLimitProvider, BaseGaugeFactory
         IMainnetBalancerMinter minter,
         IL1StandardBridge optimismL1StandardBridge,
         address optimismBal,
-        uint32 gasLimit
+        uint32 gasLimit,
+        string memory targetNetwork
     )
-        BaseGaugeFactory(address(new OptimismRootGauge(minter, optimismL1StandardBridge, optimismBal)))
+        BaseGaugeFactory(address(new OptimisticRootGauge(minter, optimismL1StandardBridge, optimismBal)))
         SingletonAuthentication(vault)
     {
         _gasLimit = gasLimit;
+        NETWORK = targetNetwork;
     }
 
     /**
@@ -55,7 +59,7 @@ contract OptimismRootGaugeFactory is IOptimismGasLimitProvider, BaseGaugeFactory
      */
     function create(address recipient, uint256 relativeWeightCap) external returns (address) {
         address gauge = _create();
-        OptimismRootGauge(gauge).initialize(recipient, relativeWeightCap);
+        OptimisticRootGauge(gauge).initialize(recipient, relativeWeightCap, NETWORK);
         return gauge;
     }
 


### PR DESCRIPTION
# Description

In response to https://github.com/balancer/balancer-deployments/pull/117#discussion_r1619323348; it might get confusing if we keep adding L2s that are OP-stack compatible.

This minor refactor changes the contract name and adds a public tag to identify the target L2 in the gauge and the factory.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- N/A Complex code has been commented, including external interfaces
- N/A Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

N/A