### PR TITLE
Veboost v2.1

### DIFF
--- a/pkg/liquidity-mining/contracts/VeBoostV2.vy
+++ b/pkg/liquidity-mining/contracts/VeBoostV2.vy
@@ -1,6 +1,6 @@
 # @version 0.3.3
 """
-@title Boost Delegation V2
+@title Boost Delegation V2.1
 @author CurveFi
 """
 
@@ -47,7 +47,7 @@ struct Point:
 
 NAME: constant(String[32]) = "Vote-Escrowed Boost"
 SYMBOL: constant(String[8]) = "veBoost"
-VERSION: constant(String[8]) = "v2.0.0"
+VERSION: constant(String[8]) = "v2.1.0"
 
 EIP712_TYPEHASH: constant(bytes32) = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
 PERMIT_TYPEHASH: constant(bytes32) = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")

--- a/pkg/liquidity-mining/contracts/VeBoostV2.vy
+++ b/pkg/liquidity-mining/contracts/VeBoostV2.vy
@@ -56,7 +56,6 @@ ERC1271_MAGIC_VAL: constant(bytes32) = 0x1626ba7e0000000000000000000000000000000
 WEEK: constant(uint256) = 86400 * 7
 
 
-BOOST_V1: immutable(address)
 DOMAIN_SEPARATOR: immutable(bytes32)
 VE: immutable(address)
 
@@ -71,8 +70,7 @@ received: public(HashMap[address, Point])
 received_slope_changes: public(HashMap[address, HashMap[uint256, uint256]])
 
 @external
-def __init__(_boost_v1: address, _ve: address):
-    BOOST_V1 = _boost_v1
+def __init__(_ve: address):
     DOMAIN_SEPARATOR = keccak256(_abi_encode(EIP712_TYPEHASH, keccak256(NAME), keccak256(VERSION), chain.id, self))
     VE = _ve
 
@@ -343,11 +341,6 @@ def symbol() -> String[8]:
 def decimals() -> uint8:
     return 18
 
-
-@pure
-@external
-def BOOST_V1() -> address:
-    return BOOST_V1
 
 @pure
 @external

--- a/pkg/liquidity-mining/contracts/VeBoostV2.vy
+++ b/pkg/liquidity-mining/contracts/VeBoostV2.vy
@@ -22,12 +22,6 @@ event Boost:
     _slope: uint256
     _start: uint256
 
-
-interface BoostV1:
-    def ownerOf(_token_id: uint256) -> address: view
-    def token_boost(_token_id: uint256) -> int256: view
-    def token_expiry(_token_id: uint256) -> uint256: view
-
 interface VotingEscrow:
     def balanceOf(_user: address) -> uint256: view
     def totalSupply() -> uint256: view

--- a/pkg/liquidity-mining/test/BoostV2.test.ts
+++ b/pkg/liquidity-mining/test/BoostV2.test.ts
@@ -33,7 +33,7 @@ describe('VeBoostV2', () => {
     });
 
     it('sets up the version properly', async () => {
-      expect(await boost.version()).to.be.equal('v2.0.0');
+      expect(await boost.version()).to.be.equal('v2.1.0');
     });
   });
 

--- a/pkg/liquidity-mining/test/BoostV2.test.ts
+++ b/pkg/liquidity-mining/test/BoostV2.test.ts
@@ -4,7 +4,7 @@ import { BigNumber, Contract } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
 
 import * as expectEvent from '@balancer-labs/v2-helpers/src/test/expectEvent';
-import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { deploy, deployVyper } from '@balancer-labs/v2-helpers/src/contract';
 import { MAX_UINT256 as MAX_DEADLINE, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
 import { bn } from '@balancer-labs/v2-helpers/src/numbers';
 import { signPermit } from '@balancer-labs/balancer-js';
@@ -12,6 +12,8 @@ import { currentTimestamp } from '@balancer-labs/v2-helpers/src/time';
 import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
 
 describe('VeBoostV2', () => {
+  const MAX_PRESEED = 10;
+
   let boost: Contract;
   let holder: SignerWithAddress, spender: SignerWithAddress;
 
@@ -20,7 +22,24 @@ describe('VeBoostV2', () => {
   });
 
   sharedBeforeEach('deploy veBoostV2', async () => {
-    boost = await deploy('VeBoostV2', { args: [ZERO_ADDRESS] });
+    const preseededBoostCalls = Array(MAX_PRESEED)
+      .fill(null)
+      .map(() => [
+        ZERO_ADDRESS, // _from
+        ZERO_ADDRESS, // to
+        0, // amount
+        0, // start_time
+        0, // end_time
+      ]);
+
+    const preseededApprovalCalls = Array(MAX_PRESEED)
+      .fill(null)
+      .map(() => [
+        ZERO_ADDRESS, // operator
+        ZERO_ADDRESS, // delegator
+      ]);
+
+    boost = await deployVyper('VeBoostV2', { args: [ZERO_ADDRESS, preseededBoostCalls, preseededApprovalCalls] });
   });
 
   describe('info', () => {

--- a/pkg/liquidity-mining/test/BoostV2.test.ts
+++ b/pkg/liquidity-mining/test/BoostV2.test.ts
@@ -20,7 +20,7 @@ describe('VeBoostV2', () => {
   });
 
   sharedBeforeEach('deploy veBoostV2', async () => {
-    boost = await deploy('VeBoostV2', { args: [ZERO_ADDRESS, ZERO_ADDRESS] });
+    boost = await deploy('VeBoostV2', { args: [ZERO_ADDRESS] });
   });
 
   describe('info', () => {


### PR DESCRIPTION
# Description

Allow Stake DAO and Tetu to use veBAL held in their respective lockers to be used for boosts. Redeploy veBoostV2 with no semantic changes, just a "preseeding" mechanism similar to the earlier "preseeded voting escrow delegation" mechanism, which migrates all current (non-expired) boosts and grants infinite allowance for Stake DAO and Tetu "operators" to create new boosts with using their locked veBAL.

It is version 2.1 instead of 3, since the contract code is unchanged. (V1 to V2 was a substantive change, as V1 used NFTs to represent boosts.) This just removes V1 and NFT migration references, adds the preseeding mechanism, modifies the internal `_boost` to accept "start times" in the past (necessary for simple preseeding), and checks for the Stake DAO/Tetu approval exceptions for new boosts.

There is an incompatibility between the Vyper ABI and what ethers expects (tuple vs. array), so transformed it on deployment to keep the hardhat tests passing.

See [this deployment PR](https://github.com/balancer/balancer-deployments/pull/270) for the current boosts and (unconfirmed) operator/delegator configuration. Note that two were expiring on 6/12, so the deployment target  was set to 6/13 to avoid them. There are two others expiring in June: 6/19 and 6/26.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [X] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
