### PR TITLE
fix: remove duplicate import in ProtocolFeeCache.test.ts

### DIFF
--- a/pkg/pool-utils/test/ProtocolFeeCache.test.ts
+++ b/pkg/pool-utils/test/ProtocolFeeCache.test.ts
@@ -11,8 +11,6 @@ import { ProtocolFee } from '@balancer-labs/v2-helpers/src/models/vault/types';
 import { actionId } from '@balancer-labs/v2-helpers/src/models/misc/actions';
 import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
 
-import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
-
 type ProviderFeeIDs = {
   swap: BigNumberish;
   yield: BigNumberish;


### PR DESCRIPTION
# Description

Remove duplicate import of `sharedBeforeEach` from '@balancer-labs/v2-common/sharedBeforeEach' in pkg/pool-utils/test/ProtocolFeeCache.test.ts. 

The same import was declared twice on lines 12 and 14, causing redundancy and potential linting issues.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths
- [ ] The base branch is either `master`, or there's a description of how to merge

