### PR TITLE
Fix license header text in IVotingEscrowRemapper.sol

### DIFF
--- a/pkg/interfaces/contracts/liquidity-mining/IVotingEscrowRemapper.sol
+++ b/pkg/interfaces/contracts/liquidity-mining/IVotingEscrowRemapper.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General external License as published by
+// it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General external License for more details.
+// GNU General Public License for more details.
 
-// You should have received a copy of the GNU General external License
+// You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pragma solidity ^0.7.0;


### PR DESCRIPTION
This PR corrects the license header in IVotingEscrowRemapper.sol by replacing incorrect wording with the proper "GNU General Public License" phrasing.
These changes are purely textual and do not affect the logic or functionality of the contract.
