### PR TITLE
Fix broken docs link in Linear Pools README

### DIFF
--- a/pkg/pool-linear/README.md
+++ b/pkg/pool-linear/README.md
@@ -3,7 +3,7 @@
 # Balancer V2 Linear Pools
 
 [![NPM Package](https://img.shields.io/npm/v/@balancer-labs/v2-pool-linear.svg)](https://www.npmjs.org/package/@balancer-labs/v2-pool-linear)
-[![Docs](https://img.shields.io/badge/docs-%F0%9F%93%84-blue)](https://docs.balancer.fi/concepts/pools/boosted.html#boosted-pools)
+[![Docs](https://img.shields.io/badge/docs-%F0%9F%93%84-blue)](https://docs-v2.balancer.fi/concepts/pools/boosted.html#boosted-pools)
 
 This package contains the source code of Balancer V2 Linear Pools. These are three-token pools which contain "Main" and "Wrapped" tokens, where the wrapped token is typically yield-bearing: e.g., USDC and aUSDC. The third token is the BPT itself, enabling "joins" and "exits" to be performed as part of a batch swap.
 


### PR DESCRIPTION

Found a broken link in the README pointing to the old Balancer docs.
Replaced it with the updated working link to the Boosted Pools section on v2.balancer.fi