### PR TITLE
Balancer Vault v2.1

### DIFF
--- a/pkg/solidity-utils/contracts/openzeppelin/SafeERC20.sol
+++ b/pkg/solidity-utils/contracts/openzeppelin/SafeERC20.sol
@@ -71,7 +71,6 @@ library SafeERC20 {
             }
         }
 
-        // Finally we check the returndata size is either zero or true - note that this check will always pass for EOAs.
         _require(returndata.length == 0 || abi.decode(returndata, (bool)), Errors.SAFE_ERC20_CALL_FAILED);
     }
 }

--- a/pkg/solidity-utils/contracts/openzeppelin/SafeERC20.sol
+++ b/pkg/solidity-utils/contracts/openzeppelin/SafeERC20.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 
-// Based on the ReentrancyGuard library from OpenZeppelin Contracts, altered to reduce gas costs.
-// The `safeTransfer` and `safeTransferFrom` functions assume that `token` is a contract (an account with code), and
-// work differently from the OpenZeppelin version if it is not.
+// Based on the SafeERC20 library from OpenZeppelin Contracts, altered to reduce gas costs.
 
 pragma solidity ^0.7.0;
 
 import "@balancer-labs/v2-interfaces/contracts/solidity-utils/helpers/BalancerErrors.sol";
 import "@balancer-labs/v2-interfaces/contracts/solidity-utils/openzeppelin/IERC20.sol";
+
+import "./Address.sol";
 
 /**
  * @title SafeERC20
@@ -53,10 +53,10 @@ library SafeERC20 {
     /**
      * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
      * on the return value: the return value is optional (but if data is returned, it must not be false).
-     *
-     * WARNING: `token` is assumed to be a contract: calls to EOAs will *not* revert.
      */
     function _callOptionalReturn(address token, bytes memory data) private {
+        require(Address.isContract(token), "Address: call to non-contract");
+
         // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
         // we're implementing it ourselves.
         // solhint-disable-next-line avoid-low-level-calls
@@ -71,7 +71,7 @@ library SafeERC20 {
             }
         }
 
-        // Finally we check the returndata size is either zero or true - note that this check will always pass for EOAs
+        // Finally we check the returndata size is either zero or true - note that this check will always pass for EOAs.
         _require(returndata.length == 0 || abi.decode(returndata, (bool)), Errors.SAFE_ERC20_CALL_FAILED);
     }
 }

--- a/pkg/vault/contracts/PoolBalances.sol
+++ b/pkg/vault/contracts/PoolBalances.sol
@@ -125,11 +125,40 @@ abstract contract PoolBalances is Fees, ReentrancyGuard, PoolTokens, UserBalance
 
         // The bulk of the work is done here: the corresponding Pool hook is called, its final balances are computed,
         // assets are transferred, and fees are paid.
-        (
-            bytes32[] memory finalBalances,
-            uint256[] memory amountsInOrOut,
-            uint256[] memory paidProtocolSwapFeeAmounts
-        ) = _callPoolBalanceChange(kind, poolId, sender, recipient, change, balances);
+        (uint256[] memory amountsInOrOut, uint256[] memory paidProtocolSwapFeeAmounts) = _callPoolBalanceChange(
+            kind,
+            poolId,
+            sender,
+            recipient,
+            change,
+            balances
+        );
+
+        InputHelpers.ensureInputLengthMatch(balances.length, amountsInOrOut.length, paidProtocolSwapFeeAmounts.length);
+
+        // The Vault ignores the `recipient` in joins and the `sender` in exits: it is up to the Pool to keep track of
+        // their participation.
+
+        bytes32[] memory finalBalances;
+        uint256 wrappedEth = 0;
+
+        if (kind == PoolBalanceChangeKind.JOIN) {
+            (finalBalances, wrappedEth) = _processJoinPoolTransfers(
+                sender,
+                change,
+                balances,
+                amountsInOrOut,
+                paidProtocolSwapFeeAmounts
+            );
+        } else {
+            finalBalances = _processExitPoolTransfers(
+                recipient,
+                change,
+                balances,
+                amountsInOrOut,
+                paidProtocolSwapFeeAmounts
+            );
+        }
 
         // All that remains is storing the new Pool balances.
         PoolSpecialization specialization = _getPoolSpecialization(poolId);
@@ -151,6 +180,10 @@ abstract contract PoolBalances is Fees, ReentrancyGuard, PoolTokens, UserBalance
             _unsafeCastToInt256(amountsInOrOut, positive),
             paidProtocolSwapFeeAmounts
         );
+
+        if (positive) {
+            _handleRemainingEth(wrappedEth);
+        }
     }
 
     /**
@@ -164,14 +197,7 @@ abstract contract PoolBalances is Fees, ReentrancyGuard, PoolTokens, UserBalance
         address payable recipient,
         PoolBalanceChange memory change,
         bytes32[] memory balances
-    )
-        private
-        returns (
-            bytes32[] memory finalBalances,
-            uint256[] memory amountsInOrOut,
-            uint256[] memory dueProtocolFeeAmounts
-        )
-    {
+    ) private returns (uint256[] memory amountsInOrOut, uint256[] memory dueProtocolFeeAmounts) {
         (uint256[] memory totalBalances, uint256 lastChangeBlock) = balances.totalsAndLastChangeBlock();
 
         IBasePool pool = IBasePool(_getPoolAddress(poolId));
@@ -194,14 +220,6 @@ abstract contract PoolBalances is Fees, ReentrancyGuard, PoolTokens, UserBalance
                 _getProtocolSwapFeePercentage(),
                 change.userData
             );
-
-        InputHelpers.ensureInputLengthMatch(balances.length, amountsInOrOut.length, dueProtocolFeeAmounts.length);
-
-        // The Vault ignores the `recipient` in joins and the `sender` in exits: it is up to the Pool to keep track of
-        // their participation.
-        finalBalances = kind == PoolBalanceChangeKind.JOIN
-            ? _processJoinPoolTransfers(sender, change, balances, amountsInOrOut, dueProtocolFeeAmounts)
-            : _processExitPoolTransfers(recipient, change, balances, amountsInOrOut, dueProtocolFeeAmounts);
     }
 
     /**
@@ -217,9 +235,9 @@ abstract contract PoolBalances is Fees, ReentrancyGuard, PoolTokens, UserBalance
         bytes32[] memory balances,
         uint256[] memory amountsIn,
         uint256[] memory dueProtocolFeeAmounts
-    ) private returns (bytes32[] memory finalBalances) {
+    ) private returns (bytes32[] memory finalBalances, uint256 wrappedEth) {
         // We need to track how much of the received ETH was used and wrapped into WETH to return any excess.
-        uint256 wrappedEth = 0;
+        wrappedEth = 0;
 
         finalBalances = new bytes32[](balances.length);
         for (uint256 i = 0; i < change.assets.length; ++i) {
@@ -243,9 +261,6 @@ abstract contract PoolBalances is Fees, ReentrancyGuard, PoolTokens, UserBalance
                 ? balances[i].increaseCash(amountIn - feeAmount)
                 : balances[i].decreaseCash(feeAmount - amountIn);
         }
-
-        // Handle any used and remaining ETH.
-        _handleRemainingEth(wrappedEth);
     }
 
     /**

--- a/pkg/vault/contracts/test/MockPool.sol
+++ b/pkg/vault/contracts/test/MockPool.sol
@@ -28,6 +28,8 @@ contract MockPool is IGeneralPool, IMinimalSwapInfoPool {
     IVault private immutable _vault;
     bytes32 private immutable _poolId;
 
+    uint256 private _totalSupply;
+
     constructor(IVault vault, IVault.PoolSpecialization specialization) {
         _poolId = vault.registerPool(specialization);
         _vault = vault;
@@ -55,6 +57,10 @@ contract MockPool is IGeneralPool, IMinimalSwapInfoPool {
 
     function deregisterTokens(IERC20[] memory tokens) external {
         _vault.deregisterTokens(_poolId, tokens);
+    }
+
+    function totalSupply() external view returns (uint256) {
+        return _totalSupply;
     }
 
     event OnJoinPoolCalled(
@@ -96,6 +102,8 @@ contract MockPool is IGeneralPool, IMinimalSwapInfoPool {
             userData
         );
 
+        _totalSupply++;
+
         (amountsIn, dueProtocolFeeAmounts) = abi.decode(userData, (uint256[], uint256[]));
     }
 
@@ -117,6 +125,8 @@ contract MockPool is IGeneralPool, IMinimalSwapInfoPool {
             protocolSwapFeePercentage,
             userData
         );
+
+        _totalSupply--;
 
         (amountsOut, dueProtocolFeeAmounts) = abi.decode(userData, (uint256[], uint256[]));
     }

--- a/pkg/vault/contracts/test/ReentrancyAttack.sol
+++ b/pkg/vault/contracts/test/ReentrancyAttack.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "@balancer-labs/v2-interfaces/contracts/solidity-utils/openzeppelin/IERC20.sol";
+import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
+
+/**
+ * @notice This contract demonstrates a read-only reentrancy attack attempt.
+ * In the vulnerable version, during the ETH return callback, it would be able to read inconsistent state
+ * (BPT minted but balances not yet updated in Vault). In the fixed version, the callback happens after storage
+ * updates, so the state is consistent.
+ */
+contract ReentrancyAttack {
+    IVault public immutable vault;
+
+    bytes32 public immutable poolId;
+    IERC20 public immutable pool;
+
+    bool public consistentState;
+    uint256 public supplyDuringCallback;
+
+    uint256[] private _balancesDuringCallback;
+
+    uint256 private initialSupply;
+    uint256[] private initialBalances;
+
+    constructor(
+        address _vault,
+        bytes32 _poolId,
+        address _pool
+    ) {
+        vault = IVault(_vault);
+        poolId = _poolId;
+        pool = IERC20(_pool);
+    }
+
+    // Return the entire array of balances.
+    function balancesDuringCallback() external view returns (uint256[] memory) {
+        return _balancesDuringCallback;
+    }
+
+    /**
+     * @dev Attempts to exploit read-only reentrancy.
+     * Joins the pool with excess ETH, triggering a callback on ETH return.
+     */
+    function attemptReadOnlyReentrancy() external payable {
+        // Get the initial state.
+        (IERC20[] memory tokens, uint256[] memory balances, ) = vault.getPoolTokens(poolId);
+        initialBalances = balances;
+
+        // We can't directly get totalSupply in this context, but we'll check during the callback.
+        initialSupply = 0;
+
+        // Prepare join with excess ETH (will trigger callback when excess is returned).
+        IAsset[] memory assets = new IAsset[](tokens.length);
+        uint256[] memory maxAmountsIn = new uint256[](tokens.length);
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            assets[i] = IAsset(address(tokens[i]));
+            maxAmountsIn[i] = type(uint256).max;
+        }
+
+        // Join amounts (much less than ETH sent)
+        uint256[] memory joinAmounts = new uint256[](tokens.length);
+        joinAmounts[0] = 1e18;
+        joinAmounts[1] = 1e18;
+
+        uint256[] memory dueProtocolFees = new uint256[](tokens.length);
+
+        bytes memory userData = abi.encode(joinAmounts, dueProtocolFees);
+
+        IVault.JoinPoolRequest memory request = IVault.JoinPoolRequest({
+            assets: assets,
+            maxAmountsIn: maxAmountsIn,
+            userData: userData,
+            fromInternalBalance: false
+        });
+
+        // This join will trigger the receive() callback when excess ETH is returned.
+        vault.joinPool{ value: msg.value }(poolId, address(this), address(0), request);
+    }
+
+    /**
+     * @dev This receive function is called when excess ETH is returned.
+     * In the vulnerable version, this happens BEFORE storage is updated.
+     * In the fixed version, this happens AFTER storage is updated.
+     */
+    receive() external payable {
+        // Read the current pool state.
+        (, uint256[] memory currentBalances, ) = vault.getPoolTokens(poolId);
+
+        // Read the pool's total supply during the callback.
+        // The MockPool adds 1 for each join, and subtracts 1 for each exit.
+
+        // Store for verification in tests.
+        _balancesDuringCallback = currentBalances;
+        supplyDuringCallback = pool.totalSupply();
+
+        // In the vulnerable version:
+        // - BPT would be minted (supply increased)
+        // - But balances not yet updated in Vault storage
+
+        // If balances haven't changed from initial values, but the supply has, that's the vulnerability.
+        if (initialBalances.length > 0) {
+            bool balancesChanged = false;
+            for (uint256 i = 0; i < initialBalances.length; i++) {
+                if (currentBalances[i] != initialBalances[i]) {
+                    balancesChanged = true;
+                    break;
+                }
+            }
+
+            // If balances are unchanged, it means the ETH callback is happening before the balance update, when
+            // the Vault is in an inconsistent state.
+            consistentState = supplyDuringCallback > 0 && balancesChanged;
+        }
+    }
+
+    /// @dev Helper to approve vault to spend tokens.
+    function approveVault(address[] memory tokenAddresses) external {
+        for (uint256 i = 0; i < tokenAddresses.length; i++) {
+            IERC20(tokenAddresses[i]).approve(address(vault), type(uint256).max);
+        }
+    }
+}

--- a/pkg/vault/test/InternalBalance.test.ts
+++ b/pkg/vault/test/InternalBalance.test.ts
@@ -301,6 +301,22 @@ describe('Internal Balance', () => {
           ).to.be.revertedWith('INSUFFICIENT_ETH');
         });
       });
+
+      context('when the asset is not a valid token', () => {
+        it('reverts', async () => {
+          await expect(
+            vault.manageUserBalance([
+              {
+                kind,
+                asset: ANY_ADDRESS,
+                amount: initialBalance,
+                sender: sender.address,
+                recipient: recipient.address,
+              },
+            ])
+          ).to.be.revertedWith('Address: call to non-contract');
+        });
+      });
     });
 
     context('when the sender is a relayer', () => {

--- a/pkg/vault/test/ReadOnlyReentrancy.test.ts
+++ b/pkg/vault/test/ReadOnlyReentrancy.test.ts
@@ -1,0 +1,133 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { Contract } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address';
+
+import TokenList from '@balancer-labs/v2-helpers/src/models/tokens/TokenList';
+import { deploy } from '@balancer-labs/v2-helpers/src/contract';
+import { MONTH } from '@balancer-labs/v2-helpers/src/time';
+import { bn } from '@balancer-labs/v2-helpers/src/numbers';
+import { PoolSpecialization } from '@balancer-labs/balancer-js';
+import Vault from '@balancer-labs/v2-helpers/src/models/vault/Vault';
+import { sharedBeforeEach } from '@balancer-labs/v2-common/sharedBeforeEach';
+import { MAX_UINT256, ZERO_ADDRESS } from '@balancer-labs/v2-helpers/src/constants';
+import { encodeJoin } from '@balancer-labs/v2-helpers/src/models/pools/mockPool';
+
+describe('Read-Only Reentrancy Protection', () => {
+  let admin: SignerWithAddress, attacker: SignerWithAddress;
+  let vault: Contract, pool: Contract;
+  let tokens: TokenList;
+  let poolId: string;
+  let maliciousContract: Contract;
+
+  before(async () => {
+    [, admin, attacker] = await ethers.getSigners();
+  });
+
+  sharedBeforeEach('deploy vault & tokens', async () => {
+    ({ instance: vault } = await Vault.create({
+      admin,
+      pauseWindowDuration: MONTH,
+      bufferPeriodDuration: MONTH,
+    }));
+
+    tokens = await TokenList.create(['DAI', 'MKR'], { sorted: true });
+    await tokens.mint({ to: [attacker], amount: bn(100e18) });
+    await tokens.approve({ to: vault, from: [attacker] });
+
+    // Deploy pool
+    pool = await deploy('MockPool', { args: [vault.address, PoolSpecialization.TwoTokenPool] });
+    poolId = await pool.getPoolId();
+    await pool.registerTokens(tokens.addresses, [ZERO_ADDRESS, ZERO_ADDRESS]);
+
+    // Initialize pool with some liquidity
+    await vault.connect(attacker).joinPool(poolId, attacker.address, ZERO_ADDRESS, {
+      assets: tokens.addresses,
+      maxAmountsIn: [MAX_UINT256, MAX_UINT256],
+      fromInternalBalance: false,
+      userData: encodeJoin([bn(50e18), bn(50e18)], [0, 0]),
+    });
+  });
+
+  sharedBeforeEach('deploy malicious contract', async () => {
+    // This contract will attempt to exploit read-only reentrancy
+    const ReentrancyAttack = await ethers.getContractFactory('ReentrancyAttack');
+    maliciousContract = await ReentrancyAttack.deploy(vault.address, poolId, pool.address);
+    await maliciousContract.deployed();
+
+    // Fund the malicious contract.
+    await tokens.mint({ to: [maliciousContract.address], amount: bn(100e18) });
+
+    // Approve vault to spend the malicious contract's tokens.
+    await maliciousContract.approveVault(tokens.addresses);
+  });
+
+  it('prevents read-only reentrancy via ETH return callback', async () => {
+    // The malicious contract will:
+    // 1. Join the pool with ETH.
+    // 2. Receive callback when excess ETH is returned.
+    // 3. Try to read pool balances during callback (before storage update in old code).
+    // 4. In the old code, we would see an inconsistent state (BPT minted but balances not updated).
+    // 5. In the fixed code, storage is updated before the callback, so the state is consistent.
+
+    // Store initial pool token info.
+    const { balances: initialBalances } = await vault.getPoolTokens(poolId);
+    const initialSupply = await pool.totalSupply();
+
+    // Attempt the attack.
+    await expect(
+      maliciousContract.connect(attacker).attemptReadOnlyReentrancy({
+        value: ethers.utils.parseEther('1.0'),
+      })
+    ).to.not.be.reverted;
+
+    // Verify that the attack didn't succeed in creating inconsistent state
+    const { balances: finalBalances } = await vault.getPoolTokens(poolId);
+    const finalSupply = await pool.totalSupply();
+
+    // Check that the callback saw a consistent state.
+    expect(await maliciousContract.consistentState()).to.be.true;
+
+    // Balances should be properly updated
+    expect(finalBalances[0]).to.be.gt(initialBalances[0]);
+    expect(finalBalances[1]).to.be.gt(initialBalances[1]);
+    expect(finalSupply).to.be.gt(initialSupply);
+  });
+
+  it('maintains consistent state between BPT supply and balances during callbacks', async () => {
+    // This test verifies that when the callback is triggered:
+    // - The pool's BPT totalSupply (updated in pool contract during onJoinPool).
+    // - The pool's token balances (updated in Vault storage).
+    // In the fixed version, BOTH are updated before the callback happens.
+    // In the vulnerable version, the supply would be updated, but the balances would be stale.
+
+    // Get the state before joining.
+    const { balances: initialBalances } = await vault.getPoolTokens(poolId);
+    const initialSupply = await pool.totalSupply();
+
+    // The malicious contract will record the state during callback.
+    await maliciousContract.connect(attacker).attemptReadOnlyReentrancy({
+      value: ethers.utils.parseEther('0.1'),
+    });
+
+    // Get the state that was observed during the callback.
+    const callbackSupply = await maliciousContract.supplyDuringCallback();
+    const callbackBalances = await maliciousContract.balancesDuringCallback();
+
+    // Get the state after the full transaction.
+    const finalSupply = await pool.totalSupply();
+    const { balances: finalBalances } = await vault.getPoolTokens(poolId);
+
+    // In the fixed version:
+    // - Both supply and balances should be updated during the callback.
+    // - So callback values should equal final values.
+    expect(callbackSupply).to.equal(finalSupply);
+    expect(callbackBalances[0]).to.equal(finalBalances[0]);
+    expect(callbackBalances[1]).to.equal(finalBalances[1]);
+
+    // Also verify they changed from the initial values (i.e., the join actually happened).
+    expect(finalSupply).to.be.gt(initialSupply);
+    expect(finalBalances[0]).to.be.gt(initialBalances[0]);
+    expect(finalBalances[1]).to.be.gt(initialBalances[1]);
+  });
+});


### PR DESCRIPTION
# Description

This fixes two outstanding issues identified over the years, prior to deployment to new L2s. Both gas "optimizations": 1) restore the contract check in our version of OZ's transfer functions (while retaining most of our gas savings); 2) eliminate read-only reentrancy during Vault joins.

## Type of change

- [X] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
