### PR TITLE
Fix spellings issues

### DIFF
--- a/pkg/liquidity-mining/contracts/PreseededVotingEscrowDelegation.vy
+++ b/pkg/liquidity-mining/contracts/PreseededVotingEscrowDelegation.vy
@@ -245,7 +245,7 @@ def _update_enumeration_data(_from: address, _to: address, _token_id: uint256):
         self.total_minted[delegator] = last_delegator_pos
 
     else:
-        # transfering - called between balance updates
+        # transferring - called between balance updates
         from_last_index: uint256 = self.balanceOf[_from]
 
         if local_pos != from_last_index:
@@ -788,7 +788,7 @@ def batch_cancel_boosts(_token_ids: uint256[256]):
 def set_delegation_status(_receiver: address, _delegator: address, _status: bool):
     """
     @notice Set or reaffirm the blacklist/whitelist status of a delegator for a receiver.
-    @dev Setting delegator as the ZERO_ADDRESS enables users to deactive delegations globally
+    @dev Setting delegator as the ZERO_ADDRESS enables users to deactivate delegations globally
         and enable the white list. The ability of a delegator to delegate to a receiver
         is determined by ~(grey_list[_receiver][ZERO_ADDRESS] ^ grey_list[_receiver][_delegator]).
     @param _receiver The account which we will be updating it's list
@@ -803,7 +803,7 @@ def set_delegation_status(_receiver: address, _delegator: address, _status: bool
 def batch_set_delegation_status(_receiver: address, _delegators: address[256], _status: uint256[256]):
     """
     @notice Set or reaffirm the blacklist/whitelist status of multiple delegators for a receiver.
-    @dev Setting delegator as the ZERO_ADDRESS enables users to deactive delegations globally
+    @dev Setting delegator as the ZERO_ADDRESS enables users to deactivate delegations globally
         and enable the white list. The ability of a delegator to delegate to a receiver
         is determined by ~(grey_list[_receiver][ZERO_ADDRESS] ^ grey_list[_receiver][_delegator]).
     @param _receiver The account which we will be updating it's list

--- a/pkg/liquidity-mining/contracts/VotingEscrow.vy
+++ b/pkg/liquidity-mining/contracts/VotingEscrow.vy
@@ -221,7 +221,7 @@ def _checkpoint(addr: address, old_locked: LockedBalance, new_locked: LockedBala
     """
     @notice Record global and per-user data to checkpoint
     @param addr User's wallet address. No user checkpoint if 0x0
-    @param old_locked Pevious locked amount / end lock time for the user
+    @param old_locked Previous locked amount / end lock time for the user
     @param new_locked New locked amount / end lock time for the user
     """
     u_old: Point = empty(Point)


### PR DESCRIPTION
# Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase:

  - `transfering` → `transferring`
  - `deactive` → `deactivate`
  - `Pevious` → `Previous`