### PR TITLE
fix: add missing quotes in import statement

### DIFF
--- a/pkg/balancer-js/README.md
+++ b/pkg/balancer-js/README.md
@@ -26,7 +26,7 @@ Sample code that calculates a pool's address from its pool ID to allow approving
 
 ```typescript
 import { getPoolAddress } from "@balancer-labs/balancer-js";
-import { IERC20Abi } from ./IERC20.json
+import { IERC20Abi } from "./IERC20.json"
 
 const poolId = "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014"
 const poolAddress = getPoolAddress(poolId)


### PR DESCRIPTION
# Description

Fixed syntax error in import statement by adding quotes around file path.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge


