### PR TITLE
fix: correct balance comparison in ComposablePoolLib test

### DIFF
--- a/pkg/pool-utils/test/foundry/ComposablePoolLib.t.sol
+++ b/pkg/pool-utils/test/foundry/ComposablePoolLib.t.sol
@@ -55,7 +55,7 @@ contract ComposablePoolLibTest is Test {
 
         assertEq(balances.length, expectedBalancesWithoutBpt.length);
         for (uint256 i = 0; i < expectedBalancesWithoutBpt.length; i++) {
-            assertEq(address(balances[i]), address(expectedBalancesWithoutBpt[i]));
+            assertEq(balances[i], expectedBalancesWithoutBpt[i]);
         }
     }
 }


### PR DESCRIPTION
Fix incorrect address casting in dropBptFromBalances test. The test was trying to compare uint256 balance values as addresses, which would cause compilation errors. Now correctly compares balance values directly.