### PR TITLE
Fix typos in comments & docs

### DIFF
--- a/pkg/pool-weighted/test/ManagedPool.test.ts
+++ b/pkg/pool-weighted/test/ManagedPool.test.ts
@@ -471,7 +471,7 @@ describe('ManagedPool', function () {
             const joinSwapResult = await queryExitSwap();
             const joinResult = await queryEquivalentExit();
 
-            // Tokens are leaving the Vault and so is represented as a negative value.
+            // Tokens are leaving the Vault and so are represented as a negative value.
             expect(joinSwapResult[1].mul(-1)).to.be.eq(joinResult.amountsOut[exitTokenIndex]);
           });
         }

--- a/pkg/pool-weighted/test/ManagedPool.test.ts
+++ b/pkg/pool-weighted/test/ManagedPool.test.ts
@@ -471,7 +471,7 @@ describe('ManagedPool', function () {
             const joinSwapResult = await queryExitSwap();
             const joinResult = await queryEquivalentExit();
 
-            // Tokens are leaving the Vault and so are represented as a negative value.
+            // Tokens are leaving the Vault, so they're represented as negative values.
             expect(joinSwapResult[1].mul(-1)).to.be.eq(joinResult.amountsOut[exitTokenIndex]);
           });
         }

--- a/pkg/solidity-utils/contracts/helpers/BaseSplitCodeFactory.sol
+++ b/pkg/solidity-utils/contracts/helpers/BaseSplitCodeFactory.sol
@@ -110,7 +110,7 @@ abstract contract BaseSplitCodeFactory {
     }
 
     /**
-     * @dev Returns the two addresses where the creation code of the contract crated by this factory is stored.
+     * @dev Returns the two addresses where the creation code of the contract created by this factory is stored.
      */
     function getCreationCodeContracts() public view returns (address contractA, address contractB) {
         return (_creationCodeContractA, _creationCodeContractB);

--- a/pkg/solidity-utils/contracts/helpers/WordCodec.sol
+++ b/pkg/solidity-utils/contracts/helpers/WordCodec.sol
@@ -30,7 +30,7 @@ import "../math/Math.sol";
  * memory. Because a memory struct uses not just memory but also a slot in the stack (to store its memory location),
  * using memory for word-sized values (i.e. of 256 bits or less) is strictly less gas performant, and doesn't even
  * prevent stack-too-deep issues. This is compounded by the fact that Balancer contracts typically are memory-intensive,
- * and the cost of accesing memory increases quadratically with the number of allocated words. Manual packing and
+ * and the cost of accessing memory increases quadratically with the number of allocated words. Manual packing and
  * unpacking is therefore the preferred approach.
  */
 library WordCodec {


### PR DESCRIPTION
Changes

ManagedPool.test.ts
“so is represented” → “are/is represented” (grammar fix in test comments).

BaseSplitCodeFactory.sol
“crated” → “created” (typo in NatSpec).

WordCodec.sol
“accesing” → “accessing” (typo in comment).
