### PR TITLE
fix: correct grammar in error messages from `have` to `has`

### DIFF
--- a/pvt/helpers/src/models/vault/Vault.ts
+++ b/pvt/helpers/src/models/vault/Vault.ts
@@ -313,7 +313,7 @@ export default class Vault {
     if (!this.authorizer || !this.admin) throw Error("Missing Vault's authorizer or admin instance");
     if (!to) to = await this._defaultSender();
     if (await this.authorizer.hasPermission(actionId, TypesConverter.toAddress(to), ANY_ADDRESS))
-      throw Error(`Account ${typeof to === 'string' ? to : to.address} already have global permission for ${actionId}`);
+      throw Error(`Account ${typeof to === 'string' ? to : to.address} already has global permission for ${actionId}`);
     return this.authorizer.connect(this.admin).grantPermission(actionId, TypesConverter.toAddress(to), ANY_ADDRESS);
   }
 
@@ -324,7 +324,7 @@ export default class Vault {
   ): Promise<ContractTransaction | undefined> {
     if (!this.authorizer || !this.admin) throw Error("Missing Vault's authorizer or admin instance");
     if (await this.authorizer.hasPermission(actionId, TypesConverter.toAddress(to), ANY_ADDRESS))
-      throw Error(`Account ${typeof to === 'string' ? to : to.address} already have global permission for ${actionId}`);
+      throw Error(`Account ${typeof to === 'string' ? to : to.address} already has global permission for ${actionId}`);
     if (await this.authorizer.hasPermission(actionId, TypesConverter.toAddress(to), TypesConverter.toAddress(where))) {
       return undefined;
     }


### PR DESCRIPTION
# Description

Update error messages in Vault.ts to use proper grammar:
- `Account already have` → `Account already has`


## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths
- [ ] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
