### PR TITLE
Fix typos in tests

### DIFF
--- a/pkg/pool-linear/test/math.ts
+++ b/pkg/pool-linear/test/math.ts
@@ -241,8 +241,8 @@ export function calcWrappedOutPerBptIn(
   return toFp(wrappedOut);
 }
 
-export function calcInvariant(mainNomimalBalance: Decimal, wrappedBalance: Decimal): Decimal {
-  return mainNomimalBalance.add(wrappedBalance);
+export function calcInvariant(mainNominalBalance: Decimal, wrappedBalance: Decimal): Decimal {
+  return mainNominalBalance.add(wrappedBalance);
 }
 
 export function toNominal(real: Decimal, params: Params): Decimal {

--- a/pkg/pool-stable/test/ComposableStablePoolRates.test.ts
+++ b/pkg/pool-stable/test/ComposableStablePoolRates.test.ts
@@ -751,7 +751,7 @@ describe('ComposableStablePoolRates', () => {
         itAdaptsTheScalingFactorsCorrectly();
       });
 
-      context('with price rates belows 1', () => {
+      context('with price rates below 1', () => {
         sharedBeforeEach('mock rate', async () => {
           await allTokens.asyncEach(async (token, i) => {
             if (allRateProviders[i] === ZERO_ADDRESS) return;


### PR DESCRIPTION
Typo in variable name
File: pkg/pool-linear/test/math.ts
Old -> New: mainNomimalBalance -> mainNominalBalance (in function signature and return line)
Why: Corrects the spelling of nominal. Aligns with terminology used elsewhere and avoids confusion / IDE autocomplete mismatches.

Grammar in test description
File: pkg/pool-stable/test/ComposableStablePoolRates.test.ts
Old -> New: belows -> below
Why: Fixes an English grammar error in a test context string.