### PR TITLE
Docs: fix broken Boosted Pool link in Linear Pool README

### DIFF
--- a/pkg/pool-linear/README.md
+++ b/pkg/pool-linear/README.md
@@ -7,7 +7,7 @@
 
 This package contains the source code of Balancer V2 Linear Pools. These are three-token pools which contain "Main" and "Wrapped" tokens, where the wrapped token is typically yield-bearing: e.g., USDC and aUSDC. The third token is the BPT itself, enabling "joins" and "exits" to be performed as part of a batch swap.
 
-Linear Pools are not designed to be accessed directly by end users. Rather, they are typically components of other pools, mainly as constituents of a `ComposableStablePool`, which enables the ["Boosted Pool"](https://docs.balancer.fi/concepts/pools/boosted.html#boosted-pools) behavior.
+Linear Pools are not designed to be accessed directly by end users. Rather, they are typically components of other pools, mainly as constituents of a `ComposableStablePool`, which enables the ["Boosted Pool"](https://docs.balancer.fi/concepts/explore-available-balancer-pools/boosted-pool.html#boosted-pools) behavior.
 
 ## Overview
 


### PR DESCRIPTION
File: pkg/pool-linear/README.md
Old link:
https://docs.balancer.fi/concepts/pools/boosted.html#boosted-pools
New link:
https://docs.balancer.fi/concepts/explore-available-balancer-pools/boosted-pool.html#boosted-pools

The previous URL no longer resolves. This fix points to the correct, current location of Boosted Pool docs to avoid confusion for devs reading this README.
