### PR TITLE
Fix typos in comments

### DIFF
--- a/pkg/pool-linear/contracts/LinearPool.sol
+++ b/pkg/pool-linear/contracts/LinearPool.sol
@@ -600,7 +600,7 @@ abstract contract LinearPool is ILinearPool, IGeneralPool, IRateProvider, NewBas
      * token. The final wrapped token scaling factor is this value multiplied by the wrapped token's decimal scaling
      * factor.
      *
-     * WARNING: care must be take if calling external contracts from here, even `view` or `pure` functions. If said
+     * WARNING: care must be taken if calling external contracts from here, even `view` or `pure` functions. If said
      * calls revert, any revert data must not be bubbled-up directly but instead passed to `bubbleUpNonMaliciousRevert`
      * from `ExternalCallLib` (located in the `v2-pool-utils` package). See the following example:
      *

--- a/pkg/pool-linear/test/LinearPool.test.ts
+++ b/pkg/pool-linear/test/LinearPool.test.ts
@@ -639,7 +639,7 @@ describe('LinearPool', function () {
       const expectedBptScalingFactor = FP_ONE;
       const expectedMainTokenScalingFactor = FP_ONE;
 
-      it('adapt the scaling factors with the price rate', async () => {
+      it('adapts the scaling factors with the price rate', async () => {
         const scalingFactors = await pool.getScalingFactors();
 
         const expectedWrappedTokenScalingFactor = scaleRate(await pool.getWrappedTokenRate());

--- a/pkg/pool-linear/test/LinearPool.test.ts
+++ b/pkg/pool-linear/test/LinearPool.test.ts
@@ -639,7 +639,7 @@ describe('LinearPool', function () {
       const expectedBptScalingFactor = FP_ONE;
       const expectedMainTokenScalingFactor = FP_ONE;
 
-      it('adapts the scaling factors with the price rate', async () => {
+      it('adapts the scaling factors to the price rate', async () => {
         const scalingFactors = await pool.getScalingFactors();
 
         const expectedWrappedTokenScalingFactor = scaleRate(await pool.getWrappedTokenRate());

--- a/pkg/pool-stable/test/ComposableStablePoolProtocolFees.test.ts
+++ b/pkg/pool-stable/test/ComposableStablePoolProtocolFees.test.ts
@@ -281,7 +281,7 @@ describe('ComposableStablePoolProtocolFees', () => {
 
       const PREMINTED_BPT = fp(9e9); // This is the BPT normally stored in the Pool's accounting at the Vault
 
-      // We want a Pool that is relatively balanced so that, with a reasonably high amplification factor, each token has
+      // We want a Pool that is relatively balanced so that, with a reasonably high amplification factor, each token
       // has similar prices
       const MIN_POOL_TOKEN_BALANCE = 150e6;
       const MAX_POOL_TOKEN_BALANCE = 200e6;

--- a/pkg/pool-stable/test/ComposableStablePoolProtocolFees.test.ts
+++ b/pkg/pool-stable/test/ComposableStablePoolProtocolFees.test.ts
@@ -282,7 +282,7 @@ describe('ComposableStablePoolProtocolFees', () => {
       const PREMINTED_BPT = fp(9e9); // This is the BPT normally stored in the Pool's accounting at the Vault
 
       // We want a Pool that is relatively balanced so that, with a reasonably high amplification factor, each token has
-      // similar prices
+      // has similar prices
       const MIN_POOL_TOKEN_BALANCE = 150e6;
       const MAX_POOL_TOKEN_BALANCE = 200e6;
 

--- a/pkg/pool-stable/test/ComposableStablePoolProtocolFees.test.ts
+++ b/pkg/pool-stable/test/ComposableStablePoolProtocolFees.test.ts
@@ -281,7 +281,7 @@ describe('ComposableStablePoolProtocolFees', () => {
 
       const PREMINTED_BPT = fp(9e9); // This is the BPT normally stored in the Pool's accounting at the Vault
 
-      // We want a Pool that is relatively balaced so that, with a reasonably high amplification factor, each token has
+      // We want a Pool that is relatively balanced so that, with a reasonably high amplification factor, each token has
       // similar prices
       const MIN_POOL_TOKEN_BALANCE = 150e6;
       const MAX_POOL_TOKEN_BALANCE = 200e6;
@@ -491,7 +491,7 @@ describe('ComposableStablePoolProtocolFees', () => {
               const rates = range(numberOfTokens).map(() => fp(1 + random(MIN_SWAP_RATE_DELTA, MAX_SWAP_RATE_DELTA)));
               await Promise.all(rateProviders.map((rateProvider, i) => rateProvider.mockRate(rates[i])));
 
-              // We need to get the Pool to update the rate cache of all of its tokens, so that there balance change is
+              // We need to get the Pool to update the rate cache of all of its tokens, so that their balance change is
               // seen as a change in rates from old to current.
               await tokens.asyncMap((token) => pool.updateTokenRateCache(token.address));
 


### PR DESCRIPTION
Changes

LinearPool.sol:
care must be take → care must be taken (grammar fix).

LinearPool.test.ts:
it('adapt …') → it('adapts …') (subject–verb agreement).

ComposableStablePoolProtocolFees.test.ts:
balaced → balanced (spelling).
there balance change → their balance change (possessive pronoun).
