### PR TITLE
test: remove duplicate "should support single sided bounds" test 

### DIFF
--- a/pkg/pool-weighted/test/CircuitBreakerLib.test.ts
+++ b/pkg/pool-weighted/test/CircuitBreakerLib.test.ts
@@ -235,22 +235,6 @@ describe('CircuitBreakerLib', () => {
       expect(upperBptPriceBound).to.almostEqual(expectedUpperBound);
     });
 
-    it('should support single sided bounds', async () => {
-      // Pass in the same weight factor it was constructed with
-      const lowerBptPriceBound = await lib.getBptPriceBound(data, fp(NORMALIZED_WEIGHT), true);
-      const upperBptPriceBound = await lib.getBptPriceBound(data, fp(NORMALIZED_WEIGHT), false);
-
-      const expLower = LOWER_BOUND ** (1 - NORMALIZED_WEIGHT);
-      const expHigher = UPPER_BOUND ** (1 - NORMALIZED_WEIGHT);
-
-      const expectedLowerBound = fp(BPT_PRICE * expLower);
-      const expectedUpperBound = fp(BPT_PRICE * expHigher);
-
-      // There is compression, so it won't match exactly
-      expect(lowerBptPriceBound).to.almostEqual(expectedLowerBound);
-      expect(upperBptPriceBound).to.almostEqual(expectedUpperBound);
-    });
-
     it('should compute the bounds manually when necessary', async () => {
       const newNormalizedWeight = randomFromInterval(MIN_WEIGHT, MAX_WEIGHT);
 


### PR DESCRIPTION
The file contained two identical tests for "should support single sided bounds".
Removed the duplicate to keep the test suite clean and avoid redundancy.

