### PR TITLE
refactor(vault/test): remove duplicate `zero loans are possible` test

### DIFF
--- a/pkg/vault/test/FlashLoan.test.ts
+++ b/pkg/vault/test/FlashLoan.test.ts
@@ -95,19 +95,6 @@ describe('Flash Loans', () => {
       expect((await feesCollector.getCollectedFeeAmounts([tokens.DAI.address]))[0]).to.equal(feeAmount);
     });
 
-    it('zero loans are possible', async () => {
-      const loan = 0;
-      const feeAmount = 0;
-
-      await expectBalanceChange(
-        () => vault.connect(other).flashLoan(recipient.address, [tokens.DAI.address], [loan], '0x10'),
-        tokens,
-        { account: vault }
-      );
-
-      expect((await feesCollector.getCollectedFeeAmounts([tokens.DAI.address]))[0]).to.equal(feeAmount);
-    });
-
     it('the fees module receives protocol fees', async () => {
       const loan = bn(1e18);
       const feeAmount = divCeil(loan.mul(feePercentage), FP_100_PCT);


### PR DESCRIPTION
# Description

Remove duplicated test case in FlashLoan.test.ts within the `with protocol fees` context. The test `zero loans are possible` was defined twice with identical implementation, causing unnecessary test execution time and potential confusion.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests are included for all code paths
- [ ] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
