### PR TITLE
Fix broken logo in audits/README.md

### DIFF
--- a/audits/README.md
+++ b/audits/README.md
@@ -1,4 +1,4 @@
-# <img src="../../logo.svg" alt="Balancer" height="128px">
+# <img src="../logo.svg" alt="Balancer" height="128px">
 
 # Balancer V2 Audits
 


### PR DESCRIPTION
Replaced the broken Balancer logo (404 error) in audits/README.md with a working version used elsewhere in the repo. Screenshots attached for comparison. Small UX fix to improve docs.

Thanks!
Old:
<img width="653" height="299" alt="Знімок екрана 2025-07-25 о 11 22 16" src="https://github.com/user-attachments/assets/164e8120-7ddd-4b11-ae30-6512526663e1" />

New:
<img width="910" height="499" alt="Знімок екрана 2025-07-25 о 11 23 38" src="https://github.com/user-attachments/assets/d7c5dfb8-aa6e-4a3b-9015-255f6b4c2f8c" />
