### PR TITLE
fix: correct BTP typo to BPT across codebase

### DIFF
--- a/pkg/pool-utils/contracts/BasePool.sol
+++ b/pkg/pool-utils/contracts/BasePool.sol
@@ -490,7 +490,7 @@ abstract contract BasePool is
      * Returns the amount of BPT to mint, and the token amounts the Pool will receive in return.
      *
      * Minted BPT will be sent to `recipient`, except for _getMinimumBpt(), which will be deducted from this amount and
-     * sent to the zero address instead. This will cause that BPT to remain forever locked there, preventing total BTP
+     * sent to the zero address instead. This will cause that BPT to remain forever locked there, preventing total BPT
      * from ever dropping below that value, and ensuring `_onInitializePool` can only be called once in the entire
      * Pool's lifetime.
      *

--- a/pkg/pool-utils/contracts/NewBasePool.sol
+++ b/pkg/pool-utils/contracts/NewBasePool.sol
@@ -343,7 +343,7 @@ abstract contract NewBasePool is
      * Returns the amount of BPT to mint, and the token amounts the Pool will receive in return.
      *
      * Minted BPT will be sent to `recipient`, except for _getMinimumBpt(), which will be deducted from this amount and
-     * sent to the zero address instead. This will cause that BPT to remain forever locked there, preventing total BTP
+     * sent to the zero address instead. This will cause that BPT to remain forever locked there, preventing total BPT
      * from ever dropping below that value, and ensuring `_onInitializePool` can only be called once in the entire
      * Pool's lifetime.
      *

--- a/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
+++ b/pkg/pool-weighted/test/BaseWeightedPool.behavior.ts
@@ -543,7 +543,7 @@ export function itBehavesAsWeightedPool(numberOfTokens: number, poolType: Weight
           expect(result.bptIn).to.be.equalWithError(previousBptBalance.div(2), 0.001);
         });
 
-        it('fails if more BTP needed', async () => {
+        it('fails if more BPT needed', async () => {
           // Call should fail because we are requesting a max amount lower than the actual needed
           const amountsOut = initialBalances;
           const maximumBptIn = previousBptBalance.div(2);


### PR DESCRIPTION
Description

Fixed typo "BTP" --> "BPT" (Balancer Pool Token) across multiple files in the codebase. This is the standard abbreviation in the Balancer ecosystem that should be written as "BPT".

Type of change
[x] Documentation or wording changes
[ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
[ ] New feature <!-- (non-breaking change which adds functionality) -->
[ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
[ ] Dependency changes
[ ] Code refactor / cleanup
[ ] Other

Checklist:
[x] The diff is legible and has no extraneous changes
[ ] Complex code has been commented, including external interfaces
[ ] Tests are included for all code paths
[x] The base branch is either master, or there's a description of how to merge

Issue Resolution
<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
Files changed:
pkg/pool-utils/contracts/BasePool.sol (line 493)
pkg/pool-utils/contracts/NewBasePool.sol (line 346)
pkg/pool-weighted/test/BaseWeightedPool.behavior.ts (line 546)



