### PR TITLE
fix: update repository URL in cloning instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ nvm use
 This repository uses git submodules; use `--recurse-submodules` option when cloning. For example, using https:
 
 ```bash
-$ git clone --recurse-submodules https://github.com/balancer-labs/balancer-v2-monorepo.git
+$ git clone --recurse-submodules https://github.com/balancer/balancer-v2-monorepo.git
 ```
 
 ## Build and Test


### PR DESCRIPTION
# Description

This pull request updates the repository clone instructions in the README.md file to reflect the correct GitHub organization. The previous command referenced the outdated balancer-labs/balancer-v2-monorepo repository, which may cause confusion for new contributors. The clone URL has been updated to https://github.com/balancer/balancer-v2-monorepo.git to match the current organization and ensure setup instructions work as intended.

## Type of change

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [x] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

No related issue exists. This change addresses out-of-date documentation to help contributors use the correct repository location.